### PR TITLE
feat: deployment diff preview (show value changes before deploying)

### DIFF
--- a/backend/internal/api/handlers/bulk_operations.go
+++ b/backend/internal/api/handlers/bulk_operations.go
@@ -231,7 +231,6 @@ func (h *InstanceHandler) BulkDeploy(c *gin.Context) {
 			Instance:   inst,
 			Definition: def,
 			Charts:     chartInfos,
-			Owner:      ownerName,
 		}
 
 		logID, err := h.deployManager.Deploy(c.Request.Context(), req)

--- a/backend/internal/api/handlers/quick_deploy.go
+++ b/backend/internal/api/handlers/quick_deploy.go
@@ -480,7 +480,6 @@ func (h *QuickDeployHandler) triggerDeploy(
 		Instance:   inst,
 		Definition: def,
 		Charts:     chartInfos,
-		Owner:      ownerName,
 	}
 
 	return h.deployManager.Deploy(c.Request.Context(), req)

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1011,7 +1011,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		return
 	}
 
-	// Build locked values map from template.
+	// Validate required deployment inputs before building chart values.
 	if inst.Namespace == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Instance namespace is empty"})
 		return
@@ -1091,6 +1091,14 @@ func (h *InstanceHandler) DeployPreview(c *gin.Context) {
 	if err != nil {
 		status, message := mapError(err, entityStackInstance)
 		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	// Authorization: only the owner or an admin/devops may preview the instance.
+	userID := middleware.GetUserIDFromContext(c)
+	role := middleware.GetRoleFromContext(c)
+	if inst.OwnerID != userID && role != "admin" && role != "devops" {
+		c.JSON(http.StatusForbidden, gin.H{"error": "You are not allowed to preview this stack instance"})
 		return
 	}
 

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1027,8 +1027,6 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		return
 	}
 
-	ownerName := resolveOwnerName(h.userRepo, inst.OwnerID)
-
 	var chartInfos []deployer.ChartDeployInfo
 	for _, ch := range charts {
 		chartInfos = append(chartInfos, deployer.ChartDeployInfo{
@@ -1046,7 +1044,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		Instance:           inst,
 		Definition:         def,
 		Charts:             chartInfos,
-		Owner:              ownerName,
+		Owner:              inst.OwnerID,
 		LastDeployedValues: lastDeployedValuesJSON,
 	}
 

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -61,7 +61,6 @@ const (
 // Slog structured logging key constants.
 const logKeyInstanceID = "instance_id"
 
-
 // rfc1123InvalidChars matches any character not allowed in an RFC1123 label.
 var rfc1123InvalidChars = regexp.MustCompile(`[^a-z0-9-]`)
 

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1037,11 +1037,17 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		})
 	}
 
+	var lastDeployedValuesJSON string
+	if encoded, err := json.Marshal(valuesMap); err == nil {
+		lastDeployedValuesJSON = string(encoded)
+	}
+
 	req := deployer.DeployRequest{
-		Instance:   inst,
-		Definition: def,
-		Charts:     chartInfos,
-		Owner:      ownerName,
+		Instance:           inst,
+		Definition:         def,
+		Charts:             chartInfos,
+		Owner:              ownerName,
+		LastDeployedValues: lastDeployedValuesJSON,
 	}
 
 	logID, err := h.deployManager.Deploy(c.Request.Context(), req)
@@ -1052,18 +1058,6 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
 		return
-	}
-
-	// Save merged values per chart for deployment diff preview.
-	// Saved after Deploy() succeeds to avoid storing values for failed deploys.
-	if encoded, err := json.Marshal(valuesMap); err == nil {
-		inst.LastDeployedValues = string(encoded)
-		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
-			slog.Warn("Failed to save last deployed values",
-				logKeyInstanceID, id,
-				"error", updateErr,
-			)
-		}
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{"log_id": logID, "message": "Deployment started"})

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1044,7 +1044,6 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		Instance:           inst,
 		Definition:         def,
 		Charts:             chartInfos,
-		Owner:              inst.OwnerID,
 		LastDeployedValues: lastDeployedValuesJSON,
 	}
 

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1044,17 +1044,8 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		Owner:      ownerName,
 	}
 
-	logID, err := h.deployManager.Deploy(c.Request.Context(), req)
-	if err != nil {
-		slog.Error("Failed to start deployment",
-			logKeyInstanceID, id,
-			"error", err,
-		)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-		return
-	}
-
-	// Save merged values per chart for deployment diff preview.
+	// Save merged values per chart for deployment diff preview BEFORE
+	// starting the async deploy to avoid racing with status updates.
 	if encoded, err := json.Marshal(valuesMap); err == nil {
 		inst.LastDeployedValues = string(encoded)
 		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
@@ -1063,6 +1054,16 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 				"error", updateErr,
 			)
 		}
+	}
+
+	logID, err := h.deployManager.Deploy(c.Request.Context(), req)
+	if err != nil {
+		slog.Error("Failed to start deployment",
+			logKeyInstanceID, id,
+			"error", err,
+		)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{"log_id": logID, "message": "Deployment started"})
@@ -1076,6 +1077,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 // @Param       id path string true "Instance ID"
 // @Success     200 {object} DeployPreviewResponse
 // @Failure     400 {object} map[string]string
+// @Failure     403 {object} map[string]string
 // @Failure     404 {object} map[string]string
 // @Failure     500 {object} map[string]string
 // @Security    BearerAuth

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1104,6 +1104,11 @@ func (h *InstanceHandler) DeployPreview(c *gin.Context) {
 		return
 	}
 
+	if inst.Namespace == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Instance namespace is empty"})
+		return
+	}
+
 	def, err := h.definitionRepo.FindByID(inst.StackDefinitionID)
 	if err != nil {
 		status, message := mapError(err, entityStackDefinition)

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1044,18 +1044,6 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		Owner:      ownerName,
 	}
 
-	// Save merged values per chart for deployment diff preview BEFORE
-	// starting the async deploy to avoid racing with status updates.
-	if encoded, err := json.Marshal(valuesMap); err == nil {
-		inst.LastDeployedValues = string(encoded)
-		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
-			slog.Warn("Failed to save last deployed values",
-				logKeyInstanceID, id,
-				"error", updateErr,
-			)
-		}
-	}
-
 	logID, err := h.deployManager.Deploy(c.Request.Context(), req)
 	if err != nil {
 		slog.Error("Failed to start deployment",
@@ -1064,6 +1052,18 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
 		return
+	}
+
+	// Save merged values per chart for deployment diff preview.
+	// Saved after Deploy() succeeds to avoid storing values for failed deploys.
+	if encoded, err := json.Marshal(valuesMap); err == nil {
+		inst.LastDeployedValues = string(encoded)
+		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
+			slog.Warn("Failed to save last deployed values",
+				logKeyInstanceID, id,
+				"error", updateErr,
+			)
+		}
 	}
 
 	c.JSON(http.StatusAccepted, gin.H{"log_id": logID, "message": "Deployment started"})

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1011,96 +1012,28 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 	}
 
 	// Build locked values map from template.
