### PR TITLE
feat: add configurable API key expiration policy

### DIFF
--- a/backend/api/api_integration_test.go
+++ b/backend/api/api_integration_test.go
@@ -121,7 +121,7 @@ func newIntegServer(t *testing.T) *integServer {
 	gitHandler := handlers.NewGitHandler(gitRegistry)
 	auditLogHandler := handlers.NewAuditLogHandler(auditRepo)
 	userHandler := handlers.NewUserHandler(userRepo)
-	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo)
+	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo, nil)
 
 	healthChecker := health.New()
 	healthChecker.SetReady(true)

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -257,7 +257,7 @@ func main() {
 	gitHandler := handlers.NewGitHandler(gitRegistry)
 	auditLogHandler := handlers.NewAuditLogHandler(auditRepo)
 	userHandler := handlers.NewUserHandler(userRepo)
-	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo)
+	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo, &cfg.Auth)
 
 	adminHandler := handlers.NewAdminHandler(clusterRegistry, instanceRepo)
 	clusterHandler := handlers.NewClusterHandlerWithQuotas(clusterRepo, clusterRegistry, instanceRepo, quotaRepo)

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -1,10 +1,12 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"backend/internal/api/middleware"
+	"backend/internal/config"
 	"backend/internal/models"
 
 	"github.com/gin-gonic/gin"
@@ -15,22 +17,27 @@ const (
 	msgForbidden = "Forbidden"
 )
 
-
 // APIKeyHandler handles API key management endpoints.
 type APIKeyHandler struct {
-	apiKeyRepo models.APIKeyRepository
-	userRepo   models.UserRepository
+	apiKeyRepo            models.APIKeyRepository
+	userRepo              models.UserRepository
+	apiKeyMaxLifetimeDays int
 }
 
 // NewAPIKeyHandler creates a new APIKeyHandler.
-func NewAPIKeyHandler(apiKeyRepo models.APIKeyRepository, userRepo models.UserRepository) *APIKeyHandler {
-	return &APIKeyHandler{apiKeyRepo: apiKeyRepo, userRepo: userRepo}
+func NewAPIKeyHandler(apiKeyRepo models.APIKeyRepository, userRepo models.UserRepository, authCfg *config.AuthConfig) *APIKeyHandler {
+	maxDays := 0
+	if authCfg != nil {
+		maxDays = authCfg.APIKeyMaxLifetimeDays
+	}
+	return &APIKeyHandler{apiKeyRepo: apiKeyRepo, userRepo: userRepo, apiKeyMaxLifetimeDays: maxDays}
 }
 
 // CreateAPIKeyRequest is the request body for creating an API key.
 type CreateAPIKeyRequest struct {
-	Name      string  `json:"name" binding:"required"`
-	ExpiresAt *string `json:"expires_at,omitempty"`
+	Name          string  `json:"name" binding:"required"`
+	ExpiresAt     *string `json:"expires_at,omitempty"`
+	ExpiresInDays *int    `json:"expires_in_days,omitempty"`
 }
 
 // CreateAPIKeyResponse is returned once at key creation time.
@@ -46,7 +53,7 @@ type CreateAPIKeyResponse struct {
 
 // CreateAPIKey godoc
 // @Summary      Create an API key for a user
-// @Description  Generates a new API key. The raw key is returned once in raw_key and cannot be retrieved again.
+// @Description  Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.
 // @Tags         api-keys
 // @Accept       json
 // @Produce      json
@@ -91,7 +98,19 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	}
 
 	var expiresAt *time.Time
-	if req.ExpiresAt != nil && *req.ExpiresAt != "" {
+	if req.ExpiresAt != nil && req.ExpiresInDays != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot specify both expires_at and expires_in_days"})
+		return
+	}
+
+	if req.ExpiresInDays != nil {
+		if *req.ExpiresInDays <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "expires_in_days must be positive"})
+			return
+		}
+		t := time.Now().UTC().AddDate(0, 0, *req.ExpiresInDays)
+		expiresAt = &t
+	} else if req.ExpiresAt != nil && *req.ExpiresAt != "" {
 		parsed, perr := time.Parse(time.RFC3339, *req.ExpiresAt)
 		if perr != nil {
 			// Try date-only format: treat as end-of-day UTC.
@@ -102,7 +121,28 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 			}
 			parsed = parsed.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
 		}
+		parsed = parsed.UTC()
 		expiresAt = &parsed
+	}
+
+	// Reject expiry dates in the past.
+	if expiresAt != nil && expiresAt.Before(time.Now().UTC()) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Expiry date must be in the future"})
+		return
+	}
+
+	// Enforce max lifetime policy.
+	if h.apiKeyMaxLifetimeDays > 0 {
+		maxExpiry := time.Now().UTC().AddDate(0, 0, h.apiKeyMaxLifetimeDays)
+		if expiresAt != nil {
+			if expiresAt.After(maxExpiry) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Expiry exceeds maximum allowed lifetime of %d days", h.apiKeyMaxLifetimeDays)})
+				return
+			}
+		} else {
+			// Auto-cap: no expiry requested but max lifetime is configured.
+			expiresAt = &maxExpiry
+		}
 	}
 
 	key := &models.APIKey{

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -91,12 +91,6 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
-	rawKey, prefix, hash, err := models.GenerateAPIKey()
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-		return
-	}
-
 	// Normalize empty expires_at to nil so it doesn't conflict with expires_in_days.
 	if req.ExpiresAt != nil && *req.ExpiresAt == "" {
 		req.ExpiresAt = nil
@@ -132,8 +126,8 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		expiresAt = &parsed
 	}
 
-	// Reject expiry dates in the past.
-	if expiresAt != nil && expiresAt.Before(now) {
+	// Reject expiry dates that are not strictly in the future.
+	if expiresAt != nil && !expiresAt.After(now) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Expiry date must be in the future"})
 		return
 	}
@@ -152,6 +146,13 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 			// Auto-cap: no expiry requested but max lifetime is configured.
 			expiresAt = &maxExpiry
 		}
+	}
+
+	// Generate key only after all validation passes to avoid wasted crypto work.
+	rawKey, prefix, hash, err := models.GenerateAPIKey()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
 	}
 
 	key := &models.APIKey{

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -97,20 +97,27 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
+	// Normalize empty expires_at to nil so it doesn't conflict with expires_in_days.
+	if req.ExpiresAt != nil && *req.ExpiresAt == "" {
+		req.ExpiresAt = nil
+	}
+
 	var expiresAt *time.Time
 	if req.ExpiresAt != nil && req.ExpiresInDays != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot specify both expires_at and expires_in_days"})
 		return
 	}
 
+	now := time.Now().UTC()
+
 	if req.ExpiresInDays != nil {
 		if *req.ExpiresInDays <= 0 {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "expires_in_days must be positive"})
 			return
 		}
-		t := time.Now().UTC().AddDate(0, 0, *req.ExpiresInDays)
+		t := now.AddDate(0, 0, *req.ExpiresInDays)
 		expiresAt = &t