-	lockedMap := make(map[string]string)
-	if def.SourceTemplateID != "" && h.templateChartRepo != nil {
-		templateCharts, err := h.templateChartRepo.ListByTemplate(def.SourceTemplateID)
-		if err != nil {
-			slog.Error("Failed to list template chart configs",
-				"template_id", def.SourceTemplateID,
-				logKeyInstanceID, id,
-				"error", err,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-		for _, tc := range templateCharts {
-			lockedMap[tc.ChartName] = tc.LockedValues
-		}
+	if inst.Namespace == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Instance namespace is empty"})
+		return
 	}
 
-	// Build overrides map.
-	overridesMap := make(map[string]string)
-	overrides, err := h.overrideRepo.ListByInstance(inst.ID)
+	valuesMap, err := h.buildChartValues(c.Request.Context(), inst, def, charts)
 	if err != nil {
-		slog.Error("Failed to list value overrides",
+		slog.Error("Failed to build chart values",
 			logKeyInstanceID, id,
 			"error", err,
 		)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
 		return
 	}
-	for _, ov := range overrides {
-		overridesMap[ov.ChartConfigID] = ov.Values
-	}
-
-	// Build per-chart branch override map.
-	branchMap := make(map[string]string)
-	if h.branchOverrideRepo != nil {
-		branchOverrides, err := h.branchOverrideRepo.List(inst.ID)
-		if err != nil {
-			slog.Error("Failed to list branch overrides",
-				logKeyInstanceID, id,
-				"error", err,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-		for _, bo := range branchOverrides {
-			branchMap[bo.ChartConfigID] = bo.Branch
-		}
-	}
-
-	if inst.Namespace == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Instance namespace is empty"})
-		return
-	}
 
 	ownerName := resolveOwnerName(h.userRepo, inst.OwnerID)
 
-	templateVars := helm.TemplateVars{
-		Branch:       inst.Branch,
-		Namespace:    inst.Namespace,
-		InstanceName: inst.Name,
-		StackName:    def.Name,
-		Owner:        ownerName,
-	}
-
-	// Generate values YAML for each chart.
 	var chartInfos []deployer.ChartDeployInfo
 	for _, ch := range charts {
-		params := helm.GenerateParams{
-			ChartName:      ch.ChartName,
-			DefaultValues:  ch.DefaultValues,
-			LockedValues:   lockedMap[ch.ChartName],
-			OverrideValues: overridesMap[ch.ID],
-			ChartBranch:    branchMap[ch.ID],
-			TemplateVars:   templateVars,
-		}
-
-		yamlData, err := h.valuesGen.GenerateValues(c.Request.Context(), params)
-		if err != nil {
-			slog.Error("Failed to generate values for chart",
-				"chart", ch.ChartName,
-				logKeyInstanceID, id,
-				"error", err,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-
 		chartInfos = append(chartInfos, deployer.ChartDeployInfo{
 			ChartConfig: ch,
-			ValuesYAML:  yamlData,
+			ValuesYAML:  []byte(valuesMap[ch.ChartName]),
 		})
 	}
 
@@ -1122,11 +1055,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 	}
 
 	// Save merged values per chart for deployment diff preview.
-	deployedValues := make(map[string]string, len(chartInfos))
-	for _, ci := range chartInfos {
-		deployedValues[ci.ChartConfig.ChartName] = string(ci.ValuesYAML)
-	}
-	if encoded, err := json.Marshal(deployedValues); err == nil {
+	if encoded, err := json.Marshal(valuesMap); err == nil {
 		inst.LastDeployedValues = string(encoded)
 		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
 			slog.Warn("Failed to save last deployed values",
@@ -1149,6 +1078,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 // @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
 // @Failure     500 {object} map[string]string
+// @Security    BearerAuth
 // @Router      /api/v1/stack-instances/{id}/deploy-preview [get]
 func (h *InstanceHandler) DeployPreview(c *gin.Context) {
 	id := c.Param("id")
@@ -1178,75 +1108,26 @@ func (h *InstanceHandler) DeployPreview(c *gin.Context) {
 		return
 	}
 
-	// Build locked values map from template.
-	lockedMap := h.buildLockedValuesMap(def)
-
-	// Build overrides map.
-	overridesMap := make(map[string]string)
-	overrides, err := h.overrideRepo.ListByInstance(inst.ID)
+	// Build merged values for each chart.
+	valuesMap, err := h.buildChartValues(c.Request.Context(), inst, def, charts)
 	if err != nil {
-		slog.Error("deploy-preview: failed to list value overrides", logKeyInstanceID, id, "error", err)
+		slog.Error("deploy-preview: failed to build chart values", logKeyInstanceID, id, "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
 		return
-	}
-	for _, ov := range overrides {
-		overridesMap[ov.ChartConfigID] = ov.Values
-	}
-
-	// Build per-chart branch override map.
-	branchMap := make(map[string]string)
-	if h.branchOverrideRepo != nil {
-		branchOverrides, err := h.branchOverrideRepo.List(inst.ID)
-		if err != nil {
-			slog.Error("deploy-preview: failed to list branch overrides", logKeyInstanceID, id, "error", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-		for _, bo := range branchOverrides {
-			branchMap[bo.ChartConfigID] = bo.Branch
-		}
-	}
-
-	ownerName := resolveOwnerName(h.userRepo, inst.OwnerID)
-
-	templateVars := helm.TemplateVars{
-		Branch:       inst.Branch,
-		Namespace:    inst.Namespace,
-		InstanceName: inst.Name,
-		StackName:    def.Name,
-		Owner:        ownerName,
 	}
 
 	// Parse last deployed values.
 	previousMap := make(map[string]string)
 	if inst.LastDeployedValues != "" {
-		_ = json.Unmarshal([]byte(inst.LastDeployedValues), &previousMap)
+		if err := json.Unmarshal([]byte(inst.LastDeployedValues), &previousMap); err != nil {
+			slog.Warn("Failed to parse last deployed values", logKeyInstanceID, id, "error", err)
+		}
 	}
 
-	// Generate pending values and build per-chart comparison.
-	var chartPreviews []ChartDeployPreview
+	// Build per-chart comparison.
+	chartPreviews := make([]ChartDeployPreview, 0, len(charts))
 	for _, ch := range charts {
-		params := helm.GenerateParams{
-			ChartName:      ch.ChartName,
-			DefaultValues:  ch.DefaultValues,
-			LockedValues:   lockedMap[ch.ChartName],
-			OverrideValues: overridesMap[ch.ID],
-			ChartBranch:    branchMap[ch.ID],
-			TemplateVars:   templateVars,
-		}
-
-		yamlData, err := h.valuesGen.GenerateValues(c.Request.Context(), params)
-		if err != nil {
-			slog.Error("deploy-preview: failed to generate values",
-				"chart", ch.ChartName,
-				logKeyInstanceID, id,
-				"error", err,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-
-		pending := string(yamlData)
+		pending := valuesMap[ch.ChartName]
 		previous := previousMap[ch.ChartName]
 
 		chartPreviews = append(chartPreviews, ChartDeployPreview{
@@ -1804,8 +1685,18 @@ func (h *InstanceHandler) CompareInstances(c *gin.Context) {
 	}
 
 	// Build locked values maps from templates.
-	leftLockedMap := h.buildLockedValuesMap(leftDef)
-	rightLockedMap := h.buildLockedValuesMap(rightDef)
+	leftLockedMap, err := h.buildLockedValuesMap(leftDef)
+	if err != nil {
+		slog.Error("compare: failed to build left locked values", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+	rightLockedMap, err := h.buildLockedValuesMap(rightDef)
+	if err != nil {
+		slog.Error("compare: failed to build right locked values", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
 
 	// Resolve owner names.
 	leftOwner := resolveOwnerName(h.userRepo, leftInst.OwnerID)
@@ -1921,16 +1812,74 @@ func (h *InstanceHandler) CompareInstances(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
+// buildChartValues generates merged Helm values YAML for each chart in a stack
+// instance. It returns a map of chartName → YAML string.
+func (h *InstanceHandler) buildChartValues(ctx context.Context, inst *models.StackInstance, def *models.StackDefinition, charts []models.ChartConfig) (map[string]string, error) {
+	lockedMap, err := h.buildLockedValuesMap(def)
+	if err != nil {
+		return nil, fmt.Errorf("build locked values: %w", err)
+	}
+
+	overridesMap := make(map[string]string)
+	overrides, err := h.overrideRepo.ListByInstance(inst.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list value overrides: %w", err)
+	}
+	for _, ov := range overrides {
+		overridesMap[ov.ChartConfigID] = ov.Values
+	}
+
+	branchMap := make(map[string]string)
+	if h.branchOverrideRepo != nil {
+		branchOverrides, err := h.branchOverrideRepo.List(inst.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list branch overrides: %w", err)
+		}
+		for _, bo := range branchOverrides {
+			branchMap[bo.ChartConfigID] = bo.Branch
+		}
+	}
+
+	ownerName := resolveOwnerName(h.userRepo, inst.OwnerID)
+
+	templateVars := helm.TemplateVars{
+		Branch:       inst.Branch,
+		Namespace:    inst.Namespace,
+		InstanceName: inst.Name,
+		StackName:    def.Name,
+		Owner:        ownerName,
+	}
+
+	result := make(map[string]string, len(charts))
+	for _, ch := range charts {
+		yamlData, err := h.valuesGen.GenerateValues(ctx, helm.GenerateParams{
+			ChartName:      ch.ChartName,
+			DefaultValues:  ch.DefaultValues,
+			LockedValues:   lockedMap[ch.ChartName],
+			OverrideValues: overridesMap[ch.ID],
+			ChartBranch:    branchMap[ch.ID],
+			TemplateVars:   templateVars,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("generate values for chart %s: %w", ch.ChartName, err)
+		}
+		result[ch.ChartName] = string(yamlData)
+	}
+
+	return result, nil
+}
+
 // buildLockedValuesMap returns chartName → lockedValues for a definition's source template.
-func (h *InstanceHandler) buildLockedValuesMap(def *models.StackDefinition) map[string]string {
+func (h *InstanceHandler) buildLockedValuesMap(def *models.StackDefinition) (map[string]string, error) {
 	lockedMap := make(map[string]string)
 	if def.SourceTemplateID != "" && h.templateChartRepo != nil {
 		templateCharts, err := h.templateChartRepo.ListByTemplate(def.SourceTemplateID)
-		if err == nil {
-			for _, tc := range templateCharts {
-				lockedMap[tc.ChartName] = tc.LockedValues
-			}
+		if err != nil {
+			return nil, fmt.Errorf("list template chart configs: %w", err)
+		}
+		for _, tc := range templateCharts {
+			lockedMap[tc.ChartName] = tc.LockedValues
 		}
 	}
-	return lockedMap
+	return lockedMap, nil
 }

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -29,6 +30,22 @@ type NamespaceConflictResponse struct {
 	Error       string   `json:"error"`
 	Message     string   `json:"message"`
 	Suggestions []string `json:"suggestions"`
+}
+
+// ChartDeployPreview holds a per-chart comparison between previously deployed
+// values and the values that would be deployed now.
+type ChartDeployPreview struct {
+	ChartName      string `json:"chart_name"`
+	PreviousValues string `json:"previous_values"`
+	PendingValues  string `json:"pending_values"`
+	HasChanges     bool   `json:"has_changes"`
+}
+
+// DeployPreviewResponse is the response for the deploy-preview endpoint.
+type DeployPreviewResponse struct {
+	InstanceID   string               `json:"instance_id"`
+	InstanceName string               `json:"instance_name"`
+	Charts       []ChartDeployPreview `json:"charts"`
 }
 
 // MaxTTLMinutes is the maximum allowed TTL value (30 days).
@@ -1105,7 +1122,147 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 		return
 	}
 
+	// Save merged values per chart for deployment diff preview.
+	deployedValues := make(map[string]string, len(chartInfos))
+	for _, ci := range chartInfos {
+		deployedValues[ci.ChartConfig.ChartName] = string(ci.ValuesYAML)
+	}
+	if encoded, err := json.Marshal(deployedValues); err == nil {
+		inst.LastDeployedValues = string(encoded)
+		if updateErr := h.instanceRepo.Update(inst); updateErr != nil {
+			slog.Warn("Failed to save last deployed values",
+				logKeyInstanceID, id,
+				"error", updateErr,
+			)
+		}
+	}
+
 	c.JSON(http.StatusAccepted, gin.H{"log_id": logID, "message": "Deployment started"})
+}
+
+// DeployPreview godoc
+// @Summary     Preview deployment changes
+// @Description Compare pending merged values against last-deployed values per chart
+// @Tags        stack-instances
+// @Produce     json
+// @Param       id path string true "Instance ID"
+// @Success     200 {object} DeployPreviewResponse
+// @Failure     400 {object} map[string]string
+// @Failure     404 {object} map[string]string
+// @Failure     500 {object} map[string]string
+// @Router      /api/v1/stack-instances/{id}/deploy-preview [get]
+func (h *InstanceHandler) DeployPreview(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msgInstanceIDRequired})
+		return
+	}
+
+	inst, err := h.instanceRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	def, err := h.definitionRepo.FindByID(inst.StackDefinitionID)
+	if err != nil {
+		status, message := mapError(err, entityStackDefinition)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	charts, err := h.chartConfigRepo.ListByDefinition(def.ID)
+	if err != nil {
+		status, message := mapError(err, entityChartConfigs)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	// Build locked values map from template.
+	lockedMap := h.buildLockedValuesMap(def)
+
+	// Build overrides map.
+	overridesMap := make(map[string]string)
+	overrides, err := h.overrideRepo.ListByInstance(inst.ID)
+	if err != nil {
+		slog.Error("deploy-preview: failed to list value overrides", logKeyInstanceID, id, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+	for _, ov := range overrides {
+		overridesMap[ov.ChartConfigID] = ov.Values
+	}
+
+	// Build per-chart branch override map.
+	branchMap := make(map[string]string)
+	if h.branchOverrideRepo != nil {
+		branchOverrides, err := h.branchOverrideRepo.List(inst.ID)
+		if err != nil {
+			slog.Error("deploy-preview: failed to list branch overrides", logKeyInstanceID, id, "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+			return
+		}
+		for _, bo := range branchOverrides {
+			branchMap[bo.ChartConfigID] = bo.Branch
+		}
+	}
+
+	ownerName := resolveOwnerName(h.userRepo, inst.OwnerID)
+
+	templateVars := helm.TemplateVars{
+		Branch:       inst.Branch,
+		Namespace:    inst.Namespace,
+		InstanceName: inst.Name,
+		StackName:    def.Name,
+		Owner:        ownerName,
+	}
+
+	// Parse last deployed values.
+	previousMap := make(map[string]string)
+	if inst.LastDeployedValues != "" {
+		_ = json.Unmarshal([]byte(inst.LastDeployedValues), &previousMap)
+	}
+
+	// Generate pending values and build per-chart comparison.
+	var chartPreviews []ChartDeployPreview
+	for _, ch := range charts {
+		params := helm.GenerateParams{
+			ChartName:      ch.ChartName,
+			DefaultValues:  ch.DefaultValues,
+			LockedValues:   lockedMap[ch.ChartName],
+			OverrideValues: overridesMap[ch.ID],
+			ChartBranch:    branchMap[ch.ID],
+			TemplateVars:   templateVars,
+		}
+
+		yamlData, err := h.valuesGen.GenerateValues(c.Request.Context(), params)
+		if err != nil {
+			slog.Error("deploy-preview: failed to generate values",
+				"chart", ch.ChartName,
+				logKeyInstanceID, id,
+				"error", err,
+			)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+			return
+		}
+
+		pending := string(yamlData)
+		previous := previousMap[ch.ChartName]
+
+		chartPreviews = append(chartPreviews, ChartDeployPreview{
+			ChartName:      ch.ChartName,
+			PreviousValues: previous,
+			PendingValues:  pending,
+			HasChanges:     pending != previous,
+		})
+	}
+
+	c.JSON(http.StatusOK, DeployPreviewResponse{
+		InstanceID:   inst.ID,
+		InstanceName: inst.Name,
+		Charts:       chartPreviews,
+	})
 }
 
 // StopInstance godoc

--- a/backend/internal/api/handlers/stack_instances_test.go
+++ b/backend/internal/api/handlers/stack_instances_test.go
@@ -56,6 +56,7 @@ func setupInstanceRouter(
 		insts.POST("/:id/clone", h.CloneInstance)
 		insts.GET("/:id/values/:chartId", h.ExportChartValues)
 		insts.POST("/:id/extend", h.ExtendTTL)
+		insts.GET("/:id/deploy-preview", h.DeployPreview)
 	}
 	return r
 }
@@ -972,4 +973,214 @@ func TestExtendTTL_MaxTTLExceeded(t *testing.T) {
 	var resp map[string]string
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Contains(t, resp["error"], "TTL must not exceed")
+}
+
+// ---- DeployPreview ----
+
+func TestDeployPreview(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns per-chart diff with previous deploy", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		overrideRepo := NewMockValueOverrideRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+
+		// Instance with previously deployed values.
+		inst := seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+		previousValues := map[string]string{
+			"backend":  "replicas: 1\nimage: old\n",
+			"frontend": "replicas: 2\n",
+		}
+		encoded, _ := json.Marshal(previousValues)
+		inst.LastDeployedValues = string(encoded)
+		require.NoError(t, instRepo.Update(inst))
+
+		// Charts with default values that differ from previously deployed.
+		require.NoError(t, ccRepo.Create(&models.ChartConfig{
+			ID:                "c1",
+			StackDefinitionID: "d1",
+			ChartName:         "backend",
+			DefaultValues:     "replicas: 3\nimage: new\n",
+		}))
+		require.NoError(t, ccRepo.Create(&models.ChartConfig{
+			ID:                "c2",
+			StackDefinitionID: "d1",
+			ChartName:         "frontend",
+			DefaultValues:     "replicas: 2\n",
+		}))
+
+		router := setupInstanceRouter(instRepo, overrideRepo, defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp DeployPreviewResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "i1", resp.InstanceID)
+		assert.Equal(t, "stack-a", resp.InstanceName)
+		assert.Len(t, resp.Charts, 2)
+
+		// Find charts by name for order-independent assertions.
+		chartMap := make(map[string]ChartDeployPreview, len(resp.Charts))
+		for _, ch := range resp.Charts {
+			chartMap[ch.ChartName] = ch
+		}
+
+		backend := chartMap["backend"]
+		assert.True(t, backend.HasChanges, "backend should have changes")
+		assert.Equal(t, "replicas: 1\nimage: old\n", backend.PreviousValues)
+		assert.NotEmpty(t, backend.PendingValues)
+
+		frontend := chartMap["frontend"]
+		assert.False(t, frontend.HasChanges, "frontend should be unchanged")
+		assert.Equal(t, frontend.PreviousValues, frontend.PendingValues)
+	})
+
+	t.Run("first deploy returns empty previous values", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		overrideRepo := NewMockValueOverrideRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusDraft)
+		// No LastDeployedValues set.
+
+		require.NoError(t, ccRepo.Create(&models.ChartConfig{
+			ID:                "c1",
+			StackDefinitionID: "d1",
+			ChartName:         "backend",
+			DefaultValues:     "replicas: 1\n",
+		}))
+
+		router := setupInstanceRouter(instRepo, overrideRepo, defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp DeployPreviewResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Len(t, resp.Charts, 1)
+		assert.Equal(t, "", resp.Charts[0].PreviousValues)
+		assert.NotEmpty(t, resp.Charts[0].PendingValues)
+		assert.True(t, resp.Charts[0].HasChanges, "first deploy should always show changes")
+	})
+
+	t.Run("instance not found returns 404", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/missing-id/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp["error"], "not found")
+	})
+
+	t.Run("instance with no charts returns empty charts array", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "Empty Def", "uid-1")
+		seedInstance(t, instRepo, "i1", "stack-empty", "d1", "uid-1", models.StackStatusDraft)
+		// No chart configs created.
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp DeployPreviewResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "i1", resp.InstanceID)
+		assert.Empty(t, resp.Charts)
+	})
+
+	t.Run("definition not found returns 404", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		// Instance references a definition that doesn't exist.
+		seedInstance(t, instRepo, "i1", "stack-a", "d-missing", "uid-1", models.StackStatusDraft)
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), defRepo, NewMockChartConfigRepository(), NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("chart config repo error returns 500", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusDraft)
+		ccRepo.SetError(errInternal)
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
+	t.Run("includes value overrides in pending values", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		overrideRepo := NewMockValueOverrideRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusDraft)
+
+		require.NoError(t, ccRepo.Create(&models.ChartConfig{
+			ID:                "c1",
+			StackDefinitionID: "d1",
+			ChartName:         "backend",
+			DefaultValues:     "replicas: 1\n",
+		}))
+		require.NoError(t, overrideRepo.Create(&models.ValueOverride{
+			ID:              "ov1",
+			StackInstanceID: "i1",
+			ChartConfigID:   "c1",
+			Values:          "replicas: 5",
+		}))
+
+		router := setupInstanceRouter(instRepo, overrideRepo, defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var resp DeployPreviewResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Len(t, resp.Charts, 1)
+		// The pending values should include the override.
+		assert.Contains(t, resp.Charts[0].PendingValues, "replicas: 5")
+		assert.True(t, resp.Charts[0].HasChanges)
+	})
 }

--- a/backend/internal/api/handlers/stack_instances_test.go
+++ b/backend/internal/api/handlers/stack_instances_test.go
@@ -1183,4 +1183,53 @@ func TestDeployPreview(t *testing.T) {
 		assert.Contains(t, resp.Charts[0].PendingValues, "replicas: 5")
 		assert.True(t, resp.Charts[0].HasChanges)
 	})
+
+	t.Run("non-owner user gets 403", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-alice")
+		// Instance owned by uid-alice.
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-alice", models.StackStatusRunning)
+
+		// Request as bob (uid-bob) with role "user" — should be forbidden.
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-bob", "bob", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusForbidden, w.Code)
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp["error"], "not allowed")
+	})
+
+	t.Run("devops role can access other users instances", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		overrideRepo := NewMockValueOverrideRepository()
+		defRepo := NewMockStackDefinitionRepository()
+		ccRepo := NewMockChartConfigRepository()
+
+		seedDefinition(t, defRepo, "d1", "My Def", "uid-alice")
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-alice", models.StackStatusRunning)
+
+		require.NoError(t, ccRepo.Create(&models.ChartConfig{
+			ID:                "c1",
+			StackDefinitionID: "d1",
+			ChartName:         "backend",
+			DefaultValues:     "replicas: 1\n",
+		}))
+
+		// Request as bob (uid-bob) with role "devops" — should pass auth check.
+		router := setupInstanceRouter(instRepo, overrideRepo, defRepo, ccRepo, NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-bob", "bob", "devops")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/deploy-preview", nil)
+		router.ServeHTTP(w, req)
+
+		assert.NotEqual(t, http.StatusForbidden, w.Code, "devops should not be forbidden")
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -304,6 +304,7 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 				instances.GET("/:id/overrides", deps.InstanceHandler.GetOverrides)
 				instances.PUT("/:id/overrides/:chartId", deps.InstanceHandler.SetOverride)
 				instances.POST("/:id/deploy", deps.InstanceHandler.DeployInstance)
+				instances.GET("/:id/deploy-preview", deps.InstanceHandler.DeployPreview)
 				instances.POST("/:id/stop", deps.InstanceHandler.StopInstance)
 				instances.POST("/:id/clean", deps.InstanceHandler.CleanInstance)
 				instances.POST("/:id/extend", deps.InstanceHandler.ExtendTTL)

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -52,9 +52,10 @@ type stackInstanceEntity struct {
 	Branch            string  `json:"Branch"`
 	ClusterID         string  `json:"ClusterID"`
 	Status            string  `json:"Status"`
-	ErrorMessage      string  `json:"ErrorMessage"`
-	TTLMinutes        float64 `json:"TTLMinutes"`
-	LastDeployedAt    string  `json:"LastDeployedAt,omitempty"`
+	ErrorMessage       string  `json:"ErrorMessage"`
+	LastDeployedValues string  `json:"LastDeployedValues"`
+	TTLMinutes         float64 `json:"TTLMinutes"`
+	LastDeployedAt     string  `json:"LastDeployedAt,omitempty"`
 	ExpiresAt         string  `json:"ExpiresAt,omitempty"`
 	CreatedAt         string  `json:"CreatedAt"`
 	UpdatedAt         string  `json:"UpdatedAt"`
@@ -62,16 +63,17 @@ type stackInstanceEntity struct {
 
 func (e *stackInstanceEntity) toModel() *models.StackInstance {
 	instance := &models.StackInstance{
-		ID:                e.ID,
-		StackDefinitionID: e.StackDefinitionID,
-		Name:              e.Name,
-		Namespace:         e.Namespace,
-		OwnerID:           e.OwnerID,
-		Branch:            e.Branch,
-		ClusterID:         e.ClusterID,
-		Status:            e.Status,
-		ErrorMessage:      e.ErrorMessage,
-		TTLMinutes:        int(e.TTLMinutes),
+		ID:                 e.ID,
+		StackDefinitionID:  e.StackDefinitionID,
+		Name:               e.Name,
+		Namespace:          e.Namespace,
+		OwnerID:            e.OwnerID,
+		Branch:             e.Branch,
+		ClusterID:          e.ClusterID,
+		Status:             e.Status,
+		ErrorMessage:       e.ErrorMessage,
+		LastDeployedValues: e.LastDeployedValues,
+		TTLMinutes:         int(e.TTLMinutes),
 	}
 	instance.CreatedAt, _ = time.Parse(time.RFC3339, e.CreatedAt)
 	instance.UpdatedAt, _ = time.Parse(time.RFC3339, e.UpdatedAt)
@@ -450,8 +452,9 @@ func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
 		"Branch":            i.Branch,
 		"ClusterID":         i.ClusterID,
 		"Status":            i.Status,
-		"ErrorMessage":      i.ErrorMessage,
-		"TTLMinutes":        int64(i.TTLMinutes),
+		"ErrorMessage":       i.ErrorMessage,
+		"LastDeployedValues": i.LastDeployedValues,
+		"TTLMinutes":         int64(i.TTLMinutes),
 		"CreatedAt":         i.CreatedAt.Format(time.RFC3339),
 		"UpdatedAt":         i.UpdatedAt.Format(time.RFC3339),
 	}

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -16,7 +16,7 @@ const filterPKGlobal = odataPartitionKeyEq + pkGlobal + "'"
 
 // stackInstanceListSelect is the $select projection for list operations,
 // excluding large fields like LastDeployedValues to reduce bandwidth.
-var stackInstanceListSelect = "PartitionKey,RowKey,ID,StackDefinitionID,Name,Namespace,OwnerID,Branch,ClusterID,Status,ErrorMessage,TTLMinutes,LastDeployedAt,ExpiresAt,CreatedAt,UpdatedAt"
+var stackInstanceListSelect = "PartitionKey,RowKey,ID,StackDefinitionID,Name,Namespace,OwnerID,Branch,ClusterID,Status,TTLMinutes,LastDeployedAt,ExpiresAt,CreatedAt,UpdatedAt"
 
 // StackInstanceRepository implements models.StackInstanceRepository for Azure Table Storage.
 // Partition key: "global", Row key: instance ID.
@@ -456,7 +456,8 @@ func (r *StackInstanceRepository) ListIDsByOwnerIDs(_ []string) (map[string][]st
 func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
 	// Azure Table Storage has a ~64KB per-property limit.
 	// If LastDeployedValues exceeds the limit, clear it rather than storing
-	// truncated invalid JSON. Deploy preview will show "First deployment".
+	// truncated invalid JSON. This leaves previous deployed values empty, so
+	// any later diff/preview compares against blank instead of prior values.
 	const maxLastDeployedValuesLen = 60 * 1024 // 60KB — leave headroom for other fields
 	ldv := i.LastDeployedValues
 	if len(ldv) > maxLastDeployedValuesLen {

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -454,6 +454,13 @@ func (r *StackInstanceRepository) ListIDsByOwnerIDs(_ []string) (map[string][]st
 }
 
 func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
+	// Azure Table Storage has a ~64KB per-property limit.
+	const maxLastDeployedValuesLen = 60 * 1024 // 60KB — leave headroom for other fields
+	ldv := i.LastDeployedValues
+	if len(ldv) > maxLastDeployedValuesLen {
+		ldv = ldv[:maxLastDeployedValuesLen]
+	}
+
 	entity := map[string]interface{}{
 		"PartitionKey":       pkGlobal,
 		"RowKey":             i.ID,
@@ -466,7 +473,7 @@ func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
 		"ClusterID":          i.ClusterID,
 		"Status":             i.Status,
 		"ErrorMessage":       i.ErrorMessage,
-		"LastDeployedValues": i.LastDeployedValues,
+		"LastDeployedValues": ldv,
 		"TTLMinutes":         int64(i.TTLMinutes),
 		"CreatedAt":          i.CreatedAt.Format(time.RFC3339),
 		"UpdatedAt":          i.UpdatedAt.Format(time.RFC3339),

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -42,23 +42,23 @@ func (r *StackInstanceRepository) SetTestClient(client AzureTableClient) {
 
 // stackInstanceEntity is the typed Azure Table entity for stack instances.
 type stackInstanceEntity struct {
-	PartitionKey      string  `json:"PartitionKey"`
-	RowKey            string  `json:"RowKey"`
-	ID                string  `json:"ID"`
-	StackDefinitionID string  `json:"StackDefinitionID"`
-	Name              string  `json:"Name"`
-	Namespace         string  `json:"Namespace"`
-	OwnerID           string  `json:"OwnerID"`
-	Branch            string  `json:"Branch"`
-	ClusterID         string  `json:"ClusterID"`
-	Status            string  `json:"Status"`
+	PartitionKey       string  `json:"PartitionKey"`
+	RowKey             string  `json:"RowKey"`
+	ID                 string  `json:"ID"`
+	StackDefinitionID  string  `json:"StackDefinitionID"`
+	Name               string  `json:"Name"`
+	Namespace          string  `json:"Namespace"`
+	OwnerID            string  `json:"OwnerID"`
+	Branch             string  `json:"Branch"`
+	ClusterID          string  `json:"ClusterID"`
+	Status             string  `json:"Status"`
 	ErrorMessage       string  `json:"ErrorMessage"`
 	LastDeployedValues string  `json:"LastDeployedValues"`
 	TTLMinutes         float64 `json:"TTLMinutes"`
 	LastDeployedAt     string  `json:"LastDeployedAt,omitempty"`
-	ExpiresAt         string  `json:"ExpiresAt,omitempty"`
-	CreatedAt         string  `json:"CreatedAt"`
-	UpdatedAt         string  `json:"UpdatedAt"`
+	ExpiresAt          string  `json:"ExpiresAt,omitempty"`
+	CreatedAt          string  `json:"CreatedAt"`
+	UpdatedAt          string  `json:"UpdatedAt"`
 }
 
 func (e *stackInstanceEntity) toModel() *models.StackInstance {
@@ -442,21 +442,21 @@ func (r *StackInstanceRepository) ListIDsByOwnerIDs(_ []string) (map[string][]st
 
 func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
 	entity := map[string]interface{}{
-		"PartitionKey":      pkGlobal,
-		"RowKey":            i.ID,
-		"ID":                i.ID,
-		"StackDefinitionID": i.StackDefinitionID,
-		"Name":              i.Name,
-		"Namespace":         i.Namespace,
-		"OwnerID":           i.OwnerID,
-		"Branch":            i.Branch,
-		"ClusterID":         i.ClusterID,
-		"Status":            i.Status,
+		"PartitionKey":       pkGlobal,
+		"RowKey":             i.ID,
+		"ID":                 i.ID,
+		"StackDefinitionID":  i.StackDefinitionID,
+		"Name":               i.Name,
+		"Namespace":          i.Namespace,
+		"OwnerID":            i.OwnerID,
+		"Branch":             i.Branch,
+		"ClusterID":          i.ClusterID,
+		"Status":             i.Status,
 		"ErrorMessage":       i.ErrorMessage,
 		"LastDeployedValues": i.LastDeployedValues,
 		"TTLMinutes":         int64(i.TTLMinutes),
-		"CreatedAt":         i.CreatedAt.Format(time.RFC3339),
-		"UpdatedAt":         i.UpdatedAt.Format(time.RFC3339),
+		"CreatedAt":          i.CreatedAt.Format(time.RFC3339),
+		"UpdatedAt":          i.UpdatedAt.Format(time.RFC3339),
 	}
 	if i.LastDeployedAt != nil {
 		entity["LastDeployedAt"] = i.LastDeployedAt.Format(time.RFC3339)

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -455,10 +455,12 @@ func (r *StackInstanceRepository) ListIDsByOwnerIDs(_ []string) (map[string][]st
 
 func stackInstanceToEntity(i *models.StackInstance) map[string]interface{} {
 	// Azure Table Storage has a ~64KB per-property limit.
+	// If LastDeployedValues exceeds the limit, clear it rather than storing
+	// truncated invalid JSON. Deploy preview will show "First deployment".
 	const maxLastDeployedValuesLen = 60 * 1024 // 60KB — leave headroom for other fields
 	ldv := i.LastDeployedValues
 	if len(ldv) > maxLastDeployedValuesLen {
-		ldv = ldv[:maxLastDeployedValuesLen]
+		ldv = ""
 	}
 
 	entity := map[string]interface{}{

--- a/backend/internal/database/azure/stack_instance_repository.go
+++ b/backend/internal/database/azure/stack_instance_repository.go
@@ -14,6 +14,10 @@ import (
 const tableStackInstances = "StackInstances"
 const filterPKGlobal = odataPartitionKeyEq + pkGlobal + "'"
 
+// stackInstanceListSelect is the $select projection for list operations,
+// excluding large fields like LastDeployedValues to reduce bandwidth.
+var stackInstanceListSelect = "PartitionKey,RowKey,ID,StackDefinitionID,Name,Namespace,OwnerID,Branch,ClusterID,Status,ErrorMessage,TTLMinutes,LastDeployedAt,ExpiresAt,CreatedAt,UpdatedAt"
+
 // StackInstanceRepository implements models.StackInstanceRepository for Azure Table Storage.
 // Partition key: "global", Row key: instance ID.
 type StackInstanceRepository struct {
@@ -210,6 +214,7 @@ func (r *StackInstanceRepository) List() ([]models.StackInstance, error) {
 	filter := filterPKGlobal
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 0)
@@ -233,6 +238,7 @@ func (r *StackInstanceRepository) ListPaged(limit, offset int) ([]models.StackIn
 	filter := filterPKGlobal
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 
 	// Collect all then paginate in-memory. Azure Table Storage does not support
@@ -271,6 +277,7 @@ func (r *StackInstanceRepository) CountAll() (int, error) {
 	filter := filterPKGlobal
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 0)
 	if err != nil {
@@ -284,6 +291,7 @@ func (r *StackInstanceRepository) CountByStatus(status string) (int, error) {
 	filter := filterPKGlobal + " and Status eq '" + escapeODataString(status) + "'"
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 0)
 	if err != nil {
@@ -301,6 +309,7 @@ func (r *StackInstanceRepository) ExistsByDefinitionAndStatus(definitionID, stat
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
 		Top:    &top,
+		Select: &stackInstanceListSelect,
 	})
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 1)
 	if err != nil {
@@ -315,6 +324,7 @@ func (r *StackInstanceRepository) ListByOwner(ownerID string) ([]models.StackIns
 	filter := filterPKGlobal + " and OwnerID eq '" + escapeODataString(ownerID) + "'"
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 0)
@@ -339,6 +349,7 @@ func (r *StackInstanceRepository) FindByCluster(clusterID string) ([]models.Stac
 		filter := filterPKGlobal
 		pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 			Filter: &filter,
+			Select: &stackInstanceListSelect,
 		})
 
 		entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, func(e *stackInstanceEntity) bool {
@@ -358,6 +369,7 @@ func (r *StackInstanceRepository) FindByCluster(clusterID string) ([]models.Stac
 	filter := filterPKGlobal + " and ClusterID eq '" + escapeODataString(clusterID) + "'"
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, nil, 0)
@@ -394,6 +406,7 @@ func (r *StackInstanceRepository) ListExpired() ([]*models.StackInstance, error)
 	filter := filterPKGlobal + " and Status eq 'running'"
 	pager := r.client.NewListEntitiesPager(&aztables.ListEntitiesOptions{
 		Filter: &filter,
+		Select: &stackInstanceListSelect,
 	})
 
 	entities, err := collectEntitiesTyped[stackInstanceEntity](ctx, pager, func(e *stackInstanceEntity) bool {

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -447,7 +447,7 @@ func (d *Database) AutoMigrate() error {
 				{"stack_definitions", "idx_stack_definitions_owner_id"},
 			}
 			for _, idx := range indexes {
-				_ = tx.Exec("DROP INDEX " + idx.name + " ON " + idx.table).Error
+				_ = tx.Exec(fmt.Sprintf("DROP INDEX %s ON %s", idx.name, idx.table)).Error // #nosec G202 -- table/index names are hardcoded constants
 			}
 			return nil
 		},
@@ -505,7 +505,7 @@ func (d *Database) AutoMigrate() error {
 				{"stack_instances", "idx_stack_instances_created_at"},
 			}
 			for _, idx := range indexes {
-				_ = tx.Exec("DROP INDEX " + idx.name + " ON " + idx.table).Error
+				_ = tx.Exec(fmt.Sprintf("DROP INDEX %s ON %s", idx.name, idx.table)).Error // #nosec G202 -- table/index names are hardcoded constants
 			}
 			return nil
 		},
@@ -573,7 +573,7 @@ func (d *Database) AutoMigrate() error {
 				var count int64
 				tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", idx.table, idx.name).Scan(&count)
 				if count > 0 {
-					if err := tx.Exec("DROP INDEX " + idx.name + " ON " + idx.table).Error; err != nil {
+					if err := tx.Exec(fmt.Sprintf("DROP INDEX %s ON %s", idx.name, idx.table)).Error; err != nil { // #nosec G202 -- table/index names are hardcoded constants
 						return err
 					}
 				}
@@ -607,7 +607,7 @@ func (d *Database) AutoMigrate() error {
 				{"stack_instances", "idx_stack_instances_status_expires"},
 			}
 			for _, idx := range dropIndexes {
-				_ = tx.Exec("DROP INDEX " + idx.name + " ON " + idx.table).Error
+				_ = tx.Exec(fmt.Sprintf("DROP INDEX %s ON %s", idx.name, idx.table)).Error // #nosec G202 -- table/index names are hardcoded constants
 			}
 			return nil
 		},
@@ -687,6 +687,12 @@ func (d *Database) AutoMigrate() error {
 		Name:        "alter_last_deployed_values_to_longtext",
 		Description: "Change last_deployed_values column from TEXT to LONGTEXT for large merged values",
 		Up: func(tx *gorm.DB) error {
+			dialector := tx.Dialector.Name()
+			if dialector == "sqlite" {
+				// SQLite TEXT is already unlimited — no alteration needed.
+				return nil
+			}
+			// MySQL/MariaDB: check current column type and alter if needed.
 			var columnType string
 			row := tx.Raw("SELECT COLUMN_TYPE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stack_instances' AND COLUMN_NAME = 'last_deployed_values'").Row()
 			if err := row.Scan(&columnType); err != nil {
@@ -701,6 +707,9 @@ func (d *Database) AutoMigrate() error {
 			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error
 		},
 		Down: func(tx *gorm.DB) error {
+			if tx.Dialector.Name() == "sqlite" {
+				return nil
+			}
 			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
 				return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error
 			}

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -416,7 +416,7 @@ func (d *Database) AutoMigrate() error {
 				var count int64
 				tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", idx.table, idx.name).Scan(&count)
 				if count == 0 {
-					if err := tx.Exec(idx.sql).Error; err != nil {
+					if err := tx.Exec(idx.sql).Error; err != nil { // #nosec G202 -- SQL from hardcoded struct constants
 						return err
 					}
 				}
@@ -486,7 +486,7 @@ func (d *Database) AutoMigrate() error {
 				var count int64
 				tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", idx.table, idx.name).Scan(&count)
 				if count == 0 {
-					if err := tx.Exec(idx.sql).Error; err != nil {
+					if err := tx.Exec(idx.sql).Error; err != nil { // #nosec G202 -- SQL from hardcoded struct constants
 						return err
 					}
 				}
@@ -554,7 +554,7 @@ func (d *Database) AutoMigrate() error {
 				var count int64
 				tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", idx.table, idx.name).Scan(&count)
 				if count == 0 {
-					if err := tx.Exec(idx.sql).Error; err != nil {
+					if err := tx.Exec(idx.sql).Error; err != nil { // #nosec G202 -- SQL from hardcoded struct constants
 						return err
 					}
 				}
@@ -593,7 +593,7 @@ func (d *Database) AutoMigrate() error {
 				var count int64
 				tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", idx.table, idx.name).Scan(&count)
 				if count == 0 {
-					if err := tx.Exec(idx.sql).Error; err != nil {
+					if err := tx.Exec(idx.sql).Error; err != nil { // #nosec G202 -- SQL from hardcoded struct constants
 						return err
 					}
 				}

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -688,8 +688,7 @@ func (d *Database) AutoMigrate() error {
 		Description: "Change last_deployed_values column from TEXT to LONGTEXT for large merged values",
 		Up: func(tx *gorm.DB) error {
 			dialector := tx.Dialector.Name()
-			if dialector == "sqlite" {
-				// SQLite TEXT is already unlimited — no alteration needed.
+			if dialector != "mysql" {
 				return nil
 			}
 			// MySQL/MariaDB: check current column type and alter if needed.
@@ -707,7 +706,7 @@ func (d *Database) AutoMigrate() error {
 			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error
 		},
 		Down: func(tx *gorm.DB) error {
-			if tx.Dialector.Name() == "sqlite" {
+			if tx.Dialector.Name() != "mysql" {
 				return nil
 			}
 			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -1,6 +1,9 @@
 package database
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
 	"log/slog"
 
 	"backend/internal/database/schema"
@@ -687,7 +690,10 @@ func (d *Database) AutoMigrate() error {
 			var columnType string
 			row := tx.Raw("SELECT COLUMN_TYPE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stack_instances' AND COLUMN_NAME = 'last_deployed_values'").Row()
 			if err := row.Scan(&columnType); err != nil {
-				return nil // column doesn't exist yet, migration 27 will handle it
+				if errors.Is(err, sql.ErrNoRows) {
+					return nil // column doesn't exist yet, migration 27 will handle it
+				}
+				return fmt.Errorf("failed to check column type: %w", err)
 			}
 			if columnType == "longtext" {
 				return nil // already longtext
@@ -695,7 +701,10 @@ func (d *Database) AutoMigrate() error {
 			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error
 		},
 		Down: func(tx *gorm.DB) error {
-			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error
+			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
+				return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error
+			}
+			return nil
 		},
 	})
 

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -659,6 +659,25 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
+	// Migration 27: Add last_deployed_values column to stack_instances
+	migrator.AddMigration(schema.Migration{
+		Version:     "20231201000027",
+		Name:        "add_last_deployed_values_to_stack_instances",
+		Description: "Add last_deployed_values TEXT column to stack_instances for deployment diff preview",
+		Up: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
+				return nil
+			}
+			return tx.Migrator().AddColumn(&models.StackInstance{}, "LastDeployedValues")
+		},
+		Down: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
+				return tx.Migrator().DropColumn(&models.StackInstance{}, "LastDeployedValues")
+			}
+			return nil
+		},
+	})
+
 	// Run migrations
 	if err := migrator.MigrateUp(); err != nil {
 		return err

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -703,14 +703,14 @@ func (d *Database) AutoMigrate() error {
 			if columnType == "longtext" {
 				return nil // already longtext
 			}
-			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error
+			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error // #nosec G202
 		},
 		Down: func(tx *gorm.DB) error {
 			if tx.Dialector.Name() != "mysql" {
 				return nil
 			}
 			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
-				return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error
+				return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error // #nosec G202
 			}
 			return nil
 		},

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -678,13 +678,21 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
-	// Migration 28: Alter last_deployed_values from TEXT to LONGTEXT
+	// Migration 28: Alter last_deployed_values from TEXT to LONGTEXT (conditional)
 	migrator.AddMigration(schema.Migration{
 		Version:     "20231201000028",
 		Name:        "alter_last_deployed_values_to_longtext",
 		Description: "Change last_deployed_values column from TEXT to LONGTEXT for large merged values",
 		Up: func(tx *gorm.DB) error {
-			return tx.Migrator().AlterColumn(&models.StackInstance{}, "LastDeployedValues")
+			var columnType string
+			row := tx.Raw("SELECT COLUMN_TYPE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'stack_instances' AND COLUMN_NAME = 'last_deployed_values'").Row()
+			if err := row.Scan(&columnType); err != nil {
+				return nil // column doesn't exist yet, migration 27 will handle it
+			}
+			if columnType == "longtext" {
+				return nil // already longtext
+			}
+			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values LONGTEXT").Error
 		},
 		Down: func(tx *gorm.DB) error {
 			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -663,7 +663,7 @@ func (d *Database) AutoMigrate() error {
 	migrator.AddMigration(schema.Migration{
 		Version:     "20231201000027",
 		Name:        "add_last_deployed_values_to_stack_instances",
-		Description: "Add last_deployed_values TEXT column to stack_instances for deployment diff preview",
+		Description: "Add last_deployed_values LONGTEXT column to stack_instances for deployment diff preview",
 		Up: func(tx *gorm.DB) error {
 			if tx.Migrator().HasColumn(&models.StackInstance{}, "LastDeployedValues") {
 				return nil
@@ -675,6 +675,19 @@ func (d *Database) AutoMigrate() error {
 				return tx.Migrator().DropColumn(&models.StackInstance{}, "LastDeployedValues")
 			}
 			return nil
+		},
+	})
+
+	// Migration 28: Alter last_deployed_values from TEXT to LONGTEXT
+	migrator.AddMigration(schema.Migration{
+		Version:     "20231201000028",
+		Name:        "alter_last_deployed_values_to_longtext",
+		Description: "Change last_deployed_values column from TEXT to LONGTEXT for large merged values",
+		Up: func(tx *gorm.DB) error {
+			return tx.Migrator().AlterColumn(&models.StackInstance{}, "LastDeployedValues")
+		},
+		Down: func(tx *gorm.DB) error {
+			return tx.Exec("ALTER TABLE stack_instances MODIFY last_deployed_values TEXT").Error
 		},
 	})
 

--- a/backend/internal/database/stack_instance_repository.go
+++ b/backend/internal/database/stack_instance_repository.go
@@ -98,8 +98,8 @@ func (r *GORMStackInstanceRepository) List() ([]models.StackInstance, error) {
 	return instances, nil
 }
 
-// listColumns are the columns fetched by ListPaged. The heavy TEXT column
-// error_message is omitted because it is only needed in the detail view.
+// listColumns are the columns fetched by ListPaged. The heavy TEXT columns
+// error_message and last_deployed_values are omitted because they are only needed in the detail view.
 var listColumns = []string{
 	"id", "name", "namespace", "owner_id", "stack_definition_id",
 	"branch", "cluster_id", "status", "ttl_minutes",

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -72,10 +72,11 @@ type ManagerConfig struct {
 
 // DeployRequest contains everything needed to deploy a stack instance.
 type DeployRequest struct {
-	Instance   *models.StackInstance
-	Definition *models.StackDefinition
-	Charts     []ChartDeployInfo
-	Owner      string
+	Instance           *models.StackInstance
+	Definition         *models.StackDefinition
+	Charts             []ChartDeployInfo
+	Owner              string
+	LastDeployedValues string // JSON-serialized merged values for deploy preview
 }
 
 // ChartDeployInfo holds chart configuration and pre-generated merged values.
@@ -197,14 +198,14 @@ func (m *Manager) Deploy(ctx context.Context, req DeployRequest) (string, error)
 
 	// Launch async deployment, passing the deployLog to avoid re-fetching.
 	m.wg.Add(1)
-	go m.executeDeploy(helmExec, req.Instance.ID, deployLog, req.Instance.Namespace, charts)
+	go m.executeDeploy(helmExec, req.Instance.ID, deployLog, req.Instance.Namespace, charts, req.LastDeployedValues)
 
 	return logID, nil
 }
 
 // executeDeploy runs the helm install for each chart sequentially within
 // a concurrency-limited goroutine.
-func (m *Manager) executeDeploy(helm HelmExecutor, instanceID string, deployLog *models.DeploymentLog, namespace string, charts []ChartDeployInfo) {
+func (m *Manager) executeDeploy(helm HelmExecutor, instanceID string, deployLog *models.DeploymentLog, namespace string, charts []ChartDeployInfo, lastDeployedValues string) {
 	defer m.wg.Done()
 	// Acquire semaphore.
 	m.semaphore <- struct{}{}
@@ -227,7 +228,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, instanceID string, deployLog 
 	if err != nil {
 		deployErr = fmt.Errorf("creating temp directory: %w", err)
 		slog.Error("deployment failed", "instance_id", instanceID, "error", deployErr)
-		m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr)
+		m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues)
 		return
 	}
 	defer os.RemoveAll(tmpDir)
@@ -325,7 +326,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, instanceID string, deployLog 
 		allOutput += rollbackOutput
 	}
 
-	m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr)
+	m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues)
 }
 
 // rollbackCharts uninstalls previously-installed charts in reverse order after
@@ -372,7 +373,7 @@ func (m *Manager) rollbackCharts(helm HelmExecutor, ctx context.Context, instanc
 // finalizeDeploy updates the instance and deployment log with the final status.
 // The deployLog is passed directly from the goroutine closure to avoid a
 // partition-scanning FindByID call on Azure Table Storage.
-func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.DeploymentLog, output string, deployErr error) {
+func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.DeploymentLog, output string, deployErr error, lastDeployedValues string) {
 	now := time.Now().UTC()
 
 	instance, err := m.instanceRepo.FindByID(instanceID)
@@ -404,6 +405,7 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 		instance.Status = models.StackStatusRunning
 		instance.ErrorMessage = ""
 		instance.LastDeployedAt = &now
+		instance.LastDeployedValues = lastDeployedValues
 		deployLog.Status = models.DeployLogSuccess
 
 		slog.Info("deployment succeeded",

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -75,7 +75,6 @@ type DeployRequest struct {
 	Instance           *models.StackInstance
 	Definition         *models.StackDefinition
 	Charts             []ChartDeployInfo
-	Owner              string
 	LastDeployedValues string // JSON-serialized merged values for deploy preview
 }
 

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -1031,7 +1031,7 @@ func TestManager_FinalizeDeploy_InstanceNotFound(t *testing.T) {
 
 	// Should not panic when instance is not found.
 	orphanLog := &models.DeploymentLog{ID: "some-log-id", StackInstanceID: "nonexistent-id"}
-	mgr.finalizeDeploy("nonexistent-id", orphanLog, "output", nil)
+	mgr.finalizeDeploy("nonexistent-id", orphanLog, "output", nil, "")
 }
 
 func TestManager_BroadcastStatusWithError_NilHub(t *testing.T) {
@@ -1380,7 +1380,7 @@ func TestManager_FinalizeDeploy_OutputTruncation(t *testing.T) {
 
 	// Create output larger than maxOutputLen (64KB).
 	largeOutput := strings.Repeat("x", maxOutputLen+1000)
-	mgr.finalizeDeploy(inst.ID, deployLog, largeOutput, nil)
+	mgr.finalizeDeploy(inst.ID, deployLog, largeOutput, nil, "")
 
 	finalLog, err := logRepo.FindByID(context.Background(), deployLog.ID)
 	assert.NoError(t, err)

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -414,7 +414,6 @@ func TestManager_Deploy_CreatesLogAndUpdatesStatus(t *testing.T) {
 		Instance:   inst,
 		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
 		Charts:     []ChartDeployInfo{}, // No charts = quick finish.
-		Owner:      "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -491,7 +490,6 @@ func TestManager_Deploy_WithCharts_Fails(t *testing.T) {
 				},
 			},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -1487,7 +1485,6 @@ func TestManager_Deploy_PartialRollback(t *testing.T) {
 			{ChartConfig: models.ChartConfig{ChartName: "chart-b", DeployOrder: 2}},
 			{ChartConfig: models.ChartConfig{ChartName: "chart-c", DeployOrder: 3}},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -1566,7 +1563,6 @@ func TestManager_Deploy_PartialRollback_RollbackFails(t *testing.T) {
 			{ChartConfig: models.ChartConfig{ChartName: "chart-b", DeployOrder: 2}},
 			{ChartConfig: models.ChartConfig{ChartName: "chart-c", DeployOrder: 3}},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -1893,7 +1889,6 @@ func TestManager_Deploy_FirstChartFails_NoRollback(t *testing.T) {
 			{ChartConfig: models.ChartConfig{ChartName: "chart-a", DeployOrder: 1}},
 			{ChartConfig: models.ChartConfig{ChartName: "chart-b", DeployOrder: 2}},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -2495,7 +2490,6 @@ func TestManager_ExecuteDeploy_OCIChartRef(t *testing.T) {
 				ValuesYAML: []byte("key: value\n"),
 			},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -2561,7 +2555,6 @@ func TestManager_ExecuteDeploy_HTTPRepoRef(t *testing.T) {
 				},
 			},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -2628,7 +2621,6 @@ func TestManager_ExecuteDeploy_ValuesFileWritten(t *testing.T) {
 				ValuesYAML: nil,
 			},
 		},
-		Owner: "testuser",
 	}
 
 	logID, err := mgr.Deploy(context.Background(), req)
@@ -2822,4 +2814,84 @@ func TestManager_Clean_NilHelmExecutor(t *testing.T) {
 	_, err := mgr.Clean(context.Background(), &models.StackInstance{ID: "inst-clean-nil-helm"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "helm executor is nil")
+}
+
+func TestManager_FinalizeDeploy_LastDeployedValues(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	inst := &models.StackInstance{
+		ID:        "inst-ldv",
+		Name:      "ldv-test",
+		Namespace: "stack-ldv",
+		Status:    models.StackStatusDeploying,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	deployLog := &models.DeploymentLog{
+		ID:              "log-ldv",
+		StackInstanceID: inst.ID,
+		Action:          models.DeployActionDeploy,
+		Status:          models.DeployLogRunning,
+		StartedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, logRepo.Create(context.Background(), deployLog))
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: NewHelmClient("/nonexistent/helm", "", 1*time.Second)},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		Hub:           nil,
+		MaxConcurrent: 2,
+	})
+
+	lastValues := `{"mychart":"key: value\n"}`
+	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", nil, lastValues)
+
+	updated, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, lastValues, updated.LastDeployedValues)
+	assert.Equal(t, models.StackStatusRunning, updated.Status)
+}
+
+func TestManager_FinalizeDeploy_LastDeployedValuesNotSetOnError(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	inst := &models.StackInstance{
+		ID:        "inst-ldv-err",
+		Name:      "ldv-err-test",
+		Namespace: "stack-ldv-err",
+		Status:    models.StackStatusDeploying,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	deployLog := &models.DeploymentLog{
+		ID:              "log-ldv-err",
+		StackInstanceID: inst.ID,
+		Action:          models.DeployActionDeploy,
+		Status:          models.DeployLogRunning,
+		StartedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, logRepo.Create(context.Background(), deployLog))
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: NewHelmClient("/nonexistent/helm", "", 1*time.Second)},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		Hub:           nil,
+		MaxConcurrent: 2,
+	})
+
+	lastValues := `{"mychart":"key: value\n"}`
+	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", fmt.Errorf("helm install failed"), lastValues)
+
+	updated, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Empty(t, updated.LastDeployedValues)
+	assert.Equal(t, models.StackStatusError, updated.Status)
 }

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -17,7 +17,7 @@ type StackInstance struct {
 	ClusterID          string     `json:"cluster_id,omitempty" gorm:"size:36"`
 	Status             string     `json:"status" gorm:"size:50"`
 	ErrorMessage       string     `json:"error_message,omitempty" gorm:"type:text"`
-	LastDeployedValues string     `json:"last_deployed_values,omitempty" gorm:"type:text"`
+	LastDeployedValues string     `json:"-" gorm:"type:text"`
 	TTLMinutes         int        `json:"ttl_minutes"`
 }
 

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -17,7 +17,7 @@ type StackInstance struct {
 	ClusterID          string     `json:"cluster_id,omitempty" gorm:"size:36"`
 	Status             string     `json:"status" gorm:"size:50"`
 	ErrorMessage       string     `json:"error_message,omitempty" gorm:"type:text"`
-	LastDeployedValues string     `json:"-" gorm:"type:text"`
+	LastDeployedValues string     `json:"-" gorm:"type:longtext"`
 	TTLMinutes         int        `json:"ttl_minutes"`
 }
 

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -4,20 +4,21 @@ import "time"
 
 // StackInstance represents a deployed instance of a stack definition.
 type StackInstance struct {
-	CreatedAt         time.Time  `json:"created_at"`
-	UpdatedAt         time.Time  `json:"updated_at"`
-	LastDeployedAt    *time.Time `json:"last_deployed_at,omitempty"`
-	ExpiresAt         *time.Time `json:"expires_at,omitempty"`
-	ID                string     `json:"id" gorm:"primaryKey;size:36"`
-	StackDefinitionID string     `json:"stack_definition_id" gorm:"size:36"`
-	Name              string     `json:"name" gorm:"size:255"`
-	Namespace         string     `json:"namespace" gorm:"size:255"`
-	OwnerID           string     `json:"owner_id" gorm:"size:36"`
-	Branch            string     `json:"branch" gorm:"size:255"`
-	ClusterID         string     `json:"cluster_id,omitempty" gorm:"size:36"`
-	Status            string     `json:"status" gorm:"size:50"`
-	ErrorMessage      string     `json:"error_message,omitempty" gorm:"type:text"`
-	TTLMinutes        int        `json:"ttl_minutes"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+	LastDeployedAt     *time.Time `json:"last_deployed_at,omitempty"`
+	ExpiresAt          *time.Time `json:"expires_at,omitempty"`
+	ID                 string     `json:"id" gorm:"primaryKey;size:36"`
+	StackDefinitionID  string     `json:"stack_definition_id" gorm:"size:36"`
+	Name               string     `json:"name" gorm:"size:255"`
+	Namespace          string     `json:"namespace" gorm:"size:255"`
+	OwnerID            string     `json:"owner_id" gorm:"size:36"`
+	Branch             string     `json:"branch" gorm:"size:255"`
+	ClusterID          string     `json:"cluster_id,omitempty" gorm:"size:36"`
+	Status             string     `json:"status" gorm:"size:50"`
+	ErrorMessage       string     `json:"error_message,omitempty" gorm:"type:text"`
+	LastDeployedValues string     `json:"last_deployed_values,omitempty" gorm:"type:text"`
+	TTLMinutes         int        `json:"ttl_minutes"`
 }
 
 // Valid stack instance statuses.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2782,9 +2782,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6690,9 +6690,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.4.tgz",
-      "integrity": "sha512-baBr4jUVSLJ0RPyZ2nK0zS2+W8hNHbM4hEzfvllukmRPVS3xDG5ATTNtbRXrKIOE2b8/FsPWJAOnuIxcs7g3cw==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.5.tgz",
+      "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -53,6 +53,7 @@ import type {
   VersionDiffResponse,
   UpgradeCheckResponse,
   InstanceQuotaOverride,
+  DeployPreviewResponse,
 } from '../types';
 
 const api = axios.create(axiosConfig);
@@ -1052,6 +1053,21 @@ export const instanceService = {
    */
   deleteQuotaOverride: async (instanceId: string): Promise<void> => {
     await api.delete(`/api/v1/stack-instances/${instanceId}/quota-overrides`);
+  },
+  /**
+   * Preview deployment changes for an instance.
+   * @param id - The instance ID
+   * @returns Per-chart diff of previous vs pending values
+   * @see GET /api/v1/stack-instances/:id/deploy-preview
+   */
+  deployPreview: async (id: number | string): Promise<DeployPreviewResponse> => {
+    try {
+      const response = await api.get(`/api/v1/stack-instances/${id}/deploy-preview`);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch deploy preview:', error);
+      throw error;
+    }
   },
 };
 

--- a/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
+++ b/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
@@ -197,7 +197,7 @@ describe('DeployPreviewDialog', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load deploy preview')).toBeInTheDocument();
+      expect(screen.getByText(/failed to load deploy preview/i)).toBeInTheDocument();
     });
 
     // Deploy button should be disabled on error.

--- a/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
+++ b/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
@@ -140,6 +140,7 @@ describe('DeployPreviewDialog', () => {
   it('deploy button calls onConfirm', async () => {
     mockDeployPreview.mockResolvedValue(previewWithChanges);
     const onConfirm = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <DeployPreviewDialog
@@ -156,13 +157,14 @@ describe('DeployPreviewDialog', () => {
     });
 
     const deployButton = screen.getByRole('button', { name: /deploy/i });
-    await userEvent.click(deployButton);
+    await user.click(deployButton);
     expect(onConfirm).toHaveBeenCalledTimes(1);
   });
 
   it('cancel button calls onClose', async () => {
     mockDeployPreview.mockResolvedValue(previewWithChanges);
     const onClose = vi.fn();
+    const user = userEvent.setup();
 
     render(
       <DeployPreviewDialog
@@ -179,7 +181,7 @@ describe('DeployPreviewDialog', () => {
     });
 
     const cancelButton = screen.getByRole('button', { name: /cancel/i });
-    await userEvent.click(cancelButton);
+    await user.click(cancelButton);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 

--- a/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
+++ b/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
@@ -200,9 +200,9 @@ describe('DeployPreviewDialog', () => {
       expect(screen.getByText(/failed to load deploy preview/i)).toBeInTheDocument();
     });
 
-    // Deploy button should be disabled on error.
+    // Deploy button should still be enabled on error (allow "deploy anyway").
     const deployButton = screen.getByRole('button', { name: /deploy/i });
-    expect(deployButton).toBeDisabled();
+    expect(deployButton).not.toBeDisabled();
   });
 
   it('does not fetch when dialog is closed', () => {

--- a/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
+++ b/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { DeployPreviewResponse } from '../../../types';
+
+vi.mock('react-diff-viewer-continued', () => ({
+  default: ({ oldValue, newValue, leftTitle, rightTitle }: {
+    oldValue: string; newValue: string; leftTitle?: string; rightTitle?: string;
+  }) => (
+    <div data-testid="diff-viewer">
+      <span data-testid="diff-left-title">{leftTitle}</span>
+      <span data-testid="diff-right-title">{rightTitle}</span>
+      <pre data-testid="diff-old">{oldValue}</pre>
+      <pre data-testid="diff-new">{newValue}</pre>
+    </div>
+  ),
+}));
+
+const mockDeployPreview = vi.fn();
+vi.mock('../../../api/client', () => ({
+  instanceService: {
+    deployPreview: (...args: unknown[]) => mockDeployPreview(...args),
+  },
+}));
+
+vi.mock('../../../context/ThemeContext', () => ({
+  useThemeMode: () => ({ mode: 'light', toggleThemeMode: vi.fn() }),
+}));
+
+import DeployPreviewDialog from '../index';
+
+const previewWithChanges: DeployPreviewResponse = {
+  instance_id: '1',
+  instance_name: 'test-stack',
+  charts: [
+    {
+      chart_name: 'backend',
+      previous_values: 'replicas: 1\n',
+      pending_values: 'replicas: 3\n',
+      has_changes: true,
+    },
+    {
+      chart_name: 'frontend',
+      previous_values: 'replicas: 2\n',
+      pending_values: 'replicas: 2\n',
+      has_changes: false,
+    },
+  ],
+};
+
+const previewNoChanges: DeployPreviewResponse = {
+  instance_id: '1',
+  instance_name: 'test-stack',
+  charts: [
+    {
+      chart_name: 'backend',
+      previous_values: 'replicas: 1\n',
+      pending_values: 'replicas: 1\n',
+      has_changes: false,
+    },
+  ],
+};
+
+describe('DeployPreviewDialog', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  it('renders loading state when dialog opens', async () => {
+    // Never-resolving promise to keep loading state.
+    mockDeployPreview.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.getByText('Review Changes — test-stack')).toBeInTheDocument();
+  });
+
+  it('shows diff view when data loads with changes', async () => {
+    mockDeployPreview.mockResolvedValue(previewWithChanges);
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+    });
+
+    // Should show the changed chart name.
+    expect(screen.getByText('backend')).toBeInTheDocument();
+
+    // Should show summary chips.
+    expect(screen.getByText('1 chart changed')).toBeInTheDocument();
+    expect(screen.getByText('1 unchanged')).toBeInTheDocument();
+
+    // Diff viewer should show the values.
+    expect(screen.getByTestId('diff-old')).toHaveTextContent('replicas: 1');
+    expect(screen.getByTestId('diff-new')).toHaveTextContent('replicas: 3');
+  });
+
+  it('shows no-changes message when no charts have changes', async () => {
+    mockDeployPreview.mockResolvedValue(previewNoChanges);
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no value changes detected/i),
+      ).toBeInTheDocument();
+    });
+
+    // Diff viewer should not be present.
+    expect(screen.queryByTestId('diff-viewer')).not.toBeInTheDocument();
+  });
+
+  it('deploy button calls onConfirm', async () => {
+    mockDeployPreview.mockResolvedValue(previewWithChanges);
+    const onConfirm = vi.fn();
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={onConfirm}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+    });
+
+    const deployButton = screen.getByRole('button', { name: /deploy/i });
+    await userEvent.click(deployButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel button calls onClose', async () => {
+    mockDeployPreview.mockResolvedValue(previewWithChanges);
+    const onClose = vi.fn();
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('diff-viewer')).toBeInTheDocument();
+    });
+
+    const cancelButton = screen.getByRole('button', { name: /cancel/i });
+    await userEvent.click(cancelButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows error alert when API call fails', async () => {
+    mockDeployPreview.mockRejectedValue(new Error('network error'));
+
+    render(
+      <DeployPreviewDialog
+        open
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load deploy preview')).toBeInTheDocument();
+    });
+
+    // Deploy button should be disabled on error.
+    const deployButton = screen.getByRole('button', { name: /deploy/i });
+    expect(deployButton).toBeDisabled();
+  });
+
+  it('does not fetch when dialog is closed', () => {
+    render(
+      <DeployPreviewDialog
+        open={false}
+        instanceId={1}
+        instanceName="test-stack"
+        onConfirm={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(mockDeployPreview).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
+++ b/frontend/src/components/DeployPreviewDialog/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { DeployPreviewResponse } from '../../../types';

--- a/frontend/src/components/DeployPreviewDialog/index.tsx
+++ b/frontend/src/components/DeployPreviewDialog/index.tsx
@@ -1,0 +1,171 @@
+import { useState, useEffect, useMemo } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  Box,
+  Tabs,
+  Tab,
+  Chip,
+  Alert,
+  CircularProgress,
+  Typography,
+} from '@mui/material';
+import ReactDiffViewer from 'react-diff-viewer-continued';
+import { instanceService } from '../../api/client';
+import { useThemeMode } from '../../context/ThemeContext';
+import type { DeployPreviewResponse, ChartDeployPreview } from '../../types';
+
+interface DeployPreviewDialogProps {
+  open: boolean;
+  instanceId: string | number;
+  instanceName: string;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+const DeployPreviewDialog = ({
+  open,
+  instanceId,
+  instanceName,
+  onConfirm,
+  onClose,
+}: DeployPreviewDialogProps) => {
+  const { mode } = useThemeMode();
+  const [preview, setPreview] = useState<DeployPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState(0);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    setPreview(null);
+    setActiveTab(0);
+
+    instanceService
+      .deployPreview(instanceId)
+      .then(setPreview)
+      .catch(() => setError('Failed to load deploy preview'))
+      .finally(() => setLoading(false));
+  }, [open, instanceId]);
+
+  const chartsWithChanges = useMemo(
+    () => (preview?.charts ?? []).filter((c) => c.has_changes),
+    [preview],
+  );
+
+  const chartsUnchanged = useMemo(
+    () => (preview?.charts ?? []).filter((c) => !c.has_changes),
+    [preview],
+  );
+
+  const activeChart: ChartDeployPreview | undefined = chartsWithChanges[activeTab];
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
+      <DialogTitle>Review Changes — {instanceName}</DialogTitle>
+      <DialogContent dividers>
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 6 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {error && <Alert severity="error">{error}</Alert>}
+
+        {preview && !loading && !error && (
+          <Box>
+            {/* Summary chips */}
+            <Box sx={{ display: 'flex', gap: 1, mb: 2, flexWrap: 'wrap' }}>
+              {chartsWithChanges.length > 0 && (
+                <Chip
+                  label={`${chartsWithChanges.length} chart${chartsWithChanges.length > 1 ? 's' : ''} changed`}
+                  color="warning"
+                  size="small"
+                  variant="outlined"
+                />
+              )}
+              {chartsUnchanged.length > 0 && (
+                <Chip
+                  label={`${chartsUnchanged.length} unchanged`}
+                  color="success"
+                  size="small"
+                  variant="outlined"
+                />
+              )}
+            </Box>
+
+            {chartsWithChanges.length === 0 ? (
+              <Alert severity="info">
+                No value changes detected. The deployment will use the same values as the last deploy.
+              </Alert>
+            ) : (
+              <Box>
+                {chartsWithChanges.length > 1 && (
+                  <Tabs
+                    value={activeTab}
+                    onChange={(_e, v: number) => setActiveTab(v)}
+                    variant="scrollable"
+                    scrollButtons="auto"
+                    sx={{ mb: 2, borderBottom: 1, borderColor: 'divider' }}
+                  >
+                    {chartsWithChanges.map((chart, index) => (
+                      <Tab
+                        key={chart.chart_name}
+                        label={chart.chart_name}
+                        id={`preview-tab-${index}`}
+                        aria-controls={`preview-tabpanel-${index}`}
+                      />
+                    ))}
+                  </Tabs>
+                )}
+
+                {activeChart && (
+                  <Box
+                    role="tabpanel"
+                    id={`preview-tabpanel-${activeTab}`}
+                    aria-labelledby={`preview-tab-${activeTab}`}
+                  >
+                    {chartsWithChanges.length === 1 && (
+                      <Typography variant="subtitle2" sx={{ mb: 1 }}>
+                        {activeChart.chart_name}
+                      </Typography>
+                    )}
+                    <Box sx={{ border: 1, borderColor: 'divider', borderRadius: 1, overflow: 'auto' }}>
+                      <ReactDiffViewer
+                        oldValue={activeChart.previous_values || ''}
+                        newValue={activeChart.pending_values || ''}
+                        splitView
+                        leftTitle="Previous Values"
+                        rightTitle="Pending Values"
+                        showDiffOnly={false}
+                        useDarkTheme={mode === 'dark'}
+                      />
+                    </Box>
+                  </Box>
+                )}
+              </Box>
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="success"
+          onClick={onConfirm}
+          disabled={loading || !!error}
+        >
+          Deploy
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default DeployPreviewDialog;

--- a/frontend/src/components/DeployPreviewDialog/index.tsx
+++ b/frontend/src/components/DeployPreviewDialog/index.tsx
@@ -85,7 +85,11 @@ const DeployPreviewDialog = ({
           </Box>
         )}
 
-        {error && <Alert severity="error">{error}</Alert>}
+        {error && (
+          <Alert severity="warning">
+            Failed to load deploy preview. You can still proceed with deployment.
+          </Alert>
+        )}
 
         {preview && !loading && !error && (
           <Box>
@@ -169,7 +173,7 @@ const DeployPreviewDialog = ({
           variant="contained"
           color="success"
           onClick={onConfirm}
-          disabled={loading || !!error}
+          disabled={loading}
         >
           Deploy
         </Button>

--- a/frontend/src/components/DeployPreviewDialog/index.tsx
+++ b/frontend/src/components/DeployPreviewDialog/index.tsx
@@ -41,6 +41,8 @@ const DeployPreviewDialog = ({
 
   useEffect(() => {
     if (!open) return;
+
+    let cancelled = false;
     setLoading(true);
     setError(null);
     setPreview(null);
@@ -48,9 +50,17 @@ const DeployPreviewDialog = ({
 
     instanceService
       .deployPreview(instanceId)
-      .then(setPreview)
-      .catch(() => setError('Failed to load deploy preview'))
-      .finally(() => setLoading(false));
+      .then((data) => {
+        if (!cancelled) setPreview(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError('Failed to load deploy preview');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
   }, [open, instanceId]);
 
   const chartsWithChanges = useMemo(

--- a/frontend/src/components/DeployPreviewDialog/index.tsx
+++ b/frontend/src/components/DeployPreviewDialog/index.tsx
@@ -173,9 +173,8 @@ const DeployPreviewDialog = ({
           variant="contained"
           color="success"
           onClick={onConfirm}
-          disabled={loading}
         >
-          Deploy
+          {loading ? 'Deploy anyway' : 'Deploy'}
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -22,6 +22,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import StatusBadge from '../../components/StatusBadge';
 import BranchSelector from '../../components/BranchSelector';
 import ConfirmDialog from '../../components/ConfirmDialog';
+import DeployPreviewDialog from '../../components/DeployPreviewDialog';
 import DeploymentLogViewer from '../../components/DeploymentLogViewer';
 import PodStatusDisplay from '../../components/PodStatusDisplay';
 import AccessUrls from '../../components/AccessUrls';
@@ -51,6 +52,7 @@ const Detail = () => {
   const [error, setError] = useState<string | null>(null);
   const { showSuccess } = useNotification();
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deployPreviewOpen, setDeployPreviewOpen] = useState(false);
   const [deploying, setDeploying] = useState(false);
   const [stopping, setStopping] = useState(false);
   const [cleaning, setCleaning] = useState(false);
@@ -401,7 +403,7 @@ const Detail = () => {
   const renderStatusActions = (status: string) => (
     <>
       {canDeploy && (
-        <Button variant="contained" color="success" onClick={handleDeploy} disabled={deploying}>
+        <Button variant="contained" color="success" onClick={() => setDeployPreviewOpen(true)} disabled={deploying}>
           {deploying ? 'Deploying...' : 'Deploy'}
         </Button>
       )}
@@ -647,6 +649,14 @@ const Detail = () => {
         onConfirm={() => { setCleanDialogOpen(false); handleClean(); }}
         onCancel={() => setCleanDialogOpen(false)}
         confirmText="Clean"
+      />
+
+      <DeployPreviewDialog
+        open={deployPreviewOpen}
+        instanceId={instance.id}
+        instanceName={instance.name}
+        onConfirm={() => { setDeployPreviewOpen(false); handleDeploy(); }}
+        onClose={() => setDeployPreviewOpen(false)}
       />
 
     </Box>

--- a/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
@@ -134,6 +134,19 @@ vi.mock('../../../components/ConfirmDialog', () => ({
   ) : null,
 }));
 
+vi.mock('../../../components/DeployPreviewDialog', () => ({
+  default: ({ open, instanceName, onConfirm, onClose }: {
+    open: boolean; instanceId: string | number; instanceName: string;
+    onConfirm: () => void; onClose: () => void;
+  }) => open ? (
+    <div data-testid="deploy-preview-dialog">
+      <div>Review Changes — {instanceName}</div>
+      <button onClick={onConfirm}>Deploy</button>
+      <button onClick={onClose}>Cancel</button>
+    </div>
+  ) : null,
+}));
+
 import { instanceService, definitionService, branchOverrideService } from '../../../api/client';
 import useCountdown from '../../../hooks/useCountdown';
 
@@ -371,7 +384,12 @@ describe('StackInstances Detail', () => {
       expect(screen.getByText('Test Instance')).toBeInTheDocument();
     });
 
+    // Click Deploy to open preview dialog
     await user.click(screen.getByRole('button', { name: /deploy/i }));
+
+    // Confirm deploy in the preview dialog
+    const previewDialog = screen.getByTestId('deploy-preview-dialog');
+    await user.click(within(previewDialog).getByRole('button', { name: /deploy/i }));
 
     await waitFor(() => {
       expect(instanceService.deploy).toHaveBeenCalledWith('123');
@@ -413,7 +431,12 @@ describe('StackInstances Detail', () => {
       expect(screen.getByText('Test Instance')).toBeInTheDocument();
     });
 
+    // Click Deploy to open preview dialog
     await user.click(screen.getByRole('button', { name: /deploy/i }));
+
+    // Confirm deploy in the preview dialog
+    const previewDialog = screen.getByTestId('deploy-preview-dialog');
+    await user.click(within(previewDialog).getByRole('button', { name: /deploy/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Failed to start deployment')).toBeInTheDocument();
@@ -1143,7 +1166,12 @@ describe('StackInstances Detail', () => {
       expect(screen.getByText('Test Instance')).toBeInTheDocument();
     });
 
+    // Click Deploy to open preview dialog
     await user.click(screen.getByRole('button', { name: /deploy/i }));
+
+    // Confirm deploy in the preview dialog
+    const previewDialog = screen.getByTestId('deploy-preview-dialog');
+    await user.click(within(previewDialog).getByRole('button', { name: /deploy/i }));
 
     await waitFor(() => {
       expect(instanceService.deploy).toHaveBeenCalledWith('123');

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -638,3 +638,16 @@ export interface UpgradeCheckResponse {
     charts_unchanged: string[];
   };
 }
+
+export interface ChartDeployPreview {
+  chart_name: string;
+  previous_values: string;
+  pending_values: string;
+  has_changes: boolean;
+}
+
+export interface DeployPreviewResponse {
+  instance_id: string;
+  instance_name: string;
+  charts: ChartDeployPreview[];
+}


### PR DESCRIPTION
## Summary

Adds a deployment diff preview that shows users what Helm values changed before
deploying, reducing "what did I break" situations.

Closes #121

## Backend Changes

- New model field: `LastDeployedValues` on StackInstance (LONGTEXT, hidden from API responses)
- Migration 27: Adds `last_deployed_values` LONGTEXT column (reads type from model tag)
- Migration 28: Conditional ALTER for databases that ran migration 27 before the LONGTEXT tag update (MySQL-only, no-op on SQLite/other dialectors)
- Save on deploy: After `Deploy()` succeeds, serialized merged values are persisted
- New endpoint: `GET /api/v1/stack-instances/:id/deploy-preview` with owner/admin/devops authorization
- Shared `buildChartValues()` method extracted from DeployInstance and DeployPreview
- Azure Table Storage: `LastDeployedValues` added to entity mapping

## Frontend Changes

- API client: `instanceService.deployPreview()` method with TSDoc
- TypeScript types: `Ch- TypeScript types: `Ch- TypeScript types: `Ch- TypeScript types: `Ch- Typiew- TypeScript types: `Ch- TypeScript types: `Ch- TypeScript types: `Ch- TypeScrev- TypeScript types: `Ch- TypeScript tible if preview fails

## Te## Te## Te## Te 9 ta## Te## Te## Te## Te 9 ta## Te## Te## Te## Te 9 ta## Te## Te## Te## Te 9 ta## Te## Te## Te##  diff view, no-changes, error, deploy/cancel)

## Security

- Endpoint is behind auth midd- Endpoint is behind auth midd- Endpoint is behind auth midd- Endpoint is behind auth midd- Endpoint is behind auth midd- Endpoint is behind auth idation mirrors DeployInstance