-	} else if req.ExpiresAt != nil && *req.ExpiresAt != "" {
+	} else if req.ExpiresAt != nil {
 		parsed, perr := time.Parse(time.RFC3339, *req.ExpiresAt)
 		if perr != nil {
 			// Try date-only format: treat as end-of-day UTC.
@@ -126,14 +133,16 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	}
 
 	// Reject expiry dates in the past.
-	if expiresAt != nil && expiresAt.Before(time.Now().UTC()) {
+	if expiresAt != nil && expiresAt.Before(now) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Expiry date must be in the future"})
 		return
 	}
 
 	// Enforce max lifetime policy.
 	if h.apiKeyMaxLifetimeDays > 0 {
-		maxExpiry := time.Now().UTC().AddDate(0, 0, h.apiKeyMaxLifetimeDays)
+		// Compute maxExpiry as end-of-day so date-only boundary values aren't rejected.
+		maxDate := now.AddDate(0, 0, h.apiKeyMaxLifetimeDays)
+		maxExpiry := time.Date(maxDate.Year(), maxDate.Month(), maxDate.Day(), 23, 59, 59, 0, time.UTC)
 		if expiresAt != nil {
 			if expiresAt.After(maxExpiry) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Expiry exceeds maximum allowed lifetime of %d days", h.apiKeyMaxLifetimeDays)})

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -136,7 +136,7 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	if h.apiKeyMaxLifetimeDays > 0 {
 		// Compute maxExpiry as end-of-day so date-only boundary values aren't rejected.
 		maxDate := now.AddDate(0, 0, h.apiKeyMaxLifetimeDays)
-		maxExpiry := time.Date(maxDate.Year(), maxDate.Month(), maxDate.Day(), 23, 59, 59, 0, time.UTC)
+		maxExpiry := time.Date(maxDate.Year(), maxDate.Month(), maxDate.Day(), 23, 59, 59, 999999999, time.UTC)
 		if expiresAt != nil {
 			if expiresAt.After(maxExpiry) {
 				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Expiry exceeds maximum allowed lifetime of %d days", h.apiKeyMaxLifetimeDays)})

--- a/backend/internal/api/handlers/api_keys_test.go
+++ b/backend/internal/api/handlers/api_keys_test.go
@@ -483,9 +483,12 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 					require.True(t, ok, "expires_at should be present")
 					parsed, err := time.Parse(time.RFC3339, expiresStr)
 					require.NoError(t, err)
-					expectedApprox := time.Now().UTC().AddDate(0, 0, tt.wantExpiryDays)
-					diff := parsed.Sub(expectedApprox)
-					assert.InDelta(t, 0, diff.Seconds(), 60, "expires_at should be ~%d days from now", tt.wantExpiryDays)
+					now := time.Now().UTC()
+					expectedDate := now.AddDate(0, 0, tt.wantExpiryDays)
+					// Auto-cap uses end-of-day; expires_in_days uses exact offset.
+					// Allow up to 24h + 60s tolerance to cover both cases.
+					diff := parsed.Sub(expectedDate)
+					assert.InDelta(t, 0, diff.Seconds(), 86460, "expires_at should be ~%d days from now", tt.wantExpiryDays)
 				}
 
 				if tt.name == "no expiry with max 0 (no limit) - no expiry set" {

--- a/backend/internal/api/handlers/api_keys_test.go
+++ b/backend/internal/api/handlers/api_keys_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"backend/internal/config"
 	"backend/internal/models"
 
 	"github.com/gin-gonic/gin"
@@ -23,10 +24,22 @@ func setupAPIKeyRouter(
 	apiKeyRepo *MockAPIKeyRepository,
 	callerID, callerRole string,
 ) *gin.Engine {
+	return setupAPIKeyRouterWithMaxDays(userRepo, apiKeyRepo, callerID, callerRole, 0)
+}
+
+// setupAPIKeyRouterWithMaxDays creates a gin engine wired to APIKeyHandler routes
+// with a configurable max lifetime policy (0 = no limit).
+func setupAPIKeyRouterWithMaxDays(
+	userRepo *MockUserRepository,
+	apiKeyRepo *MockAPIKeyRepository,
+	callerID, callerRole string,
+	maxDays int,
+) *gin.Engine {
 	gin.SetMode(gin.TestMode)
 	r := gin.New()
 	r.Use(injectAuthContext(callerID, callerRole))
-	h := NewAPIKeyHandler(apiKeyRepo, userRepo)
+	cfg := &config.AuthConfig{APIKeyMaxLifetimeDays: maxDays}
+	h := NewAPIKeyHandler(apiKeyRepo, userRepo, cfg)
 	keys := r.Group("/api/v1/users/:id/api-keys")
 	{
 		keys.GET("", h.ListAPIKeys)
@@ -325,6 +338,161 @@ func TestDeleteAPIKey(t *testing.T) {
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, tt.wantStatus, w.Code)
+		})
+	}
+}
+
+// ---- TestCreateAPIKeyExpiration ----
+
+func TestCreateAPIKeyExpiration(t *testing.T) {
+	t.Parallel()
+
+	type tc struct {
+		name       string
+		maxDays    int
+		body       string
+		wantStatus int
+		// If non-zero, verify that ExpiresAt is approximately this many days from now.
+		wantExpiryDays int
+		wantErrSubstr  string
+	}
+
+	tests := []tc{
+		{
+			name:           "expires_in_days 90 - success",
+			maxDays:        365,
+			body:           `{"name":"ci-key","expires_in_days":90}`,
+			wantStatus:     http.StatusCreated,
+			wantExpiryDays: 90,
+		},
+		{
+			name:          "expires_in_days 0 - 400",
+			maxDays:       0,
+			body:          `{"name":"ci-key","expires_in_days":0}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "expires_in_days must be positive",
+		},
+		{
+			name:          "expires_in_days negative - 400",
+			maxDays:       0,
+			body:          `{"name":"ci-key","expires_in_days":-5}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "expires_in_days must be positive",
+		},
+		{
+			name:          "both expires_at and expires_in_days - 400",
+			maxDays:       0,
+			body:          `{"name":"ci-key","expires_at":"2099-12-31","expires_in_days":90}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "Cannot specify both",
+		},
+		{
+			name:          "expires_in_days 500 exceeds max 365 - 400",
+			maxDays:       365,
+			body:          `{"name":"ci-key","expires_in_days":500}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "maximum allowed lifetime of 365 days",
+		},
+		{
+			name:           "no expiry with max 365 - auto-capped",
+			maxDays:        365,
+			body:           `{"name":"ci-key"}`,
+			wantStatus:     http.StatusCreated,
+			wantExpiryDays: 365,
+		},
+		{
+			name:       "expires_at within max - success",
+			maxDays:    365,
+			body:       `{"name":"ci-key","expires_at":"` + time.Now().UTC().AddDate(0, 0, 30).Format("2006-01-02") + `"}`,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:          "expires_at beyond max - 400",
+			maxDays:       365,
+			body:          `{"name":"ci-key","expires_at":"` + time.Now().UTC().AddDate(0, 0, 400).Format("2006-01-02") + `"}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "maximum allowed lifetime of 365 days",
+		},
+		{
+			name:       "no expiry with max 0 (no limit) - no expiry set",
+			maxDays:    0,
+			body:       `{"name":"ci-key"}`,
+			wantStatus: http.StatusCreated,
+		},
+		{
+			name:           "expires_in_days exactly at max - success",
+			maxDays:        365,
+			body:           `{"name":"ci-key","expires_in_days":365}`,
+			wantStatus:     http.StatusCreated,
+			wantExpiryDays: 365,
+		},
+		{
+			name:          "expires_in_days one day over max - 400",
+			maxDays:       365,
+			body:          `{"name":"ci-key","expires_in_days":366}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "maximum allowed lifetime of 365 days",
+		},
+		{
+			name:          "expires_at in the past - 400",
+			maxDays:       0,
+			body:          `{"name":"ci-key","expires_at":"2020-01-01"}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "Expiry date must be in the future",
+		},
+		{
+			name:          "invalid expires_at format - 400",
+			maxDays:       0,
+			body:          `{"name":"ci-key","expires_at":"not-a-date"}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "Invalid expires_at format",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			userRepo := NewMockUserRepository()
+			apiKeyRepo := NewMockAPIKeyRepository()
+			seedUser(t, userRepo, "user-1", "alice", "testpass", "user")
+
+			router := setupAPIKeyRouterWithMaxDays(userRepo, apiKeyRepo, "user-1", "user", tt.maxDays)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPost,
+				"/api/v1/users/user-1/api-keys",
+				bytes.NewBufferString(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantErrSubstr != "" {
+				var resp map[string]interface{}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				errMsg, _ := resp["error"].(string)
+				assert.Contains(t, errMsg, tt.wantErrSubstr)
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp map[string]interface{}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+				if tt.wantExpiryDays > 0 {
+					expiresStr, ok := resp["expires_at"].(string)
+					require.True(t, ok, "expires_at should be present")
+					parsed, err := time.Parse(time.RFC3339, expiresStr)
+					require.NoError(t, err)
+					expectedApprox := time.Now().UTC().AddDate(0, 0, tt.wantExpiryDays)
+					diff := parsed.Sub(expectedApprox)
+					assert.InDelta(t, 0, diff.Seconds(), 60, "expires_at should be ~%d days from now", tt.wantExpiryDays)
+				}
+
+				if tt.name == "no expiry with max 0 (no limit) - no expiry set" {
+					_, hasExpiry := resp["expires_at"]
+					assert.False(t, hasExpiry, "expires_at should not be set when no limit and no expiry requested")
+				}
+			}
 		})
 	}
 }

--- a/backend/internal/api/routes/routes_test.go
+++ b/backend/internal/api/routes/routes_test.go
@@ -490,7 +490,7 @@ func TestSetupRoutes_WithAllHandlersRegistersFullAPI(t *testing.T) {
 	cfg := testConfig()
 	authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth)
 	userHandler := handlers.NewUserHandler(&stubUserRepo{})
-	apiKeyHandler := handlers.NewAPIKeyHandler(&stubAPIKeyRepo{}, &stubUserRepo{})
+	apiKeyHandler := handlers.NewAPIKeyHandler(&stubAPIKeyRepo{}, &stubUserRepo{}, &cfg.Auth)
 	auditLogHandler := handlers.NewAuditLogHandler(nil)
 
 	rl := SetupRoutes(router, Deps{

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,7 +46,7 @@ type AuthConfig struct {
 	AdminPassword           string
 	DefaultBranch           string
 	MaxRefreshTokensPerUser int
-	APIKeyMaxLifetimeDays   int
+	APIKeyMaxLifetimeDays   int // 0 means no limit; must not be negative.
 	SelfRegistration        bool
 	SecureCookies           bool
 	CookieSameSite          string // "strict" (default), "lax", or "none"
@@ -353,6 +353,10 @@ func (c *AuthConfig) Validate() error {
 
 	if c.MaxRefreshTokensPerUser < 0 {
 		return errors.New("max_refresh_tokens_per_user must be non-negative")
+	}
+
+	if c.APIKeyMaxLifetimeDays < 0 {
+		return errors.New("api_key_max_lifetime_days must be non-negative (0 = no limit)")
 	}
 
 	switch strings.ToLower(c.CookieSameSite) {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -537,6 +537,8 @@ func loadAuthConfig() AuthConfig {
 		SelfRegistration:        getEnvBool("SELF_REGISTRATION", false),
 		DefaultBranch:           getEnv("DEFAULT_BRANCH", "master"),
 		MaxRefreshTokensPerUser: int(getEnvInt32("MAX_REFRESH_TOKENS_PER_USER", 10)),
+		// Default 0 = no limit. Set to a positive value (e.g. 365) to enforce max API key lifetime.
+		// Intentionally not defaulting to 365 to avoid breaking existing deployments.
 		APIKeyMaxLifetimeDays:   int(getEnvInt32("API_KEY_MAX_LIFETIME_DAYS", 0)),
 		SecureCookies:           getEnvBool("SECURE_COOKIES", false),
 		CookieSameSite:          getEnv("COOKIE_SAMESITE", "strict"),

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -46,6 +46,7 @@ type AuthConfig struct {
 	AdminPassword           string
 	DefaultBranch           string
 	MaxRefreshTokensPerUser int
+	APIKeyMaxLifetimeDays   int
 	SelfRegistration        bool
 	SecureCookies           bool
 	CookieSameSite          string // "strict" (default), "lax", or "none"
@@ -532,6 +533,7 @@ func loadAuthConfig() AuthConfig {
 		SelfRegistration:        getEnvBool("SELF_REGISTRATION", false),
 		DefaultBranch:           getEnv("DEFAULT_BRANCH", "master"),
 		MaxRefreshTokensPerUser: int(getEnvInt32("MAX_REFRESH_TOKENS_PER_USER", 10)),
+		APIKeyMaxLifetimeDays:   int(getEnvInt32("API_KEY_MAX_LIFETIME_DAYS", 0)),
 		SecureCookies:           getEnvBool("SECURE_COOKIES", false),
 		CookieSameSite:          getEnv("COOKIE_SAMESITE", "strict"),
 	}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -722,7 +722,7 @@ func TestAPIKeyMaxLifetimeDaysConfig(t *testing.T) {
 	})
 
 	t.Run("default value is 0 (no limit)", func(t *testing.T) {
-		os.Unsetenv("API_KEY_MAX_LIFETIME_DAYS")
+		t.Setenv("API_KEY_MAX_LIFETIME_DAYS", "")
 		cfg, err := config.LoadConfig()
 		require.NoError(t, err)
 		assert.Equal(t, 0, cfg.Auth.APIKeyMaxLifetimeDays)

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -710,3 +710,21 @@ func TestOtelConfigLoad(t *testing.T) {
 		assert.Equal(t, 0.25, cfg.Otel.SampleRate)
 	})
 }
+
+func TestAPIKeyMaxLifetimeDaysConfig(t *testing.T) {
+	// Not parallel: uses t.Setenv which modifies process env
+
+	t.Run("custom value from env", func(t *testing.T) {
+		t.Setenv("API_KEY_MAX_LIFETIME_DAYS", "90")
+		cfg, err := config.LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 90, cfg.Auth.APIKeyMaxLifetimeDays)
+	})
+
+	t.Run("default value is 0 (no limit)", func(t *testing.T) {
+		os.Unsetenv("API_KEY_MAX_LIFETIME_DAYS")
+		cfg, err := config.LoadConfig()
+		require.NoError(t, err)
+		assert.Equal(t, 0, cfg.Auth.APIKeyMaxLifetimeDays)
+	})
+}

--- a/frontend/src/pages/Profile/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/Profile/__tests__/Profile.test.tsx
@@ -406,7 +406,7 @@ describe('Profile Page', () => {
     });
   });
 
-  it('includes expires_at when generate form has an expiry date', async () => {
+  it('sends expires_at when custom date mode is selected', async () => {
     (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (apiKeyService.create as ReturnType<typeof vi.fn>).mockResolvedValue({
       id: 'k-temp',
@@ -430,6 +430,9 @@ describe('Profile Page', () => {
     await user.click(screen.getByRole('button', { name: /generate api key/i }));
     await user.type(screen.getByLabelText(/key name/i), 'Temp Key');
 
+    // Select "Custom date" mode
+    await user.click(screen.getByLabelText(/custom date/i));
+
     fireEvent.change(screen.getByLabelText(/expires at/i), {
       target: { value: '2026-12-31' },
     });
@@ -437,10 +440,139 @@ describe('Profile Page', () => {
     await user.click(screen.getByRole('button', { name: /^generate$/i }));
 
     await waitFor(() => {
-      expect(apiKeyService.create).toHaveBeenCalledWith(
-        'u1',
-        expect.objectContaining({ name: 'Temp Key', expires_at: '2026-12-31' }),
-      );
+      expect(apiKeyService.create).toHaveBeenCalledWith('u1', {
+        name: 'Temp Key',
+        expires_at: '2026-12-31',
+      });
     });
+  });
+
+  it('sends expires_in_days when preset duration is selected', async () => {
+    (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (apiKeyService.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'k-preset',
+      name: 'Preset Key',
+      prefix: 'sk_pre11',
+      raw_key: 'sk_pre11xyz',
+      created_at: '2026-03-18T00:00:00Z',
+    });
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generate api key/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /generate api key/i }));
+    await user.type(screen.getByLabelText(/key name/i), 'Preset Key');
+
+    // Select "Preset duration" mode
+    await user.click(screen.getByLabelText(/preset duration/i));
+
+    // Default preset is 90 days — computed expiry date should be visible
+    expect(screen.getByText(/expires:/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^generate$/i }));
+
+    await waitFor(() => {
+      expect(apiKeyService.create).toHaveBeenCalledWith('u1', {
+        name: 'Preset Key',
+        expires_in_days: 90,
+      });
+    });
+  });
+
+  it('sends neither expires_at nor expires_in_days when no expiry is selected', async () => {
+    (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (apiKeyService.create as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: 'k-none',
+      name: 'No Expiry Key',
+      prefix: 'sk_none11',
+      raw_key: 'sk_none11xyz',
+      created_at: '2026-03-18T00:00:00Z',
+    });
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /generate api key/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /generate api key/i }));
+    await user.type(screen.getByLabelText(/key name/i), 'No Expiry Key');
+
+    // "No expiry" is default — just submit
+    await user.click(screen.getByRole('button', { name: /^generate$/i }));
+
+    await waitFor(() => {
+      expect(apiKeyService.create).toHaveBeenCalledWith('u1', { name: 'No Expiry Key' });
+    });
+  });
+
+  it('displays expired key with red chip indicator', async () => {
+    const expiredKey = {
+      id: 'k-expired',
+      user_id: 'u1',
+      name: 'Expired Key',
+      prefix: 'exp12345',
+      created_at: '2025-01-01T00:00:00Z',
+      expires_at: '2025-06-01T00:00:00Z',
+    };
+    (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([expiredKey]);
+
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Expired Key')).toBeInTheDocument();
+    });
+
+    // Expired chip should be present (label starts with "Expired" followed by a date)
+    const expiredChip = screen.getByText(/^Expired \d/);
+    expect(expiredChip.closest('.MuiChip-root')).toBeInTheDocument();
+    expect(expiredChip.closest('.MuiChip-colorError')).toBeInTheDocument();
+  });
+
+  it('displays expiring-soon key with warning chip', async () => {
+    // Set expiry to 15 days from now
+    const soonDate = new Date();
+    soonDate.setDate(soonDate.getDate() + 15);
+    const soonKey = {
+      id: 'k-soon',
+      user_id: 'u1',
+      name: 'Soon Key',
+      prefix: 'soon1234',
+      created_at: '2026-01-01T00:00:00Z',
+      expires_at: soonDate.toISOString(),
+    };
+    (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([soonKey]);
+
+    render(
+      <MemoryRouter>
+        <Profile />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Soon Key')).toBeInTheDocument();
+    });
+
+    // Warning chip should be present (rendered as MuiChip with color="warning")
+    const dateStr = soonDate.toLocaleDateString();
+    const chip = screen.getByText(dateStr);
+    expect(chip.closest('.MuiChip-root')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -21,6 +21,12 @@ import {
   DialogActions,
   TextField,
   Switch,
+  RadioGroup,
+  Radio,
+  FormControlLabel,
+  FormControl,
+  FormLabel,
+  MenuItem,
 } from '@mui/material';
 import KeyIcon from '@mui/icons-material/Key';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -44,6 +50,32 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
 
 const DEFAULT_EVENT_TYPES = Object.keys(EVENT_TYPE_LABELS);
 
+type ExpiryMode = 'none' | 'preset' | 'custom';
+
+const PRESET_DURATIONS = [
+  { value: 30, label: '30 days' },
+  { value: 60, label: '60 days' },
+  { value: 90, label: '90 days' },
+  { value: 180, label: '180 days' },
+  { value: 365, label: '365 days' },
+];
+
+const getExpiryStatus = (expiresAt: string | undefined): 'expired' | 'expiring-soon' | 'ok' | 'never' => {
+  if (!expiresAt) return 'never';
+  const now = new Date();
+  const expiry = new Date(expiresAt);
+  if (expiry <= now) return 'expired';
+  const daysUntilExpiry = (expiry.getTime() - now.getTime()) / (1000 * 60 * 60 * 24);
+  if (daysUntilExpiry <= 30) return 'expiring-soon';
+  return 'ok';
+};
+
+const computeExpiryDate = (days: number): Date => {
+  const date = new Date();
+  date.setDate(date.getDate() + days);
+  return date;
+};
+
 const getRoleChipColor = (role: string): 'error' | 'warning' | 'default' => {
   if (role === 'admin') return 'error';
   if (role === 'devops') return 'warning';
@@ -62,6 +94,8 @@ const Profile = () => {
   const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>({ name: '' });
   const [generateKeyError, setGenerateKeyError] = useState<string | null>(null);
   const [generateKeyLoading, setGenerateKeyLoading] = useState(false);
+  const [expiryMode, setExpiryMode] = useState<ExpiryMode>('none');
+  const [presetDays, setPresetDays] = useState<number>(90);
 
   // Raw key modal
   const [rawKeyData, setRawKeyData] = useState<CreateAPIKeyResponse | null>(null);
@@ -151,9 +185,17 @@ const Profile = () => {
     setGenerateKeyLoading(true);
     setGenerateKeyError(null);
     try {
-      const result = await apiKeyService.create(currentUser.id, generateKeyForm);
+      const request: CreateAPIKeyRequest = { name: generateKeyForm.name.trim() };
+      if (expiryMode === 'preset') {
+        request.expires_in_days = presetDays;
+      } else if (expiryMode === 'custom' && generateKeyForm.expires_at) {
+        request.expires_at = generateKeyForm.expires_at;
+      }
+      const result = await apiKeyService.create(currentUser.id, request);
       setGenerateKeyOpen(false);
       setGenerateKeyForm({ name: '' });
+      setExpiryMode('none');
+      setPresetDays(90);
       setRawKeyData(result);
       await fetchApiKeys();
     } catch {
@@ -244,6 +286,8 @@ const Profile = () => {
           onClick={() => {
             setGenerateKeyOpen(true);
             setGenerateKeyForm({ name: '' });
+            setExpiryMode('none');
+            setPresetDays(90);
             setGenerateKeyError(null);
           }}
         >
@@ -290,7 +334,22 @@ const Profile = () => {
                         {key.last_used_at ? new Date(key.last_used_at).toLocaleDateString() : '—'}
                       </TableCell>
                       <TableCell>
-                        {key.expires_at ? new Date(key.expires_at).toLocaleDateString() : 'Never'}
+                        {(() => {
+                          const status = getExpiryStatus(key.expires_at);
+                          if (status === 'never') return 'Never';
+                          const dateStr = new Date(key.expires_at!).toLocaleDateString();
+                          if (status === 'expired') {
+                            return (
+                              <Chip label={`Expired ${dateStr}`} size="small" color="error" variant="outlined" />
+                            );
+                          }
+                          if (status === 'expiring-soon') {
+                            return (
+                              <Chip label={dateStr} size="small" color="warning" variant="outlined" />
+                            );
+                          }
+                          return dateStr;
+                        })()}
                       </TableCell>
                       <TableCell>
                         <Tooltip title="Revoke key">
@@ -381,17 +440,52 @@ const Profile = () => {
               error={generateKeyForm.name.length > 50}
               slotProps={{ htmlInput: { maxLength: 50 } }}
             />
-            <TextField
-              label="Expires At (optional)"
-              type="date"
-              value={generateKeyForm.expires_at ?? ''}
-              onChange={(e) =>
-                setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || undefined }))
-              }
-              fullWidth
-              size="small"
-              slotProps={{ inputLabel: { shrink: true } }}
-            />
+            <FormControl>
+              <FormLabel id="expiry-mode-label">Expiration</FormLabel>
+              <RadioGroup
+                aria-labelledby="expiry-mode-label"
+                value={expiryMode}
+                onChange={(e) => setExpiryMode(e.target.value as ExpiryMode)}
+              >
+                <FormControlLabel value="none" control={<Radio />} label="No expiry" />
+                <FormControlLabel value="preset" control={<Radio />} label="Preset duration" />
+                <FormControlLabel value="custom" control={<Radio />} label="Custom date" />
+              </RadioGroup>
+            </FormControl>
+            {expiryMode === 'preset' && (
+              <Box>
+                <TextField
+                  select
+                  label="Duration"
+                  value={presetDays}
+                  onChange={(e) => setPresetDays(Number(e.target.value))}
+                  fullWidth
+                  size="small"
+                >
+                  {PRESET_DURATIONS.map((d) => (
+                    <MenuItem key={d.value} value={d.value}>
+                      {d.label}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  Expires: {computeExpiryDate(presetDays).toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })}
+                </Typography>
+              </Box>
+            )}
+            {expiryMode === 'custom' && (
+              <TextField
+                label="Expires At"
+                type="date"
+                value={generateKeyForm.expires_at ?? ''}
+                onChange={(e) =>
+                  setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || undefined }))
+                }
+                fullWidth
+                size="small"
+                slotProps={{ inputLabel: { shrink: true } }}
+              />
+            )}
           </Box>
         </DialogContent>
         <DialogActions>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -254,7 +254,6 @@ export interface CreateAPIKeyRequest {
 
 export interface CreateAPIKeyResponse {
   id: string;
-  user_id?: string;
   name: string;
   prefix: string;
   raw_key: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -254,7 +254,7 @@ export interface CreateAPIKeyRequest {
 
 export interface CreateAPIKeyResponse {
   id: string;
-  user_id: string;
+  user_id?: string;
   name: string;
   prefix: string;
   raw_key: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -249,6 +249,7 @@ export interface APIKey {
 export interface CreateAPIKeyRequest {
   name: string;
   expires_at?: string;
+  expires_in_days?: number;
 }
 
 export interface CreateAPIKeyResponse {
@@ -258,6 +259,7 @@ export interface CreateAPIKeyResponse {
   prefix: string;
   raw_key: string;
   created_at: string;
+  expires_at?: string;
 }
 
 export interface ResourceCounts {


### PR DESCRIPTION
## Summary

Closes #135

Adds configurable API key expiration policy with admin-configurable max lifetime, convenience `expires_in_days` parameter, and frontend UI enhancements.

## Changes

### Backend
- **Config**: `API_KEY_MAX_LIFETIME_DAYS` env var (default: 0 = no limit) in `AuthConfig`
- **Handler** (`api_keys.go`):
  - `expires_in_days` field on `CreateAPIKeyRequest` (alternative to `expires_at`)
  - Mutual exclusion: rejects requests with both fields
  - Max lifetime enforcement: rejects keys exceeding configured limit
  - Auto-cap: keys without explicit expiry get capped when max lifetime is set
  - Past-date rejection: `expires_at` in the past returns 400
  - UTC normalization for RFC3339-parsed timestamps
  - Updated Swagger `@Description`
- **Config test**: Verifies env var loading + default value (0)
- **Handler tests**: 13 expiration-specific subtest- **Handler tests**: 13 expiration-specific subtest- **ts, both fields, zero/negative days, auto-cap, no-limit)

### Frontend
- **Profile page**: Expiry mo- **Profile page**: Expiry mo- **Profile page**: Expiry mo- **Profile page**: Expiry mo- **Profile page**: Expiry mo- **Profile page**: Expiry mo- *y list**: Expired keys show red chip, expiring-within-30-days shows warning chip
- **Types**: `expires_in_days` on request, - **Types**: `expiesponse
- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **Te- **T: 13 new expiration tests + config tests — all pass
- Frontend: 20- Frontend: 20- Frontend: 20- Frontend: 20- Frontend: 20- F Full backend suite: all packages pass