### PR TITLE
feat: instance runtime health monitoring (pod status, restarts, OOMKills)

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -5034,6 +5034,15 @@ const docTemplate = `{
                                 "type": "string"
                             }
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -4966,6 +4966,11 @@ const docTemplate = `{
         },
         "/api/v1/stack-instances/{id}/pods": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Returns detailed pod health including container states, conditions, and recent events",
                 "produces": [
                     "application/json"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -5008,6 +5008,15 @@ const docTemplate = `{
                             }
                         }
                     },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -7804,7 +7804,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "state": {
-                    "description": "\"running\", \"waiting\", \"terminated\"",
+                    "description": "\"running\", \"waiting\", \"terminated\", \"unknown\"",
                     "type": "string"
                 }
             }

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -700,7 +700,7 @@ const docTemplate = `{
         },
         "/api/v1/auth/login": {
             "post": {
-                "description": "Authenticate with username and password, returns a JWT token",
+                "description": "Authenticate with username and password, returns a JWT access token and sets a refresh token cookie",
                 "consumes": [
                     "application/json"
                 ],
@@ -740,6 +740,85 @@ const docTemplate = `{
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/logout": {
+            "post": {
+                "description": "Revokes the current refresh token and blocklists the access token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Logout",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/logout-all": {
+            "post": {
+                "description": "Revokes all refresh tokens for the current user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Logout from all sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -894,6 +973,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/auth/refresh": {
+            "post": {
+                "description": "Issues a new access token using the refresh token cookie. Rotates the refresh token (old one invalidated, new one issued).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Refresh access token",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RefreshResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid, expired, or revoked refresh token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Refresh tokens not enabled",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/auth/register": {
             "post": {
                 "description": "Create a new user account (admin only, or when self-registration is enabled)",
@@ -962,7 +1091,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all registered clusters. Kubeconfig data is never included in responses.",
+                "description": "Returns all registered clusters. Kubeconfig data is never included in responses. Admin/DevOps users receive full cluster details; other roles receive a summary (id, name, is_default only).",
                 "produces": [
                     "application/json"
                 ],
@@ -972,11 +1101,11 @@ const docTemplate = `{
                 "summary": "List all clusters",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Summary (other roles)",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Cluster"
+                                "$ref": "#/definitions/handlers.ClusterSummary"
                             }
                         }
                     },
@@ -1063,7 +1192,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns a single cluster by ID. Kubeconfig data is never included.",
+                "description": "Returns a single cluster by ID. Kubeconfig data is never included. Admin/DevOps users receive full cluster details; other roles receive a summary (id, name, is_default only).",
                 "produces": [
                     "application/json"
                 ],
@@ -1082,9 +1211,9 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Summary (other roles)",
                         "schema": {
-                            "$ref": "#/definitions/models.Cluster"
+                            "$ref": "#/definitions/handlers.ClusterSummary"
                         }
                     },
                     "404": {
@@ -2690,7 +2819,8 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int64"
                             }
                         }
                     },
@@ -2997,6 +3127,21 @@ const docTemplate = `{
                         "type": "integer",
                         "description": "Items per page (default 25, max 100)",
                         "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Max items to return (default 25, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "description": "Number of items to skip (default 0)",
+                        "name": "offset",
                         "in": "query"
                     }
                 ],
@@ -4584,6 +4729,76 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/stack-instances/{id}/deploy-preview": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Compare pending merged values against last-deployed values per chart",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "stack-instances"
+                ],
+                "summary": "Preview deployment changes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DeployPreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/stack-instances/{id}/extend": {
             "post": {
                 "description": "Extend the expiry time of a stack instance. Uses provided ttl_minutes or the instance's existing TTLMinutes.",
@@ -4739,6 +4954,71 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/stack-instances/{id}/pods": {
+            "get": {
+                "description": "Returns detailed pod health including container states, conditions, and recent events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "stack-instances"
+                ],
+                "summary": "Get instance pod status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/k8s.NamespaceStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -6350,7 +6630,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Generates a new API key. The raw key is returned once in raw_key and cannot be retrieved again.",
+                "description": "Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6552,6 +6832,14 @@ const docTemplate = `{
                     "health"
                 ],
                 "summary": "Readiness Check",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Include per-check details",
+                        "name": "verbose",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -6570,17 +6858,34 @@ const docTemplate = `{
         },
         "/ws": {
             "get": {
-                "description": "Upgrades the HTTP connection to a WebSocket for real-time events.",
+                "description": "Upgrades the HTTP connection to a WebSocket for real-time events. Requires a valid JWT token via ?token= query parameter or Authorization: Bearer header.",
                 "tags": [
                     "websocket"
                 ],
                 "summary": "Open a WebSocket connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT authentication token",
+                        "name": "token",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "101": {
                         "description": "Switching Protocols"
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -6733,6 +7038,9 @@ const docTemplate = `{
         "handlers.ChartConfigExportData": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },
@@ -6756,10 +7064,41 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.ChartDeployPreview": {
+            "type": "object",
+            "properties": {
+                "chart_name": {
+                    "type": "string"
+                },
+                "has_changes": {
+                    "type": "boolean"
+                },
+                "pending_values": {
+                    "type": "string"
+                },
+                "previous_values": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ClusterSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ClusterUtilization": {
             "type": "object",
             "properties": {
-                "clusterID": {
+                "cluster_id": {
                     "type": "string"
                 },
                 "namespaces": {
@@ -6833,6 +7172,9 @@ const docTemplate = `{
                 "expires_at": {
                     "type": "string"
                 },
+                "expires_in_days": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 }
@@ -6865,7 +7207,6 @@ const docTemplate = `{
         "handlers.CreateClusterRequest": {
             "type": "object",
             "required": [
-                "api_server_url",
                 "name"
             ],
             "properties": {
@@ -6895,6 +7236,9 @@ const docTemplate = `{
                 },
                 "region": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -6928,6 +7272,23 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DeployPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "charts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ChartDeployPreview"
+                    }
+                },
+                "instance_id": {
+                    "type": "string"
+                },
+                "instance_name": {
                     "type": "string"
                 }
             }
@@ -7047,6 +7408,14 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.RefreshResponse": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.RegisterRequest": {
             "type": "object",
             "required": [
@@ -7132,6 +7501,9 @@ const docTemplate = `{
                 },
                 "region": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -7398,6 +7770,36 @@ const docTemplate = `{
                 }
             }
         },
+        "k8s.ContainerStateInfo": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "restart_count": {
+                    "type": "integer"
+                },
+                "state": {
+                    "description": "\"running\", \"waiting\", \"terminated\"",
+                    "type": "string"
+                }
+            }
+        },
         "k8s.DeploymentInfo": {
             "type": "object",
             "properties": {
@@ -7461,6 +7863,12 @@ const docTemplate = `{
                         "$ref": "#/definitions/k8s.ChartStatus"
                     }
                 },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.PodEvent"
+                    }
+                },
                 "ingresses": {
                     "type": "array",
                     "items": {
@@ -7520,13 +7928,75 @@ const docTemplate = `{
                 }
             }
         },
+        "k8s.PodConditionInfo": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "\"True\", \"False\", \"Unknown\"",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"Ready\", \"ContainersReady\", \"Initialized\", \"PodScheduled\"",
+                    "type": "string"
+                }
+            }
+        },
+        "k8s.PodEvent": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "first_seen": {
+                    "type": "string"
+                },
+                "last_seen": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "object": {
+                    "description": "\"Pod/my-pod-xyz\"",
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"Normal\", \"Warning\"",
+                    "type": "string"
+                }
+            }
+        },
         "k8s.PodInfo": {
             "type": "object",
             "properties": {
+                "conditions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.PodConditionInfo"
+                    }
+                },
+                "container_states": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.ContainerStateInfo"
+                    }
+                },
                 "image": {
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "node_name": {
                     "type": "string"
                 },
                 "phase": {
@@ -7537,6 +8007,9 @@ const docTemplate = `{
                 },
                 "restart_count": {
                     "type": "integer"
+                },
+                "start_time": {
+                    "type": "string"
                 }
             }
         },
@@ -7682,6 +8155,10 @@ const docTemplate = `{
         "models.ChartConfig": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "description": "CI pipeline ID to trigger for image builds",
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },
@@ -7793,6 +8270,9 @@ const docTemplate = `{
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -8182,6 +8662,10 @@ const docTemplate = `{
         "models.TemplateChartConfig": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "description": "CI pipeline ID to trigger for image builds",
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -7802,7 +7802,7 @@
                     "type": "integer"
                 },
                 "state": {
-                    "description": "\"running\", \"waiting\", \"terminated\"",
+                    "description": "\"running\", \"waiting\", \"terminated\", \"unknown\"",
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5006,6 +5006,15 @@
                             }
                         }
                     },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
                     "502": {
                         "description": "Bad Gateway",
                         "schema": {

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -698,7 +698,7 @@
         },
         "/api/v1/auth/login": {
             "post": {
-                "description": "Authenticate with username and password, returns a JWT token",
+                "description": "Authenticate with username and password, returns a JWT access token and sets a refresh token cookie",
                 "consumes": [
                     "application/json"
                 ],
@@ -738,6 +738,85 @@
                     },
                     "401": {
                         "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/logout": {
+            "post": {
+                "description": "Revokes the current refresh token and blocklists the access token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Logout",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/logout-all": {
+            "post": {
+                "description": "Revokes all refresh tokens for the current user",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Logout from all sessions",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -892,6 +971,56 @@
                 }
             }
         },
+        "/api/v1/auth/refresh": {
+            "post": {
+                "description": "Issues a new access token using the refresh token cookie. Rotates the refresh token (old one invalidated, new one issued).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Refresh access token",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.RefreshResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid, expired, or revoked refresh token",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "501": {
+                        "description": "Refresh tokens not enabled",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/auth/register": {
             "post": {
                 "description": "Create a new user account (admin only, or when self-registration is enabled)",
@@ -960,7 +1089,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns all registered clusters. Kubeconfig data is never included in responses.",
+                "description": "Returns all registered clusters. Kubeconfig data is never included in responses. Admin/DevOps users receive full cluster details; other roles receive a summary (id, name, is_default only).",
                 "produces": [
                     "application/json"
                 ],
@@ -970,11 +1099,11 @@
                 "summary": "List all clusters",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Summary (other roles)",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/models.Cluster"
+                                "$ref": "#/definitions/handlers.ClusterSummary"
                             }
                         }
                     },
@@ -1061,7 +1190,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Returns a single cluster by ID. Kubeconfig data is never included.",
+                "description": "Returns a single cluster by ID. Kubeconfig data is never included. Admin/DevOps users receive full cluster details; other roles receive a summary (id, name, is_default only).",
                 "produces": [
                     "application/json"
                 ],
@@ -1080,9 +1209,9 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Summary (other roles)",
                         "schema": {
-                            "$ref": "#/definitions/models.Cluster"
+                            "$ref": "#/definitions/handlers.ClusterSummary"
                         }
                     },
                     "404": {
@@ -2688,7 +2817,8 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer"
+                                "type": "integer",
+                                "format": "int64"
                             }
                         }
                     },
@@ -2995,6 +3125,21 @@
                         "type": "integer",
                         "description": "Items per page (default 25, max 100)",
                         "name": "pageSize",
+                        "in": "query"
+                    },
+                    {
+                        "maximum": 100,
+                        "minimum": 1,
+                        "type": "integer",
+                        "description": "Max items to return (default 25, max 100)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "minimum": 0,
+                        "type": "integer",
+                        "description": "Number of items to skip (default 0)",
+                        "name": "offset",
                         "in": "query"
                     }
                 ],
@@ -4582,6 +4727,76 @@
                 }
             }
         },
+        "/api/v1/stack-instances/{id}/deploy-preview": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Compare pending merged values against last-deployed values per chart",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "stack-instances"
+                ],
+                "summary": "Preview deployment changes",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.DeployPreviewResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/stack-instances/{id}/extend": {
             "post": {
                 "description": "Extend the expiry time of a stack instance. Uses provided ttl_minutes or the instance's existing TTLMinutes.",
@@ -4737,6 +4952,71 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/stack-instances/{id}/pods": {
+            "get": {
+                "description": "Returns detailed pod health including container states, conditions, and recent events",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "stack-instances"
+                ],
+                "summary": "Get instance pod status",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Instance ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/k8s.NamespaceStatus"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "502": {
+                        "description": "Bad Gateway",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -6348,7 +6628,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Generates a new API key. The raw key is returned once in raw_key and cannot be retrieved again.",
+                "description": "Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.",
                 "consumes": [
                     "application/json"
                 ],
@@ -6550,6 +6830,14 @@
                     "health"
                 ],
                 "summary": "Readiness Check",
+                "parameters": [
+                    {
+                        "type": "boolean",
+                        "description": "Include per-check details",
+                        "name": "verbose",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "OK",
@@ -6568,17 +6856,34 @@
         },
         "/ws": {
             "get": {
-                "description": "Upgrades the HTTP connection to a WebSocket for real-time events.",
+                "description": "Upgrades the HTTP connection to a WebSocket for real-time events. Requires a valid JWT token via ?token= query parameter or Authorization: Bearer header.",
                 "tags": [
                     "websocket"
                 ],
                 "summary": "Open a WebSocket connection",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "JWT authentication token",
+                        "name": "token",
+                        "in": "query"
+                    }
+                ],
                 "responses": {
                     "101": {
                         "description": "Switching Protocols"
                     },
                     "400": {
                         "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -6731,6 +7036,9 @@
         "handlers.ChartConfigExportData": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },
@@ -6754,10 +7062,41 @@
                 }
             }
         },
+        "handlers.ChartDeployPreview": {
+            "type": "object",
+            "properties": {
+                "chart_name": {
+                    "type": "string"
+                },
+                "has_changes": {
+                    "type": "boolean"
+                },
+                "pending_values": {
+                    "type": "string"
+                },
+                "previous_values": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ClusterSummary": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "is_default": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.ClusterUtilization": {
             "type": "object",
             "properties": {
-                "clusterID": {
+                "cluster_id": {
                     "type": "string"
                 },
                 "namespaces": {
@@ -6831,6 +7170,9 @@
                 "expires_at": {
                     "type": "string"
                 },
+                "expires_in_days": {
+                    "type": "integer"
+                },
                 "name": {
                     "type": "string"
                 }
@@ -6863,7 +7205,6 @@
         "handlers.CreateClusterRequest": {
             "type": "object",
             "required": [
-                "api_server_url",
                 "name"
             ],
             "properties": {
@@ -6893,6 +7234,9 @@
                 },
                 "region": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -6926,6 +7270,23 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.DeployPreviewResponse": {
+            "type": "object",
+            "properties": {
+                "charts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handlers.ChartDeployPreview"
+                    }
+                },
+                "instance_id": {
+                    "type": "string"
+                },
+                "instance_name": {
                     "type": "string"
                 }
             }
@@ -7045,6 +7406,14 @@
                 }
             }
         },
+        "handlers.RefreshResponse": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.RegisterRequest": {
             "type": "object",
             "required": [
@@ -7130,6 +7499,9 @@
                 },
                 "region": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -7396,6 +7768,36 @@
                 }
             }
         },
+        "k8s.ContainerStateInfo": {
+            "type": "object",
+            "properties": {
+                "exit_code": {
+                    "type": "integer"
+                },
+                "image": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "restart_count": {
+                    "type": "integer"
+                },
+                "state": {
+                    "description": "\"running\", \"waiting\", \"terminated\"",
+                    "type": "string"
+                }
+            }
+        },
         "k8s.DeploymentInfo": {
             "type": "object",
             "properties": {
@@ -7459,6 +7861,12 @@
                         "$ref": "#/definitions/k8s.ChartStatus"
                     }
                 },
+                "events": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.PodEvent"
+                    }
+                },
                 "ingresses": {
                     "type": "array",
                     "items": {
@@ -7518,13 +7926,75 @@
                 }
             }
         },
+        "k8s.PodConditionInfo": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "status": {
+                    "description": "\"True\", \"False\", \"Unknown\"",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"Ready\", \"ContainersReady\", \"Initialized\", \"PodScheduled\"",
+                    "type": "string"
+                }
+            }
+        },
+        "k8s.PodEvent": {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer"
+                },
+                "first_seen": {
+                    "type": "string"
+                },
+                "last_seen": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "object": {
+                    "description": "\"Pod/my-pod-xyz\"",
+                    "type": "string"
+                },
+                "reason": {
+                    "type": "string"
+                },
+                "type": {
+                    "description": "\"Normal\", \"Warning\"",
+                    "type": "string"
+                }
+            }
+        },
         "k8s.PodInfo": {
             "type": "object",
             "properties": {
+                "conditions": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.PodConditionInfo"
+                    }
+                },
+                "container_states": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/k8s.ContainerStateInfo"
+                    }
+                },
                 "image": {
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "node_name": {
                     "type": "string"
                 },
                 "phase": {
@@ -7535,6 +8005,9 @@
                 },
                 "restart_count": {
                     "type": "integer"
+                },
+                "start_time": {
+                    "type": "string"
                 }
             }
         },
@@ -7680,6 +8153,10 @@
         "models.ChartConfig": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "description": "CI pipeline ID to trigger for image builds",
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },
@@ -7791,6 +8268,9 @@
                 },
                 "updated_at": {
                     "type": "string"
+                },
+                "use_in_cluster": {
+                    "type": "boolean"
                 }
             }
         },
@@ -8180,6 +8660,10 @@
         "models.TemplateChartConfig": {
             "type": "object",
             "properties": {
+                "build_pipeline_id": {
+                    "description": "CI pipeline ID to trigger for image builds",
+                    "type": "string"
+                },
                 "chart_name": {
                     "type": "string"
                 },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -5032,6 +5032,15 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "504": {
+                        "description": "Gateway Timeout",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -4964,6 +4964,11 @@
         },
         "/api/v1/stack-instances/{id}/pods": {
             "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
                 "description": "Returns detailed pod health including container states, conditions, and recent events",
                 "produces": [
                     "application/json"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -4395,6 +4395,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "504":
+          description: Gateway Timeout
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       summary: Get instance pod status
       tags:
       - stack-instances

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -4377,6 +4377,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
         "502":
           description: Bad Gateway
           schema:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -581,7 +581,7 @@ definitions:
       restart_count:
         type: integer
       state:
-        description: '"running", "waiting", "terminated"'
+        description: '"running", "waiting", "terminated", "unknown"'
         type: string
     type: object
   k8s.DeploymentInfo:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -4401,6 +4401,8 @@ paths:
             additionalProperties:
               type: string
             type: object
+      security:
+      - BearerAuth: []
       summary: Get instance pod status
       tags:
       - stack-instances

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -85,6 +85,8 @@ definitions:
     type: object
   handlers.ChartConfigExportData:
     properties:
+      build_pipeline_id:
+        type: string
       chart_name:
         type: string
       chart_path:
@@ -100,9 +102,29 @@ definitions:
       source_repo_url:
         type: string
     type: object
+  handlers.ChartDeployPreview:
+    properties:
+      chart_name:
+        type: string
+      has_changes:
+        type: boolean
+      pending_values:
+        type: string
+      previous_values:
+        type: string
+    type: object
+  handlers.ClusterSummary:
+    properties:
+      id:
+        type: string
+      is_default:
+        type: boolean
+      name:
+        type: string
+    type: object
   handlers.ClusterUtilization:
     properties:
-      clusterID:
+      cluster_id:
         type: string
       namespaces:
         items:
@@ -148,6 +170,8 @@ definitions:
     properties:
       expires_at:
         type: string
+      expires_in_days:
+        type: integer
       name:
         type: string
     required:
@@ -189,8 +213,9 @@ definitions:
         type: string
       region:
         type: string
+      use_in_cluster:
+        type: boolean
     required:
-    - api_server_url
     - name
     type: object
   handlers.DefinitionExportBundle:
@@ -213,6 +238,17 @@ definitions:
       description:
         type: string
       name:
+        type: string
+    type: object
+  handlers.DeployPreviewResponse:
+    properties:
+      charts:
+        items:
+          $ref: '#/definitions/handlers.ChartDeployPreview'
+        type: array
+      instance_id:
+        type: string
+      instance_name:
         type: string
     type: object
   handlers.LoginRequest:
@@ -290,6 +326,11 @@ definitions:
       total_users:
         type: integer
     type: object
+  handlers.RefreshResponse:
+    properties:
+      token:
+        type: string
+    type: object
   handlers.RegisterRequest:
     properties:
       display_name:
@@ -347,6 +388,8 @@ definitions:
         type: string
       region:
         type: string
+      use_in_cluster:
+        type: boolean
     type: object
   handlers.UpdateQuotaRequest:
     properties:
@@ -521,6 +564,26 @@ definitions:
       total_memory:
         type: string
     type: object
+  k8s.ContainerStateInfo:
+    properties:
+      exit_code:
+        type: integer
+      image:
+        type: string
+      message:
+        type: string
+      name:
+        type: string
+      ready:
+        type: boolean
+      reason:
+        type: string
+      restart_count:
+        type: integer
+      state:
+        description: '"running", "waiting", "terminated"'
+        type: string
+    type: object
   k8s.DeploymentInfo:
     properties:
       available:
@@ -562,6 +625,10 @@ definitions:
         items:
           $ref: '#/definitions/k8s.ChartStatus'
         type: array
+      events:
+        items:
+          $ref: '#/definitions/k8s.PodEvent'
+        type: array
       ingresses:
         items:
           $ref: '#/definitions/k8s.IngressInfo'
@@ -601,11 +668,53 @@ definitions:
         description: '"Ready" or "NotReady"'
         type: string
     type: object
+  k8s.PodConditionInfo:
+    properties:
+      message:
+        type: string
+      reason:
+        type: string
+      status:
+        description: '"True", "False", "Unknown"'
+        type: string
+      type:
+        description: '"Ready", "ContainersReady", "Initialized", "PodScheduled"'
+        type: string
+    type: object
+  k8s.PodEvent:
+    properties:
+      count:
+        type: integer
+      first_seen:
+        type: string
+      last_seen:
+        type: string
+      message:
+        type: string
+      object:
+        description: '"Pod/my-pod-xyz"'
+        type: string
+      reason:
+        type: string
+      type:
+        description: '"Normal", "Warning"'
+        type: string
+    type: object
   k8s.PodInfo:
     properties:
+      conditions:
+        items:
+          $ref: '#/definitions/k8s.PodConditionInfo'
+        type: array
+      container_states:
+        items:
+          $ref: '#/definitions/k8s.ContainerStateInfo'
+        type: array
       image:
         type: string
       name:
+        type: string
+      node_name:
         type: string
       phase:
         type: string
@@ -613,6 +722,8 @@ definitions:
         type: boolean
       restart_count:
         type: integer
+      start_time:
+        type: string
     type: object
   k8s.ResourceCounts:
     properties:
@@ -707,6 +818,9 @@ definitions:
     type: object
   models.ChartConfig:
     properties:
+      build_pipeline_id:
+        description: CI pipeline ID to trigger for image builds
+        type: string
       chart_name:
         type: string
       chart_path:
@@ -783,6 +897,8 @@ definitions:
         type: string
       updated_at:
         type: string
+      use_in_cluster:
+        type: boolean
     type: object
   models.DeploymentLog:
     properties:
@@ -1040,6 +1156,9 @@ definitions:
     type: object
   models.TemplateChartConfig:
     properties:
+      build_pipeline_id:
+        description: CI pipeline ID to trigger for image builds
+        type: string
       chart_name:
         type: string
       chart_path:
@@ -1640,7 +1759,8 @@ paths:
     post:
       consumes:
       - application/json
-      description: Authenticate with username and password, returns a JWT token
+      description: Authenticate with username and password, returns a JWT access token
+        and sets a refresh token cookie
       parameters:
       - description: Login credentials
         in: body
@@ -1668,6 +1788,58 @@ paths:
               type: string
             type: object
       summary: User login
+      tags:
+      - auth
+  /api/v1/auth/logout:
+    post:
+      consumes:
+      - application/json
+      description: Revokes the current refresh token and blocklists the access token
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Logout
+      tags:
+      - auth
+  /api/v1/auth/logout-all:
+    post:
+      consumes:
+      - application/json
+      description: Revokes all refresh tokens for the current user
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Logout from all sessions
       tags:
       - auth
   /api/v1/auth/me:
@@ -1769,6 +1941,40 @@ paths:
       summary: Get OIDC configuration
       tags:
       - auth
+  /api/v1/auth/refresh:
+    post:
+      consumes:
+      - application/json
+      description: Issues a new access token using the refresh token cookie. Rotates
+        the refresh token (old one invalidated, new one issued).
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.RefreshResponse'
+        "401":
+          description: Invalid, expired, or revoked refresh token
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "501":
+          description: Refresh tokens not enabled
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Refresh access token
+      tags:
+      - auth
   /api/v1/auth/register:
     post:
       consumes:
@@ -1813,15 +2019,16 @@ paths:
   /api/v1/clusters:
     get:
       description: Returns all registered clusters. Kubeconfig data is never included
-        in responses.
+        in responses. Admin/DevOps users receive full cluster details; other roles
+        receive a summary (id, name, is_default only).
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Summary (other roles)
           schema:
             items:
-              $ref: '#/definitions/models.Cluster'
+              $ref: '#/definitions/handlers.ClusterSummary'
             type: array
         "500":
           description: Internal Server Error
@@ -1916,6 +2123,8 @@ paths:
       - clusters
     get:
       description: Returns a single cluster by ID. Kubeconfig data is never included.
+        Admin/DevOps users receive full cluster details; other roles receive a summary
+        (id, name, is_default only).
       parameters:
       - description: Cluster ID
         in: path
@@ -1926,9 +2135,9 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Summary (other roles)
           schema:
-            $ref: '#/definitions/models.Cluster'
+            $ref: '#/definitions/handlers.ClusterSummary'
         "404":
           description: Not Found
           schema:
@@ -2984,6 +3193,7 @@ paths:
           description: OK
           schema:
             additionalProperties:
+              format: int64
               type: integer
             type: object
         "401":
@@ -3136,6 +3346,17 @@ paths:
         maximum: 100
         minimum: 1
         name: pageSize
+        type: integer
+      - description: Max items to return (default 25, max 100)
+        in: query
+        maximum: 100
+        minimum: 1
+        name: limit
+        type: integer
+      - description: Number of items to skip (default 0)
+        in: query
+        minimum: 0
+        name: offset
         type: integer
       produces:
       - application/json
@@ -3971,6 +4192,52 @@ paths:
       summary: Get deployment logs
       tags:
       - stack-instances
+  /api/v1/stack-instances/{id}/deploy-preview:
+    get:
+      description: Compare pending merged values against last-deployed values per
+        chart
+      parameters:
+      - description: Instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handlers.DeployPreviewResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Preview deployment changes
+      tags:
+      - stack-instances
   /api/v1/stack-instances/{id}/extend:
     post:
       consumes:
@@ -4081,6 +4348,50 @@ paths:
       summary: Set or update override for a chart
       tags:
       - value-overrides
+  /api/v1/stack-instances/{id}/pods:
+    get:
+      description: Returns detailed pod health including container states, conditions,
+        and recent events
+      parameters:
+      - description: Instance ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/k8s.NamespaceStatus'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "502":
+          description: Bad Gateway
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Get instance pod status
+      tags:
+      - stack-instances
   /api/v1/stack-instances/{id}/quota-overrides:
     delete:
       description: Remove the per-instance resource quota override for a stack instance
@@ -5373,8 +5684,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: Generates a new API key. The raw key is returned once in raw_key
-        and cannot be retrieved again.
+      description: Generates a new API key. Optionally set expires_at (YYYY-MM-DD
+        or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS
+        is configured, keys without explicit expiry are auto-capped. The raw key is
+        returned once in raw_key and cannot be retrieved again.
       parameters:
       - description: User ID
         in: path
@@ -5502,6 +5815,11 @@ paths:
   /health/ready:
     get:
       description: Get API readiness status
+      parameters:
+      - description: Include per-check details
+        in: query
+        name: verbose
+        type: boolean
       produces:
       - application/json
       responses:
@@ -5518,12 +5836,25 @@ paths:
       - health
   /ws:
     get:
-      description: Upgrades the HTTP connection to a WebSocket for real-time events.
+      description: 'Upgrades the HTTP connection to a WebSocket for real-time events.
+        Requires a valid JWT token via ?token= query parameter or Authorization: Bearer
+        header.'
+      parameters:
+      - description: JWT authentication token
+        in: query
+        name: token
+        type: string
       responses:
         "101":
           description: Switching Protocols
         "400":
           description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
           schema:
             additionalProperties:
               type: string

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1418,59 +1418,8 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 // @Failure     503 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/pods [get]
 func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
-	id := c.Param("id")
-	if id == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": msgInstanceIDRequired})
-		return
-	}
-
-	inst, err := h.instanceRepo.FindByID(id)
-	if err != nil {
-		status, message := mapError(err, entityStackInstance)
-		c.JSON(status, gin.H{"error": message})
-		return
-	}
-
-	// Try cached status from watcher first.
-	if h.k8sWatcher != nil {
-		if nsStatus, ok := h.k8sWatcher.GetStatus(id); ok {
-			c.JSON(http.StatusOK, nsStatus)
-			return
-		}
-	}
-
-	// Fall back to direct query if we have a cluster registry.
-	if h.registry != nil {
-		client, clientErr := h.registry.GetK8sClient(inst.ClusterID)
-		if clientErr != nil {
-			slog.Warn("Failed to get k8s client for instance pods",
-				logKeyInstanceID, id,
-				"cluster_id", inst.ClusterID,
-				"error", clientErr,
-			)
-			var dbErr *dberrors.DatabaseError
-			if errors.As(clientErr, &dbErr) && errors.Is(dbErr.Unwrap(), dberrors.ErrNotFound) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "Unknown cluster_id"})
-			} else {
-				c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to connect to cluster"})
-			}
-			return
-		}
-		nsStatus, err := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace)
-		if err != nil {
-			slog.Error("Failed to get namespace status for pods",
-				logKeyInstanceID, id,
-				"namespace", inst.Namespace,
-				"error", err,
-			)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-			return
-		}
-		c.JSON(http.StatusOK, nsStatus)
-		return
-	}
-
-	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "K8s monitoring not configured"})
+	// Delegates to GetInstanceStatus — same data, separate route for semantic clarity.
+	h.GetInstanceStatus(c)
 }
 
 // checkNamespaceUniqueness checks whether the given namespace is already in use.

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1409,6 +1409,7 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 // @Description Returns detailed pod health including container states, conditions, and recent events
 // @Tags        stack-instances
 // @Produce     json
+// @Security    BearerAuth
 // @Param       id path string true "Instance ID"
 // @Success     200 {object} k8s.NamespaceStatus
 // @Failure     400 {object} map[string]string

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1896,6 +1896,7 @@ func (h *InstanceHandler) buildChartValues(ctx context.Context, inst *models.Sta
 
 	templateVars := helm.TemplateVars{
 		Branch:       inst.Branch,
+		ImageTag:     helm.SanitizeImageTag(inst.Branch),
 		Namespace:    inst.Namespace,
 		InstanceName: inst.Name,
 		StackName:    def.Name,

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1897,7 +1897,6 @@ func (h *InstanceHandler) buildChartValues(ctx context.Context, inst *models.Sta
 
 	templateVars := helm.TemplateVars{
 		Branch:       inst.Branch,
-		ImageTag:     helm.SanitizeImageTag(inst.Branch),
 		Namespace:    inst.Namespace,
 		InstanceName: inst.Name,
 		StackName:    def.Name,

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1387,7 +1387,7 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 			}
 			return
 		}
-		nsStatus, err := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace)
+		nsStatus, err := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace, k8s.StatusOptions{})
 		if err != nil {
 			slog.Error("Failed to get namespace status",
 				logKeyInstanceID, id,
@@ -1418,8 +1418,59 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 // @Failure     503 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/pods [get]
 func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
-	// Delegates to GetInstanceStatus — same data, separate route for semantic clarity.
-	h.GetInstanceStatus(c)
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msgInstanceIDRequired})
+		return
+	}
+
+	inst, err := h.instanceRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	// Try cached status from watcher first.
+	if h.k8sWatcher != nil {
+		if nsStatus, ok := h.k8sWatcher.GetStatus(id); ok {
+			c.JSON(http.StatusOK, nsStatus)
+			return
+		}
+	}
+
+	// Fall back to direct query with events included.
+	if h.registry != nil {
+		client, clientErr := h.registry.GetK8sClient(inst.ClusterID)
+		if clientErr != nil {
+			slog.Warn("Failed to get k8s client for instance pods",
+				logKeyInstanceID, id,
+				"cluster_id", inst.ClusterID,
+				"error", clientErr,
+			)
+			var dbErr *dberrors.DatabaseError
+			if errors.As(clientErr, &dbErr) && errors.Is(dbErr.Unwrap(), dberrors.ErrNotFound) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Unknown cluster_id"})
+			} else {
+				c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to connect to cluster"})
+			}
+			return
+		}
+		nsStatus, nsErr := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace, k8s.StatusOptions{IncludeEvents: true})
+		if nsErr != nil {
+			slog.Error("Failed to get namespace status for pods",
+				logKeyInstanceID, id,
+				"namespace", inst.Namespace,
+				"error", nsErr,
+			)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+			return
+		}
+		c.JSON(http.StatusOK, nsStatus)
+		return
+	}
+
+	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "K8s monitoring not configured"})
 }
 
 // checkNamespaceUniqueness checks whether the given namespace is already in use.

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1431,15 +1431,7 @@ func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
 		return
 	}
 
-	// Try cached status from watcher first.
-	if h.k8sWatcher != nil {
-		if nsStatus, ok := h.k8sWatcher.GetStatus(id); ok {
-			c.JSON(http.StatusOK, nsStatus)
-			return
-		}
-	}
-
-	// Fall back to direct query with events included.
+	// Always query directly with events — the watcher cache does not include events.
 	if h.registry != nil {
 		client, clientErr := h.registry.GetK8sClient(inst.ClusterID)
 		if clientErr != nil {

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1404,6 +1404,74 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "K8s monitoring not configured"})
 }
 
+// GetInstancePods godoc
+// @Summary     Get instance pod status
+// @Description Returns detailed pod health including container states, conditions, and recent events
+// @Tags        stack-instances
+// @Produce     json
+// @Param       id path string true "Instance ID"
+// @Success     200 {object} k8s.NamespaceStatus
+// @Failure     400 {object} map[string]string
+// @Failure     404 {object} map[string]string
+// @Failure     502 {object} map[string]string
+// @Failure     503 {object} map[string]string
+// @Router      /api/v1/stack-instances/{id}/pods [get]
+func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msgInstanceIDRequired})
+		return
+	}
+
+	inst, err := h.instanceRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	// Try cached status from watcher first.
+	if h.k8sWatcher != nil {
+		if nsStatus, ok := h.k8sWatcher.GetStatus(id); ok {
+			c.JSON(http.StatusOK, nsStatus)
+			return
+		}
+	}
+
+	// Fall back to direct query if we have a cluster registry.
+	if h.registry != nil {
+		client, clientErr := h.registry.GetK8sClient(inst.ClusterID)
+		if clientErr != nil {
+			slog.Warn("Failed to get k8s client for instance pods",
+				logKeyInstanceID, id,
+				"cluster_id", inst.ClusterID,
+				"error", clientErr,
+			)
+			var dbErr *dberrors.DatabaseError
+			if errors.As(clientErr, &dbErr) && errors.Is(dbErr.Unwrap(), dberrors.ErrNotFound) {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "Unknown cluster_id"})
+			} else {
+				c.JSON(http.StatusBadGateway, gin.H{"error": "Failed to connect to cluster"})
+			}
+			return
+		}
+		nsStatus, err := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace)
+		if err != nil {
+			slog.Error("Failed to get namespace status for pods",
+				logKeyInstanceID, id,
+				"namespace", inst.Namespace,
+				"error", err,
+			)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+			return
+		}
+		c.JSON(http.StatusOK, nsStatus)
+		return
+	}
+
+	c.JSON(http.StatusServiceUnavailable, gin.H{"error": "K8s monitoring not configured"})
+}
+
 // checkNamespaceUniqueness checks whether the given namespace is already in use.
 // If it is, it returns true and writes a 409 response with suggestions.
 // The caller should return immediately when this returns true.

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1416,6 +1416,7 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 // @Failure     500 {object} map[string]string
 // @Failure     502 {object} map[string]string
 // @Failure     503 {object} map[string]string
+// @Failure     504 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/pods [get]
 func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
 	id := c.Param("id")
@@ -1448,8 +1449,20 @@ func (h *InstanceHandler) GetInstancePods(c *gin.Context) {
 			}
 			return
 		}
-		nsStatus, nsErr := client.GetNamespaceStatus(c.Request.Context(), inst.Namespace, k8s.StatusOptions{IncludeEvents: true})
+		statusCtx, cancel := context.WithTimeout(c.Request.Context(), 10*time.Second)
+		defer cancel()
+
+		nsStatus, nsErr := client.GetNamespaceStatus(statusCtx, inst.Namespace, k8s.StatusOptions{IncludeEvents: true})
 		if nsErr != nil {
+			if statusCtx.Err() == context.DeadlineExceeded {
+				slog.Error("Timed out getting namespace status for pods",
+					logKeyInstanceID, id,
+					"namespace", inst.Namespace,
+					"error", nsErr,
+				)
+				c.JSON(http.StatusGatewayTimeout, gin.H{"error": "Timed out fetching pod status"})
+				return
+			}
 			slog.Error("Failed to get namespace status for pods",
 				logKeyInstanceID, id,
 				"namespace", inst.Namespace,

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -1413,6 +1413,7 @@ func (h *InstanceHandler) GetInstanceStatus(c *gin.Context) {
 // @Success     200 {object} k8s.NamespaceStatus
 // @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
+// @Failure     500 {object} map[string]string
 // @Failure     502 {object} map[string]string
 // @Failure     503 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/pods [get]

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -236,6 +236,7 @@ func setupDeployRouter(
 		insts.POST("/:id/clean", h.CleanInstance)
 		insts.GET("/:id/deploy-log", h.GetDeployLog)
 		insts.GET("/:id/status", h.GetInstanceStatus)
+		insts.GET("/:id/pods", h.GetInstancePods)
 	}
 	return r
 }
@@ -723,6 +724,127 @@ func TestGetInstanceStatus(t *testing.T) {
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.Equal(t, "stack-stack-a-owner", resp.Namespace)
 		assert.Equal(t, "healthy", resp.Status)
+	})
+}
+
+// ---- GetInstancePods tests ----
+
+func TestGetInstancePods(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns 503 when no registry configured", func(t *testing.T) {
+		t.Parallel()
+
+		instRepo := NewMockStackInstanceRepository()
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+
+		router := setupDeployRouter(t,
+			instRepo, NewMockValueOverrideRepository(),
+			NewMockStackDefinitionRepository(), NewMockChartConfigRepository(),
+			NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(),
+			nil, nil, nil, NewMockDeploymentLogRepository(),
+			"uid-1", "alice", "user",
+		)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/pods", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp["error"], "not configured")
+	})
+
+	t.Run("instance not found returns 404", func(t *testing.T) {
+		t.Parallel()
+
+		router := setupDeployRouter(t,
+			NewMockStackInstanceRepository(), NewMockValueOverrideRepository(),
+			NewMockStackDefinitionRepository(), NewMockChartConfigRepository(),
+			NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(),
+			nil, nil, nil, NewMockDeploymentLogRepository(),
+			"uid-1", "alice", "user",
+		)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/missing/pods", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNotFound, w.Code)
+	})
+
+	t.Run("success with events", func(t *testing.T) {
+		t.Parallel()
+
+		instRepo := NewMockStackInstanceRepository()
+		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+
+		// Create a fake K8s client with a namespace and a pod.
+		cs := fake.NewSimpleClientset(
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "stack-stack-a-owner"},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-abc123",
+					Namespace: "stack-stack-a-owner",
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+		)
+		k8sClient := k8s.NewClientFromInterface(cs)
+		registry := cluster.NewRegistryForTest("default", k8sClient, nil)
+
+		router := setupDeployRouter(t,
+			instRepo, NewMockValueOverrideRepository(),
+			NewMockStackDefinitionRepository(), NewMockChartConfigRepository(),
+			NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(),
+			nil, nil, registry, NewMockDeploymentLogRepository(),
+			"uid-1", "alice", "user",
+		)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/pods", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp k8s.NamespaceStatus
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "stack-stack-a-owner", resp.Namespace)
+	})
+
+	t.Run("unknown cluster_id returns 400", func(t *testing.T) {
+		t.Parallel()
+
+		instRepo := NewMockStackInstanceRepository()
+		inst := seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+		inst.ClusterID = "nonexistent-cluster"
+		require.NoError(t, instRepo.Update(inst))
+
+		// Use NewRegistry with an empty cluster repo so GetClients returns ErrNotFound.
+		registry := cluster.NewRegistry(cluster.RegistryConfig{
+			ClusterRepo: NewMockClusterRepository(),
+		})
+
+		router := setupDeployRouter(t,
+			instRepo, NewMockValueOverrideRepository(),
+			NewMockStackDefinitionRepository(), NewMockChartConfigRepository(),
+			NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(),
+			nil, nil, registry, NewMockDeploymentLogRepository(),
+			"uid-1", "alice", "user",
+		)
+
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances/i1/pods", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+		var resp map[string]string
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Contains(t, resp["error"], "Unknown cluster_id")
 	})
 }
 

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -774,13 +774,14 @@ func TestGetInstancePods(t *testing.T) {
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
 
-	t.Run("success with events", func(t *testing.T) {
+	t.Run("success — returns pod and event data", func(t *testing.T) {
 		t.Parallel()
 
 		instRepo := NewMockStackInstanceRepository()
 		seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
 
-		// Create a fake K8s client with a namespace and a pod.
+		now := time.Now()
+		// Create a fake K8s client with a namespace, a pod, and a warning event.
 		cs := fake.NewSimpleClientset(
 			&corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "stack-stack-a-owner"},
@@ -793,6 +794,22 @@ func TestGetInstancePods(t *testing.T) {
 				Status: corev1.PodStatus{
 					Phase: corev1.PodRunning,
 				},
+			},
+			&corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-abc123.oom",
+					Namespace: "stack-stack-a-owner",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Kind: "Pod",
+					Name: "nginx-abc123",
+				},
+				Type:           "Warning",
+				Reason:         "OOMKilled",
+				Message:        "Container exceeded memory limit",
+				Count:          1,
+				FirstTimestamp: metav1.NewTime(now),
+				LastTimestamp:  metav1.NewTime(now),
 			},
 		)
 		k8sClient := k8s.NewClientFromInterface(cs)
@@ -814,6 +831,9 @@ func TestGetInstancePods(t *testing.T) {
 		var resp k8s.NamespaceStatus
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 		assert.Equal(t, "stack-stack-a-owner", resp.Namespace)
+		require.NotEmpty(t, resp.Events, "expected events from IncludeEvents=true")
+		assert.Equal(t, "Warning", resp.Events[0].Type)
+		assert.Equal(t, "OOMKilled", resp.Events[0].Reason)
 	})
 
 	t.Run("unknown cluster_id returns 400", func(t *testing.T) {

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -329,6 +329,7 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 				instances.POST("/:id/extend", deps.InstanceHandler.ExtendTTL)
 				instances.GET("/:id/deploy-log", deps.InstanceHandler.GetDeployLog)
 				instances.GET("/:id/status", deps.InstanceHandler.GetInstanceStatus)
+				instances.GET("/:id/pods", deps.InstanceHandler.GetInstancePods)
 
 				// Bulk operations (DevOps/Admin only)
 				bulk := instances.Group("/bulk")

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -452,10 +452,8 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string, opts 
 	// Only include Warning events or events from the last hour.
 	var events []PodEvent
 	if opts.IncludeEvents {
-		var maxEventsToScan int64 = 200
 		var eventsTimeoutSeconds int64 = 5
 		eventList, evErr := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-			Limit:          maxEventsToScan,
 			TimeoutSeconds: &eventsTimeoutSeconds,
 		})
 		if evErr != nil {

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -441,7 +441,12 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 	// Fetch namespace events (non-fatal on failure).
 	// Only include Warning events or events from the last hour.
 	var events []PodEvent
-	eventList, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	var maxEventsToScan int64 = 200
+	var eventsTimeoutSeconds int64 = 5
+	eventList, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+		Limit:          maxEventsToScan,
+		TimeoutSeconds: &eventsTimeoutSeconds,
+	})
 	if err != nil {
 		slog.Warn("Failed to list events, skipping", "namespace", namespace, "error", err)
 	} else {

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -287,7 +287,10 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string, opts 
 		ready := true
 		var restarts int32
 		var containerStates []ContainerStateInfo
-		for _, cs := range p.Status.ContainerStatuses {
+		// Include init containers so that init-phase failures (CrashLoopBackOff,
+		// ImagePullBackOff) are visible in the pod health response.
+		allContainers := append(p.Status.InitContainerStatuses, p.Status.ContainerStatuses...) //nolint:gocritic
+		for _, cs := range allContainers {
 			if !cs.Ready {
 				ready = false
 			}

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -187,8 +187,13 @@ type ServiceInfo struct {
 	IngressHosts []string `json:"ingress_hosts,omitempty"`
 }
 
+// StatusOptions controls optional data included in GetNamespaceStatus.
+type StatusOptions struct {
+	IncludeEvents bool
+}
+
 // GetNamespaceStatus queries the K8s API for the status of all resources in a namespace.
-func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*NamespaceStatus, error) {
+func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string, opts StatusOptions) (*NamespaceStatus, error) {
 	exists, err := c.NamespaceExists(ctx, namespace)
 	if err != nil {
 		return nil, fmt.Errorf("check namespace: %w", err)
@@ -305,6 +310,8 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 				state.Reason = cs.State.Terminated.Reason
 				state.Message = cs.State.Terminated.Message
 				state.ExitCode = &cs.State.Terminated.ExitCode
+			} else {
+				state.State = "unknown"
 			}
 			containerStates = append(containerStates, state)
 		}
@@ -438,55 +445,57 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 		}
 	}
 
-	// Fetch namespace events (non-fatal on failure).
+	// Fetch namespace events only when explicitly requested (non-fatal on failure).
 	// Only include Warning events or events from the last hour.
 	var events []PodEvent
-	var maxEventsToScan int64 = 200
-	var eventsTimeoutSeconds int64 = 5
-	eventList, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
-		Limit:          maxEventsToScan,
-		TimeoutSeconds: &eventsTimeoutSeconds,
-	})
-	if err != nil {
-		slog.Warn("Failed to list events, skipping", "namespace", namespace, "error", err)
-	} else {
-		oneHourAgo := time.Now().UTC().Add(-1 * time.Hour)
-		for _, e := range eventList.Items {
-			lastSeen := e.LastTimestamp.Time
-			if lastSeen.IsZero() {
-				lastSeen = e.CreationTimestamp.Time
-			}
-			firstSeen := e.FirstTimestamp.Time
-			if firstSeen.IsZero() {
-				firstSeen = e.CreationTimestamp.Time
-			}
-
-			// Include Warning events regardless of age, or any event from the last hour.
-			if e.Type != "Warning" && lastSeen.Before(oneHourAgo) {
-				continue
-			}
-
-			objectRef := ""
-			if e.InvolvedObject.Kind != "" {
-				objectRef = e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name
-			}
-
-			events = append(events, PodEvent{
-				Type:      e.Type,
-				Reason:    e.Reason,
-				Message:   e.Message,
-				Object:    objectRef,
-				Count:     e.Count,
-				FirstSeen: firstSeen,
-				LastSeen:  lastSeen,
-			})
-		}
-		// Sort by most recent first and cap at 50 to bound payload size.
-		sort.Slice(events, func(i, j int) bool {
-			return events[i].LastSeen.After(events[j].LastSeen)
+	if opts.IncludeEvents {
+		var maxEventsToScan int64 = 200
+		var eventsTimeoutSeconds int64 = 5
+		eventList, evErr := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
+			Limit:          maxEventsToScan,
+			TimeoutSeconds: &eventsTimeoutSeconds,
 		})
-		if len(events) > 50 {
-			events = events[:50]
+		if evErr != nil {
+			slog.Warn("Failed to list events, skipping", "namespace", namespace, "error", evErr)
+		} else {
+			oneHourAgo := time.Now().UTC().Add(-1 * time.Hour)
+			for _, e := range eventList.Items {
+				lastSeen := e.LastTimestamp.Time
+				if lastSeen.IsZero() {
+					lastSeen = e.CreationTimestamp.Time
+				}
+				firstSeen := e.FirstTimestamp.Time
+				if firstSeen.IsZero() {
+					firstSeen = e.CreationTimestamp.Time
+				}
+
+				// Include Warning events regardless of age, or any event from the last hour.
+				if e.Type != "Warning" && lastSeen.Before(oneHourAgo) {
+					continue
+				}
+
+				objectRef := ""
+				if e.InvolvedObject.Kind != "" {
+					objectRef = e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name
+				}
+
+				events = append(events, PodEvent{
+					Type:      e.Type,
+					Reason:    e.Reason,
+					Message:   e.Message,
+					Object:    objectRef,
+					Count:     e.Count,
+					FirstSeen: firstSeen,
+					LastSeen:  lastSeen,
+				})
+			}
+			// Sort by most recent first and cap at 50 to bound payload size.
+			sort.Slice(events, func(i, j int) bool {
+				return events[i].LastSeen.After(events[j].LastSeen)
+			})
+			if len(events) > 50 {
+				events = events[:50]
+			}
 		}
 	}
 

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -453,8 +453,10 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string, opts 
 	var events []PodEvent
 	if opts.IncludeEvents {
 		var eventsTimeoutSeconds int64 = 5
+		var eventListLimit int64 = 200
 		eventList, evErr := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{
 			TimeoutSeconds: &eventsTimeoutSeconds,
+			Limit:          eventListLimit,
 		})
 		if evErr != nil {
 			slog.Warn("Failed to list events, skipping", "namespace", namespace, "error", evErr)

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -160,7 +160,7 @@ type PodInfo struct {
 type ContainerStateInfo struct {
 	ExitCode     *int32 `json:"exit_code,omitempty"`
 	Name         string `json:"name"`
-	State        string `json:"state"`              // "running", "waiting", "terminated"
+	State        string `json:"state"`              // "running", "waiting", "terminated", "unknown"
 	Reason       string `json:"reason,omitempty"`
 	Message      string `json:"message,omitempty"`
 	Image        string `json:"image"`

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -108,6 +108,19 @@ type NamespaceStatus struct {
 	Status      string        `json:"status"`
 	Charts      []ChartStatus `json:"charts"`
 	Ingresses   []IngressInfo `json:"ingresses,omitempty"`
+	Events      []PodEvent    `json:"events,omitempty"`
+}
+
+// PodEvent represents a Kubernetes event associated with a pod or other resource
+// in the namespace.
+type PodEvent struct {
+	FirstSeen time.Time `json:"first_seen"`
+	LastSeen  time.Time `json:"last_seen"`
+	Type      string    `json:"type"`       // "Normal", "Warning"
+	Reason    string    `json:"reason"`
+	Message   string    `json:"message"`
+	Object    string    `json:"object"`     // "Pod/my-pod-xyz"
+	Count     int32     `json:"count"`
 }
 
 // ChartStatus represents the status of a single Helm release's resources.
@@ -131,11 +144,36 @@ type DeploymentInfo struct {
 
 // PodInfo summarizes a Kubernetes Pod.
 type PodInfo struct {
+	StartTime       *time.Time           `json:"start_time,omitempty"`
+	ContainerStates []ContainerStateInfo `json:"container_states"`
+	Conditions      []PodConditionInfo   `json:"conditions,omitempty"`
+	Name            string               `json:"name"`
+	Phase           string               `json:"phase"`
+	Image           string               `json:"image"`
+	NodeName        string               `json:"node_name,omitempty"`
+	RestartCount    int32                `json:"restart_count"`
+	Ready           bool                 `json:"ready"`
+}
+
+// ContainerStateInfo provides detailed state information for a single container
+// within a pod, including its running/waiting/terminated state and reason.
+type ContainerStateInfo struct {
+	ExitCode     *int32 `json:"exit_code,omitempty"`
 	Name         string `json:"name"`
-	Phase        string `json:"phase"`
+	State        string `json:"state"`              // "running", "waiting", "terminated"
+	Reason       string `json:"reason,omitempty"`
+	Message      string `json:"message,omitempty"`
 	Image        string `json:"image"`
 	RestartCount int32  `json:"restart_count"`
 	Ready        bool   `json:"ready"`
+}
+
+// PodConditionInfo represents a single condition reported by the kubelet for a pod.
+type PodConditionInfo struct {
+	Type    string `json:"type"`     // "Ready", "ContainersReady", "Initialized", "PodScheduled"
+	Status  string `json:"status"`   // "True", "False", "Unknown"
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // ServiceInfo summarizes a Kubernetes Service.
@@ -243,11 +281,45 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 
 		ready := true
 		var restarts int32
+		var containerStates []ContainerStateInfo
 		for _, cs := range p.Status.ContainerStatuses {
 			if !cs.Ready {
 				ready = false
 			}
 			restarts += cs.RestartCount
+
+			state := ContainerStateInfo{
+				Name:         cs.Name,
+				RestartCount: cs.RestartCount,
+				Ready:        cs.Ready,
+				Image:        cs.Image,
+			}
+			if cs.State.Running != nil {
+				state.State = "running"
+			} else if cs.State.Waiting != nil {
+				state.State = "waiting"
+				state.Reason = cs.State.Waiting.Reason
+				state.Message = cs.State.Waiting.Message
+			} else if cs.State.Terminated != nil {
+				state.State = "terminated"
+				state.Reason = cs.State.Terminated.Reason
+				state.Message = cs.State.Terminated.Message
+				state.ExitCode = &cs.State.Terminated.ExitCode
+			}
+			containerStates = append(containerStates, state)
+		}
+		if containerStates == nil {
+			containerStates = []ContainerStateInfo{}
+		}
+
+		var conditions []PodConditionInfo
+		for _, cond := range p.Status.Conditions {
+			conditions = append(conditions, PodConditionInfo{
+				Type:    string(cond.Type),
+				Status:  string(cond.Status),
+				Reason:  cond.Reason,
+				Message: cond.Message,
+			})
 		}
 
 		image := ""
@@ -255,13 +327,22 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 			image = p.Spec.Containers[0].Image
 		}
 
-		cr.pods = append(cr.pods, PodInfo{
-			Name:         p.Name,
-			Phase:        string(p.Status.Phase),
-			Ready:        ready,
-			RestartCount: restarts,
-			Image:        image,
-		})
+		podInfo := PodInfo{
+			Name:            p.Name,
+			Phase:           string(p.Status.Phase),
+			Ready:           ready,
+			RestartCount:    restarts,
+			Image:           image,
+			ContainerStates: containerStates,
+			Conditions:      conditions,
+			NodeName:        p.Spec.NodeName,
+		}
+		if p.Status.StartTime != nil {
+			t := p.Status.StartTime.Time
+			podInfo.StartTime = &t
+		}
+
+		cr.pods = append(cr.pods, podInfo)
 	}
 
 	for _, s := range svcList.Items {
@@ -357,6 +438,46 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 		}
 	}
 
+	// Fetch namespace events (non-fatal on failure).
+	// Only include Warning events or events from the last hour.
+	var events []PodEvent
+	eventList, err := c.clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		slog.Warn("Failed to list events, skipping", "namespace", namespace, "error", err)
+	} else {
+		oneHourAgo := time.Now().UTC().Add(-1 * time.Hour)
+		for _, e := range eventList.Items {
+			lastSeen := e.LastTimestamp.Time
+			if lastSeen.IsZero() {
+				lastSeen = e.CreationTimestamp.Time
+			}
+			firstSeen := e.FirstTimestamp.Time
+			if firstSeen.IsZero() {
+				firstSeen = e.CreationTimestamp.Time
+			}
+
+			// Include Warning events regardless of age, or any event from the last hour.
+			if e.Type != "Warning" && lastSeen.Before(oneHourAgo) {
+				continue
+			}
+
+			objectRef := ""
+			if e.InvolvedObject.Kind != "" {
+				objectRef = e.InvolvedObject.Kind + "/" + e.InvolvedObject.Name
+			}
+
+			events = append(events, PodEvent{
+				Type:      e.Type,
+				Reason:    e.Reason,
+				Message:   e.Message,
+				Object:    objectRef,
+				Count:     e.Count,
+				FirstSeen: firstSeen,
+				LastSeen:  lastSeen,
+			})
+		}
+	}
+
 	// Build chart statuses.
 	var chartStatuses []ChartStatus
 	for release, cr := range charts {
@@ -384,6 +505,7 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 		Status:      overall,
 		Charts:      chartStatuses,
 		Ingresses:   ingresses,
+		Events:      events,
 		LastChecked: time.Now().UTC(),
 	}, nil
 }

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -116,10 +116,10 @@ type NamespaceStatus struct {
 type PodEvent struct {
 	FirstSeen time.Time `json:"first_seen"`
 	LastSeen  time.Time `json:"last_seen"`
-	Type      string    `json:"type"`       // "Normal", "Warning"
+	Type      string    `json:"type"` // "Normal", "Warning"
 	Reason    string    `json:"reason"`
 	Message   string    `json:"message"`
-	Object    string    `json:"object"`     // "Pod/my-pod-xyz"
+	Object    string    `json:"object"` // "Pod/my-pod-xyz"
 	Count     int32     `json:"count"`
 }
 
@@ -160,7 +160,7 @@ type PodInfo struct {
 type ContainerStateInfo struct {
 	ExitCode     *int32 `json:"exit_code,omitempty"`
 	Name         string `json:"name"`
-	State        string `json:"state"`              // "running", "waiting", "terminated", "unknown"
+	State        string `json:"state"` // "running", "waiting", "terminated", "unknown"
 	Reason       string `json:"reason,omitempty"`
 	Message      string `json:"message,omitempty"`
 	Image        string `json:"image"`
@@ -170,8 +170,8 @@ type ContainerStateInfo struct {
 
 // PodConditionInfo represents a single condition reported by the kubelet for a pod.
 type PodConditionInfo struct {
-	Type    string `json:"type"`     // "Ready", "ContainersReady", "Initialized", "PodScheduled"
-	Status  string `json:"status"`   // "True", "False", "Unknown"
+	Type    string `json:"type"`   // "Ready", "ContainersReady", "Initialized", "PodScheduled"
+	Status  string `json:"status"` // "True", "False", "Unknown"
 	Reason  string `json:"reason,omitempty"`
 	Message string `json:"message,omitempty"`
 }
@@ -312,7 +312,8 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string, opts 
 				state.State = "terminated"
 				state.Reason = cs.State.Terminated.Reason
 				state.Message = cs.State.Terminated.Message
-				state.ExitCode = &cs.State.Terminated.ExitCode
+				exitCode := cs.State.Terminated.ExitCode
+				state.ExitCode = &exitCode
 			} else {
 				state.State = "unknown"
 			}

--- a/backend/internal/k8s/status.go
+++ b/backend/internal/k8s/status.go
@@ -476,6 +476,13 @@ func (c *Client) GetNamespaceStatus(ctx context.Context, namespace string) (*Nam
 				LastSeen:  lastSeen,
 			})
 		}
+		// Sort by most recent first and cap at 50 to bound payload size.
+		sort.Slice(events, func(i, j int) bool {
+			return events[i].LastSeen.After(events[j].LastSeen)
+		})
+		if len(events) > 50 {
+			events = events[:50]
+		}
 	}
 
 	// Build chart statuses.

--- a/backend/internal/k8s/status_test.go
+++ b/backend/internal/k8s/status_test.go
@@ -21,7 +21,7 @@ func TestGetNamespaceStatus_NotFound(t *testing.T) {
 	cs := fake.NewSimpleClientset()
 	client := NewClientFromInterface(cs)
 
-	status, err := client.GetNamespaceStatus(context.Background(), "nonexistent")
+	status, err := client.GetNamespaceStatus(context.Background(), "nonexistent", StatusOptions{})
 	assert.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, StatusNotFound, status.Status)
@@ -37,7 +37,7 @@ func TestGetNamespaceStatus_EmptyNamespace(t *testing.T) {
 	})
 	client := NewClientFromInterface(cs)
 
-	status, err := client.GetNamespaceStatus(context.Background(), "empty-ns")
+	status, err := client.GetNamespaceStatus(context.Background(), "empty-ns", StatusOptions{})
 	assert.NoError(t, err)
 	require.NotNil(t, status)
 	assert.Equal(t, StatusHealthy, status.Status)
@@ -107,7 +107,7 @@ func TestGetNamespaceStatus_WithHealthyResources(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -167,7 +167,7 @@ func TestGetNamespaceStatus_MultipleReleases(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -211,7 +211,7 @@ func TestGetNamespaceStatus_DegradedPod(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -243,7 +243,7 @@ func TestGetNamespaceStatus_FailedPod(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -363,7 +363,7 @@ func TestGetNamespaceStatus_WithIngress(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -423,7 +423,7 @@ func TestGetNamespaceStatus_WithIngressNoTLS(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -468,7 +468,7 @@ func TestGetNamespaceStatus_LoadBalancerExternalIP(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -510,7 +510,7 @@ func TestGetNamespaceStatus_LoadBalancerHostname(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -544,7 +544,7 @@ func TestGetNamespaceStatus_NodePortService(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -581,7 +581,7 @@ func TestGetNamespaceStatus_ProgressingDeployment(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -614,7 +614,7 @@ func TestGetNamespaceStatus_UnmanagedResources(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -649,7 +649,7 @@ func TestGetNamespaceStatus_HelmShReleaseLabel(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -1021,7 +1021,7 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -1097,7 +1097,7 @@ func TestGetNamespaceStatus_EmptyContainerStates(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -1155,7 +1155,7 @@ func TestGetNamespaceStatus_WithEvents(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{IncludeEvents: true})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)
@@ -1214,7 +1214,7 @@ func TestGetNamespaceStatus_PodStartTimeAndNodeName(t *testing.T) {
 	)
 
 	client := NewClientFromInterface(cs)
-	status, err := client.GetNamespaceStatus(context.Background(), ns)
+	status, err := client.GetNamespaceStatus(context.Background(), ns, StatusOptions{})
 
 	assert.NoError(t, err)
 	require.NotNil(t, status)

--- a/backend/internal/k8s/status_test.go
+++ b/backend/internal/k8s/status_test.go
@@ -949,3 +949,279 @@ func TestSortNodeStatuses(t *testing.T) {
 	assert.Equal(t, "bravo", nodes[1].Name)
 	assert.Equal(t, "charlie", nodes[2].Name)
 }
+
+func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
+	t.Parallel()
+
+	ns := "container-states-ns"
+	exitCode := int32(137)
+
+	cs := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "multi-container-pod",
+				Namespace: ns,
+				Labels:    map[string]string{"app.kubernetes.io/instance": "multi-release"},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "node-1",
+				Containers: []corev1.Container{
+					{Name: "app", Image: "myimage:v1"},
+					{Name: "sidecar", Image: "sidecar:v1"},
+					{Name: "init-done", Image: "init:v1"},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				StartTime: &metav1.Time{Time: metav1.Now().Add(-10 * 60 * 1000000000)},
+				Conditions: []corev1.PodCondition{
+					{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady", Message: "sidecar not ready"},
+					{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+				},
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:         "app",
+						Ready:        true,
+						RestartCount: 0,
+						Image:        "myimage:v1",
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{},
+						},
+					},
+					{
+						Name:         "sidecar",
+						Ready:        false,
+						RestartCount: 3,
+						Image:        "sidecar:v1",
+						State: corev1.ContainerState{
+							Waiting: &corev1.ContainerStateWaiting{
+								Reason:  "CrashLoopBackOff",
+								Message: "back-off 5m0s restarting",
+							},
+						},
+					},
+					{
+						Name:         "init-done",
+						Ready:        true,
+						RestartCount: 1,
+						Image:        "init:v1",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "OOMKilled",
+								Message:  "out of memory",
+								ExitCode: exitCode,
+							},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	client := NewClientFromInterface(cs)
+	status, err := client.GetNamespaceStatus(context.Background(), ns)
+
+	assert.NoError(t, err)
+	require.NotNil(t, status)
+	require.Len(t, status.Charts, 1)
+	require.Len(t, status.Charts[0].Pods, 1)
+
+	pod := status.Charts[0].Pods[0]
+	assert.Equal(t, "multi-container-pod", pod.Name)
+	assert.Equal(t, "Running", pod.Phase)
+	assert.False(t, pod.Ready)
+	assert.Equal(t, int32(4), pod.RestartCount) // 0 + 3 + 1
+	assert.Equal(t, "node-1", pod.NodeName)
+	assert.NotNil(t, pod.StartTime)
+
+	// Container states
+	require.Len(t, pod.ContainerStates, 3)
+
+	// Running container
+	assert.Equal(t, "app", pod.ContainerStates[0].Name)
+	assert.Equal(t, "running", pod.ContainerStates[0].State)
+	assert.True(t, pod.ContainerStates[0].Ready)
+	assert.Equal(t, int32(0), pod.ContainerStates[0].RestartCount)
+	assert.Nil(t, pod.ContainerStates[0].ExitCode)
+
+	// Waiting container
+	assert.Equal(t, "sidecar", pod.ContainerStates[1].Name)
+	assert.Equal(t, "waiting", pod.ContainerStates[1].State)
+	assert.Equal(t, "CrashLoopBackOff", pod.ContainerStates[1].Reason)
+	assert.Equal(t, "back-off 5m0s restarting", pod.ContainerStates[1].Message)
+	assert.False(t, pod.ContainerStates[1].Ready)
+	assert.Equal(t, int32(3), pod.ContainerStates[1].RestartCount)
+	assert.Nil(t, pod.ContainerStates[1].ExitCode)
+
+	// Terminated container
+	assert.Equal(t, "init-done", pod.ContainerStates[2].Name)
+	assert.Equal(t, "terminated", pod.ContainerStates[2].State)
+	assert.Equal(t, "OOMKilled", pod.ContainerStates[2].Reason)
+	assert.Equal(t, "out of memory", pod.ContainerStates[2].Message)
+	require.NotNil(t, pod.ContainerStates[2].ExitCode)
+	assert.Equal(t, int32(137), *pod.ContainerStates[2].ExitCode)
+
+	// Pod conditions
+	require.Len(t, pod.Conditions, 2)
+	assert.Equal(t, "Ready", pod.Conditions[0].Type)
+	assert.Equal(t, "False", pod.Conditions[0].Status)
+	assert.Equal(t, "ContainersNotReady", pod.Conditions[0].Reason)
+	assert.Equal(t, "sidecar not ready", pod.Conditions[0].Message)
+	assert.Equal(t, "Initialized", pod.Conditions[1].Type)
+	assert.Equal(t, "True", pod.Conditions[1].Status)
+}
+
+func TestGetNamespaceStatus_EmptyContainerStates(t *testing.T) {
+	t.Parallel()
+
+	ns := "empty-cs-ns"
+
+	cs := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pending-pod",
+				Namespace: ns,
+				Labels:    map[string]string{"app.kubernetes.io/instance": "pending-release"},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "app", Image: "myimage:v1"}},
+			},
+			Status: corev1.PodStatus{
+				Phase:             corev1.PodPending,
+				ContainerStatuses: nil,
+			},
+		},
+	)
+
+	client := NewClientFromInterface(cs)
+	status, err := client.GetNamespaceStatus(context.Background(), ns)
+
+	assert.NoError(t, err)
+	require.NotNil(t, status)
+	require.Len(t, status.Charts, 1)
+	require.Len(t, status.Charts[0].Pods, 1)
+
+	pod := status.Charts[0].Pods[0]
+	assert.Equal(t, "Pending", pod.Phase)
+	// Should be empty slice, not nil (for consistent JSON serialization).
+	assert.NotNil(t, pod.ContainerStates)
+	assert.Empty(t, pod.ContainerStates)
+	assert.Nil(t, pod.Conditions)
+	assert.Nil(t, pod.StartTime)
+}
+
+func TestGetNamespaceStatus_WithEvents(t *testing.T) {
+	t.Parallel()
+
+	ns := "events-ns"
+
+	cs := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "warning-event",
+				Namespace: ns,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "my-pod-xyz",
+			},
+			Type:           "Warning",
+			Reason:         "BackOff",
+			Message:        "Back-off restarting failed container",
+			Count:          5,
+			FirstTimestamp: metav1.Now(),
+			LastTimestamp:  metav1.Now(),
+		},
+		&corev1.Event{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "normal-event",
+				Namespace: ns,
+			},
+			InvolvedObject: corev1.ObjectReference{
+				Kind: "Pod",
+				Name: "my-pod-xyz",
+			},
+			Type:           "Normal",
+			Reason:         "Pulled",
+			Message:        "Successfully pulled image",
+			Count:          1,
+			FirstTimestamp: metav1.Now(),
+			LastTimestamp:  metav1.Now(),
+		},
+	)
+
+	client := NewClientFromInterface(cs)
+	status, err := client.GetNamespaceStatus(context.Background(), ns)
+
+	assert.NoError(t, err)
+	require.NotNil(t, status)
+
+	// Both events should be included (Warning always, Normal within the last hour).
+	require.Len(t, status.Events, 2)
+
+	// Find the warning event.
+	var warningEvent *PodEvent
+	for i := range status.Events {
+		if status.Events[i].Type == "Warning" {
+			warningEvent = &status.Events[i]
+			break
+		}
+	}
+	require.NotNil(t, warningEvent)
+	assert.Equal(t, "BackOff", warningEvent.Reason)
+	assert.Equal(t, "Back-off restarting failed container", warningEvent.Message)
+	assert.Equal(t, "Pod/my-pod-xyz", warningEvent.Object)
+	assert.Equal(t, int32(5), warningEvent.Count)
+}
+
+func TestGetNamespaceStatus_PodStartTimeAndNodeName(t *testing.T) {
+	t.Parallel()
+
+	ns := "starttime-ns"
+	startTime := metav1.Now()
+
+	cs := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "timed-pod",
+				Namespace: ns,
+				Labels:    map[string]string{"app.kubernetes.io/instance": "timed-release"},
+			},
+			Spec: corev1.PodSpec{
+				NodeName:   "worker-node-1",
+				Containers: []corev1.Container{{Name: "app", Image: "myimage:v2"}},
+			},
+			Status: corev1.PodStatus{
+				Phase:     corev1.PodRunning,
+				StartTime: &startTime,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "app",
+						Ready: true,
+						Image: "myimage:v2",
+						State: corev1.ContainerState{
+							Running: &corev1.ContainerStateRunning{},
+						},
+					},
+				},
+			},
+		},
+	)
+
+	client := NewClientFromInterface(cs)
+	status, err := client.GetNamespaceStatus(context.Background(), ns)
+
+	assert.NoError(t, err)
+	require.NotNil(t, status)
+	require.Len(t, status.Charts, 1)
+	require.Len(t, status.Charts[0].Pods, 1)
+
+	pod := status.Charts[0].Pods[0]
+	assert.Equal(t, "worker-node-1", pod.NodeName)
+	require.NotNil(t, pod.StartTime)
+	assert.Equal(t, startTime.Time, *pod.StartTime)
+}

--- a/backend/internal/k8s/status_test.go
+++ b/backend/internal/k8s/status_test.go
@@ -967,10 +967,12 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 			},
 			Spec: corev1.PodSpec{
 				NodeName: "node-1",
+				InitContainers: []corev1.Container{
+					{Name: "init-done", Image: "init:v1"},
+				},
 				Containers: []corev1.Container{
 					{Name: "app", Image: "myimage:v1"},
 					{Name: "sidecar", Image: "sidecar:v1"},
-					{Name: "init-done", Image: "init:v1"},
 				},
 			},
 			Status: corev1.PodStatus{
@@ -979,6 +981,21 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 				Conditions: []corev1.PodCondition{
 					{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady", Message: "sidecar not ready"},
 					{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},
+				},
+				InitContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:         "init-done",
+						Ready:        true,
+						RestartCount: 1,
+						Image:        "init:v1",
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason:   "OOMKilled",
+								Message:  "out of memory",
+								ExitCode: exitCode,
+							},
+						},
+					},
 				},
 				ContainerStatuses: []corev1.ContainerStatus{
 					{
@@ -999,19 +1016,6 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 							Waiting: &corev1.ContainerStateWaiting{
 								Reason:  "CrashLoopBackOff",
 								Message: "back-off 5m0s restarting",
-							},
-						},
-					},
-					{
-						Name:         "init-done",
-						Ready:        true,
-						RestartCount: 1,
-						Image:        "init:v1",
-						State: corev1.ContainerState{
-							Terminated: &corev1.ContainerStateTerminated{
-								Reason:   "OOMKilled",
-								Message:  "out of memory",
-								ExitCode: exitCode,
 							},
 						},
 					},
@@ -1039,29 +1043,29 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 	// Container states
 	require.Len(t, pod.ContainerStates, 3)
 
-	// Running container
-	assert.Equal(t, "app", pod.ContainerStates[0].Name)
-	assert.Equal(t, "running", pod.ContainerStates[0].State)
-	assert.True(t, pod.ContainerStates[0].Ready)
-	assert.Equal(t, int32(0), pod.ContainerStates[0].RestartCount)
-	assert.Nil(t, pod.ContainerStates[0].ExitCode)
+	// Init container (terminated — appears first because init statuses are prepended)
+	assert.Equal(t, "init-done", pod.ContainerStates[0].Name)
+	assert.Equal(t, "terminated", pod.ContainerStates[0].State)
+	assert.Equal(t, "OOMKilled", pod.ContainerStates[0].Reason)
+	assert.Equal(t, "out of memory", pod.ContainerStates[0].Message)
+	require.NotNil(t, pod.ContainerStates[0].ExitCode)
+	assert.Equal(t, int32(137), *pod.ContainerStates[0].ExitCode)
 
-	// Waiting container
-	assert.Equal(t, "sidecar", pod.ContainerStates[1].Name)
-	assert.Equal(t, "waiting", pod.ContainerStates[1].State)
-	assert.Equal(t, "CrashLoopBackOff", pod.ContainerStates[1].Reason)
-	assert.Equal(t, "back-off 5m0s restarting", pod.ContainerStates[1].Message)
-	assert.False(t, pod.ContainerStates[1].Ready)
-	assert.Equal(t, int32(3), pod.ContainerStates[1].RestartCount)
+	// Running container
+	assert.Equal(t, "app", pod.ContainerStates[1].Name)
+	assert.Equal(t, "running", pod.ContainerStates[1].State)
+	assert.True(t, pod.ContainerStates[1].Ready)
+	assert.Equal(t, int32(0), pod.ContainerStates[1].RestartCount)
 	assert.Nil(t, pod.ContainerStates[1].ExitCode)
 
-	// Terminated container
-	assert.Equal(t, "init-done", pod.ContainerStates[2].Name)
-	assert.Equal(t, "terminated", pod.ContainerStates[2].State)
-	assert.Equal(t, "OOMKilled", pod.ContainerStates[2].Reason)
-	assert.Equal(t, "out of memory", pod.ContainerStates[2].Message)
-	require.NotNil(t, pod.ContainerStates[2].ExitCode)
-	assert.Equal(t, int32(137), *pod.ContainerStates[2].ExitCode)
+	// Waiting container
+	assert.Equal(t, "sidecar", pod.ContainerStates[2].Name)
+	assert.Equal(t, "waiting", pod.ContainerStates[2].State)
+	assert.Equal(t, "CrashLoopBackOff", pod.ContainerStates[2].Reason)
+	assert.Equal(t, "back-off 5m0s restarting", pod.ContainerStates[2].Message)
+	assert.False(t, pod.ContainerStates[2].Ready)
+	assert.Equal(t, int32(3), pod.ContainerStates[2].RestartCount)
+	assert.Nil(t, pod.ContainerStates[2].ExitCode)
 
 	// Pod conditions
 	require.Len(t, pod.Conditions, 2)

--- a/backend/internal/k8s/status_test.go
+++ b/backend/internal/k8s/status_test.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -974,7 +975,7 @@ func TestGetNamespaceStatus_ContainerStates(t *testing.T) {
 			},
 			Status: corev1.PodStatus{
 				Phase: corev1.PodRunning,
-				StartTime: &metav1.Time{Time: metav1.Now().Add(-10 * 60 * 1000000000)},
+				StartTime: &metav1.Time{Time: metav1.Now().Add(-10 * time.Minute)},
 				Conditions: []corev1.PodCondition{
 					{Type: corev1.PodReady, Status: corev1.ConditionFalse, Reason: "ContainersNotReady", Message: "sidecar not ready"},
 					{Type: corev1.PodInitialized, Status: corev1.ConditionTrue},

--- a/backend/internal/k8s/watcher.go
+++ b/backend/internal/k8s/watcher.go
@@ -217,6 +217,12 @@ func statusDetailsChanged(prev, curr *NamespaceStatus) bool {
 		}
 	}
 
+	// Check total restart counts — catches CrashLoopBackOff increments
+	// even when phase/ready remain unchanged.
+	if totalRestarts(prev) != totalRestarts(curr) {
+		return true
+	}
+
 	// Check ready replica counts on deployments.
 	prevReady := countReadyReplicas(prev)
 	currReady := countReadyReplicas(curr)
@@ -236,6 +242,17 @@ func countPodStates(ns *NamespaceStatus) map[string]int {
 		}
 	}
 	return counts
+}
+
+// totalRestarts sums restart counts across all pods.
+func totalRestarts(ns *NamespaceStatus) int32 {
+	var total int32
+	for _, chart := range ns.Charts {
+		for _, pod := range chart.Pods {
+			total += pod.RestartCount
+		}
+	}
+	return total
 }
 
 // countReadyReplicas sums ready replicas across all deployments.

--- a/backend/internal/k8s/watcher.go
+++ b/backend/internal/k8s/watcher.go
@@ -139,7 +139,7 @@ func (w *Watcher) poll(ctx context.Context) {
 
 		// Use a per-namespace timeout to avoid one slow check blocking others.
 		checkCtx, checkCancel := context.WithTimeout(ctx, 5*time.Second)
-		nsStatus, err := client.GetNamespaceStatus(checkCtx, inst.Namespace)
+		nsStatus, err := client.GetNamespaceStatus(checkCtx, inst.Namespace, StatusOptions{})
 		checkCancel()
 
 		if err != nil {

--- a/backend/internal/k8s/watcher.go
+++ b/backend/internal/k8s/watcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -263,19 +264,26 @@ func totalRestarts(ns *NamespaceStatus) int32 {
 	return total
 }
 
-// containerStateDigest builds a comparable string from container states
-// so that reason/exit-code transitions trigger broadcasts even when
-// phase, ready count, and restart count remain unchanged.
+// containerStateDigest builds a deterministic, order-independent string from
+// all container states so that state/reason/exit-code transitions trigger
+// broadcasts even when phase, ready count, and restart count remain unchanged.
+// Entries are sorted by pod name + container name for stability.
 func containerStateDigest(ns *NamespaceStatus) string {
-	var b strings.Builder
+	var entries []string
 	for _, chart := range ns.Charts {
 		for _, pod := range chart.Pods {
 			for _, cs := range pod.ContainerStates {
-				fmt.Fprintf(&b, "%s:%s:%s:%d;", cs.Name, cs.State, cs.Reason, cs.RestartCount)
+				exitCode := int32(0)
+				if cs.ExitCode != nil {
+					exitCode = *cs.ExitCode
+				}
+				entries = append(entries, fmt.Sprintf("%s/%s:%s:%s:%d:%d",
+					pod.Name, cs.Name, cs.State, cs.Reason, exitCode, cs.RestartCount))
 			}
 		}
 	}
-	return b.String()
+	sort.Strings(entries)
+	return strings.Join(entries, ";")
 }
 
 // countReadyReplicas sums ready replicas across all deployments.

--- a/backend/internal/k8s/watcher.go
+++ b/backend/internal/k8s/watcher.go
@@ -2,7 +2,9 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -223,6 +225,12 @@ func statusDetailsChanged(prev, curr *NamespaceStatus) bool {
 		return true
 	}
 
+	// Check container state digests — catches reason transitions like
+	// ErrImagePull → ImagePullBackOff where phase/ready/restarts stay the same.
+	if containerStateDigest(prev) != containerStateDigest(curr) {
+		return true
+	}
+
 	// Check ready replica counts on deployments.
 	prevReady := countReadyReplicas(prev)
 	currReady := countReadyReplicas(curr)
@@ -253,6 +261,21 @@ func totalRestarts(ns *NamespaceStatus) int32 {
 		}
 	}
 	return total
+}
+
+// containerStateDigest builds a comparable string from container states
+// so that reason/exit-code transitions trigger broadcasts even when
+// phase, ready count, and restart count remain unchanged.
+func containerStateDigest(ns *NamespaceStatus) string {
+	var b strings.Builder
+	for _, chart := range ns.Charts {
+		for _, pod := range chart.Pods {
+			for _, cs := range pod.ContainerStates {
+				fmt.Fprintf(&b, "%s:%s:%s:%d;", cs.Name, cs.State, cs.Reason, cs.RestartCount)
+			}
+		}
+	}
+	return b.String()
 }
 
 // countReadyReplicas sums ready replicas across all deployments.

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -598,6 +598,17 @@ describe('instanceService', () => {
     expect(result).toEqual(status);
   });
 
+  it('getPods sends GET to pods endpoint', async () => {
+    const api = mockApi;
+    const podStatus = { namespace: 'stack-test', status: 'healthy', charts: [], last_checked: '2024-01-01T00:00:00Z' };
+    api.get.mockResolvedValueOnce(mockResponse(podStatus));
+
+    const result = await instanceService.getPods('i1');
+
+    expect(api.get).toHaveBeenCalledWith('/api/v1/stack-instances/i1/pods');
+    expect(result).toEqual(podStatus);
+  });
+
   it('extend sends POST with ttl_minutes when provided', async () => {
     const api = mockApi;
     const extended = { id: 'i1', ttl_minutes: 120 };
@@ -1851,6 +1862,11 @@ describe('instanceService — error paths', () => {
   it('getStatus throws on error', async () => {
     mockApi.get.mockRejectedValueOnce(new Error('Unavailable'));
     await expect(instanceService.getStatus('i1')).rejects.toThrow('Unavailable');
+  });
+
+  it('getPods throws on error', async () => {
+    mockApi.get.mockRejectedValueOnce(new Error('Pod fetch failed'));
+    await expect(instanceService.getPods('i1')).rejects.toThrow('Pod fetch failed');
   });
 
   it('extend throws on error', async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1027,6 +1027,21 @@ export const instanceService = {
     }
   },
   /**
+   * Get detailed pod health status including container states and events.
+   * @param id - Instance ID
+   * @returns Namespace status with pod details
+   * @see GET /api/v1/stack-instances/:id/pods
+   */
+  getPods: async (id: string): Promise<NamespaceStatus> => {
+    try {
+      const response = await api.get<NamespaceStatus>(`/api/v1/stack-instances/${id}/pods`);
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch pod status:', error);
+      throw error;
+    }
+  },
+  /**
    * Extend the TTL of a running instance.
    * @param id - Instance ID
    * @param ttlMinutes - New TTL in minutes (uses default if omitted)

--- a/frontend/src/components/PodStatusDisplay/__tests__/PodStatusDisplay.test.tsx
+++ b/frontend/src/components/PodStatusDisplay/__tests__/PodStatusDisplay.test.tsx
@@ -28,6 +28,7 @@ const mockStatus: NamespaceStatus = {
           ready: true,
           restart_count: 0,
           image: 'myimage:v1',
+          container_states: [],
         },
       ],
       services: [
@@ -89,6 +90,7 @@ describe('PodStatusDisplay', () => {
               ready: true,
               restart_count: 10,
               image: 'myimage:v1',
+              container_states: [],
             },
           ],
         },

--- a/frontend/src/components/PodStatusDisplay/__tests__/PodStatusDisplay.test.tsx
+++ b/frontend/src/components/PodStatusDisplay/__tests__/PodStatusDisplay.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import PodStatusDisplay from '../index';
 import type { NamespaceStatus } from '../../../types';
 
@@ -96,12 +97,222 @@ describe('PodStatusDisplay', () => {
     render(<PodStatusDisplay status={highRestartStatus} />);
     const restartText = screen.getByText('10');
     expect(restartText).toBeInTheDocument();
-    // The Typography has color="error" when restart_count > 5.
-    // MUI applies the error color via Emotion CSS-in-JS. The generated class
-    // differs from the non-error variant, so we verify the element does NOT
-    // share the same class as a normal "text.primary" Typography. We also
-    // verify the computed style contains the theme error color (#d32f2f).
     const normalText = screen.getByText('crash-pod');
     expect(restartText.className).not.toBe(normalText.className);
+  });
+
+  describe('Container States', () => {
+    it('shows expand button when pod has container states with reasons', () => {
+      const statusWithContainers: NamespaceStatus = {
+        ...mockStatus,
+        charts: [
+          {
+            ...mockStatus.charts[0],
+            pods: [
+              {
+                name: 'crash-pod',
+                phase: 'Running',
+                ready: false,
+                restart_count: 5,
+                image: 'myimage:v1',
+                container_states: [
+                  {
+                    name: 'main',
+                    state: 'waiting',
+                    reason: 'CrashLoopBackOff',
+                    message: 'back-off 5m0s restarting',
+                    restart_count: 5,
+                    ready: false,
+                    image: 'myimage:v1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusWithContainers} />);
+      expect(screen.getByRole('button', { name: 'Expand container details' })).toBeInTheDocument();
+    });
+
+    it('shows container state details when expanded', async () => {
+      const user = userEvent.setup();
+      const statusWithContainers: NamespaceStatus = {
+        ...mockStatus,
+        charts: [
+          {
+            ...mockStatus.charts[0],
+            pods: [
+              {
+                name: 'crash-pod',
+                phase: 'Running',
+                ready: false,
+                restart_count: 5,
+                image: 'myimage:v1',
+                container_states: [
+                  {
+                    name: 'main',
+                    state: 'waiting',
+                    reason: 'CrashLoopBackOff',
+                    message: 'back-off 5m0s restarting',
+                    restart_count: 5,
+                    ready: false,
+                    image: 'myimage:v1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusWithContainers} />);
+      await user.click(screen.getByRole('button', { name: 'Expand container details' }));
+      expect(screen.getByText('Container States')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+      expect(screen.getByText('CrashLoopBackOff')).toBeInTheDocument();
+      expect(screen.getByText('waiting')).toBeInTheDocument();
+    });
+
+    it('shows exit code for terminated containers', async () => {
+      const user = userEvent.setup();
+      const statusWithTerminated: NamespaceStatus = {
+        ...mockStatus,
+        charts: [
+          {
+            ...mockStatus.charts[0],
+            pods: [
+              {
+                name: 'oom-pod',
+                phase: 'Running',
+                ready: false,
+                restart_count: 3,
+                image: 'myimage:v1',
+                container_states: [
+                  {
+                    name: 'worker',
+                    state: 'terminated',
+                    reason: 'OOMKilled',
+                    restart_count: 3,
+                    ready: false,
+                    image: 'myimage:v1',
+                    exit_code: 137,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusWithTerminated} />);
+      await user.click(screen.getByRole('button', { name: 'Expand container details' }));
+      expect(screen.getByText('OOMKilled')).toBeInTheDocument();
+      expect(screen.getByText('(exit code: 137)')).toBeInTheDocument();
+    });
+
+    it('does not show expand button when container states have no reasons', () => {
+      const statusNoReasons: NamespaceStatus = {
+        ...mockStatus,
+        charts: [
+          {
+            ...mockStatus.charts[0],
+            pods: [
+              {
+                name: 'healthy-pod',
+                phase: 'Running',
+                ready: true,
+                restart_count: 0,
+                image: 'myimage:v1',
+                container_states: [
+                  {
+                    name: 'main',
+                    state: 'running',
+                    restart_count: 0,
+                    ready: true,
+                    image: 'myimage:v1',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusNoReasons} />);
+      expect(screen.queryByRole('button', { name: 'Expand container details' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Warning Events', () => {
+    it('shows warning events section when events exist', () => {
+      const statusWithEvents: NamespaceStatus = {
+        ...mockStatus,
+        events: [
+          {
+            type: 'Warning',
+            reason: 'FailedScheduling',
+            message: 'Insufficient cpu',
+            object: 'pod/my-pod',
+            count: 3,
+            first_seen: '2026-03-19T09:00:00Z',
+            last_seen: '2026-03-19T10:00:00Z',
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusWithEvents} />);
+      expect(screen.getByText('Recent Warnings')).toBeInTheDocument();
+      expect(screen.getByText('FailedScheduling')).toBeInTheDocument();
+      expect(screen.getByText('Insufficient cpu')).toBeInTheDocument();
+      expect(screen.getByText('(pod/my-pod, x3)')).toBeInTheDocument();
+    });
+
+    it('does not show events section when no warning events', () => {
+      const statusOnlyNormal: NamespaceStatus = {
+        ...mockStatus,
+        events: [
+          {
+            type: 'Normal',
+            reason: 'Scheduled',
+            message: 'Successfully assigned',
+            object: 'pod/my-pod',
+            count: 1,
+            first_seen: '2026-03-19T09:00:00Z',
+            last_seen: '2026-03-19T10:00:00Z',
+          },
+        ],
+      };
+      render(<PodStatusDisplay status={statusOnlyNormal} />);
+      expect(screen.queryByText('Recent Warnings')).not.toBeInTheDocument();
+    });
+
+    it('does not show events section when events array is empty', () => {
+      const statusEmptyEvents: NamespaceStatus = {
+        ...mockStatus,
+        events: [],
+      };
+      render(<PodStatusDisplay status={statusEmptyEvents} />);
+      expect(screen.queryByText('Recent Warnings')).not.toBeInTheDocument();
+    });
+
+    it('limits warning events to 10', () => {
+      const manyEvents = Array.from({ length: 15 }, (_, i) => ({
+        type: 'Warning' as const,
+        reason: `Reason${i}`,
+        message: `Message ${i}`,
+        object: `pod/pod-${i}`,
+        count: 1,
+        first_seen: '2026-03-19T09:00:00Z',
+        last_seen: '2026-03-19T10:00:00Z',
+      }));
+      const statusManyEvents: NamespaceStatus = {
+        ...mockStatus,
+        events: manyEvents,
+      };
+      render(<PodStatusDisplay status={statusManyEvents} />);
+      expect(screen.getByText('Recent Warnings')).toBeInTheDocument();
+      // Should show first 10
+      expect(screen.getByText('Reason0')).toBeInTheDocument();
+      expect(screen.getByText('Reason9')).toBeInTheDocument();
+      // Should not show 11th+
+      expect(screen.queryByText('Reason10')).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/src/components/PodStatusDisplay/index.tsx
+++ b/frontend/src/components/PodStatusDisplay/index.tsx
@@ -33,8 +33,11 @@ const getContainerStateColor = (state: ContainerStateInfo): 'success' | 'warning
 };
 
 const hasContainerDetails = (pod: PodInfo): boolean => {
+  if (pod.restart_count > 0) return true;
   if (!pod.container_states || pod.container_states.length === 0) return false;
-  return pod.container_states.some((cs) => cs.reason);
+  return pod.container_states.some(
+    (cs) => cs.reason || cs.message || cs.exit_code !== undefined || cs.state !== 'running'
+  );
 };
 
 interface PodRowProps {
@@ -94,7 +97,7 @@ const PodRow = ({ pod, podPhaseColor }: PodRowProps) => {
                 <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}>
                   Container States
                 </Typography>
-                {pod.container_states!.map((cs) => (
+                {(pod.container_states || []).map((cs) => (
                   <Box key={cs.name} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
                     <Typography variant="caption" sx={{ fontFamily: 'monospace', minWidth: 100 }}>
                       {cs.name}

--- a/frontend/src/components/PodStatusDisplay/index.tsx
+++ b/frontend/src/components/PodStatusDisplay/index.tsx
@@ -161,7 +161,9 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
     }
   };
 
-  const warningEvents = (status.events || []).filter((e) => e.type === 'Warning');
+  const warningEvents = (status.events || [])
+    .filter((e) => e.type === 'Warning')
+    .sort((a, b) => new Date(b.last_seen).getTime() - new Date(a.last_seen).getTime());
 
   return (
     <Box>

--- a/frontend/src/components/PodStatusDisplay/index.tsx
+++ b/frontend/src/components/PodStatusDisplay/index.tsx
@@ -1,10 +1,141 @@
-import { Box, Typography, Paper, Chip, LinearProgress, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from '@mui/material';
-import type { NamespaceStatus } from '../../types';
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  Chip,
+  LinearProgress,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Collapse,
+  IconButton,
+  Alert,
+} from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import type { NamespaceStatus, ContainerStateInfo, PodInfo } from '../../types';
 
 interface PodStatusDisplayProps {
   status: NamespaceStatus | null;
   loading?: boolean;
 }
+
+const getContainerStateColor = (state: ContainerStateInfo): 'success' | 'warning' | 'error' | 'default' => {
+  if (state.state === 'running' && state.ready) return 'success';
+  if (state.state === 'waiting') return 'warning';
+  if (state.state === 'terminated' && state.reason === 'Completed') return 'default';
+  if (state.state === 'terminated') return 'error';
+  return 'default';
+};
+
+const hasContainerDetails = (pod: PodInfo): boolean => {
+  if (!pod.container_states || pod.container_states.length === 0) return false;
+  return pod.container_states.some((cs) => cs.reason);
+};
+
+interface PodRowProps {
+  pod: PodInfo;
+  podPhaseColor: (phase: string) => 'success' | 'warning' | 'error' | 'info' | 'default';
+}
+
+const PodRow = ({ pod, podPhaseColor }: PodRowProps) => {
+  const [open, setOpen] = useState(false);
+  const expandable = hasContainerDetails(pod);
+
+  return (
+    <>
+      <TableRow>
+        <TableCell sx={{ borderBottom: expandable && open ? 'none' : undefined }}>
+          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+            {expandable && (
+              <IconButton
+                aria-label={open ? 'Collapse container details' : 'Expand container details'}
+                size="small"
+                onClick={() => setOpen(!open)}
+                sx={{ mr: 0.5 }}
+              >
+                {open ? <KeyboardArrowUpIcon fontSize="small" /> : <KeyboardArrowDownIcon fontSize="small" />}
+              </IconButton>
+            )}
+            <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+              {pod.name}
+            </Typography>
+          </Box>
+        </TableCell>
+        <TableCell sx={{ borderBottom: expandable && open ? 'none' : undefined }}>
+          <Chip label={pod.phase} size="small" color={podPhaseColor(pod.phase)} />
+        </TableCell>
+        <TableCell sx={{ borderBottom: expandable && open ? 'none' : undefined }}>
+          {pod.ready ? 'Yes' : 'No'}
+        </TableCell>
+        <TableCell sx={{ borderBottom: expandable && open ? 'none' : undefined }}>
+          <Typography
+            variant="body2"
+            color={pod.restart_count > 5 ? 'error' : 'text.primary'}
+          >
+            {pod.restart_count}
+          </Typography>
+        </TableCell>
+        <TableCell sx={{ borderBottom: expandable && open ? 'none' : undefined }}>
+          <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
+            {pod.image}
+          </Typography>
+        </TableCell>
+      </TableRow>
+      {expandable && (
+        <TableRow>
+          <TableCell colSpan={5} sx={{ py: 0, px: 2 }}>
+            <Collapse in={open} timeout="auto" unmountOnExit>
+              <Box sx={{ py: 1, pl: 4 }}>
+                <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, mb: 0.5, display: 'block' }}>
+                  Container States
+                </Typography>
+                {pod.container_states!.map((cs) => (
+                  <Box key={cs.name} sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5, flexWrap: 'wrap' }}>
+                    <Typography variant="caption" sx={{ fontFamily: 'monospace', minWidth: 100 }}>
+                      {cs.name}
+                    </Typography>
+                    <Chip
+                      label={cs.state}
+                      size="small"
+                      color={getContainerStateColor(cs)}
+                      variant="outlined"
+                      sx={{ height: 20, fontSize: '0.7rem' }}
+                    />
+                    {cs.reason && (
+                      <Typography variant="caption" color="warning.main" sx={{ fontWeight: 600 }}>
+                        {cs.reason}
+                      </Typography>
+                    )}
+                    {cs.message && (
+                      <Typography variant="caption" color="text.secondary" sx={{ fontStyle: 'italic' }}>
+                        {cs.message}
+                      </Typography>
+                    )}
+                    {cs.state === 'terminated' && cs.exit_code !== undefined && (
+                      <Typography variant="caption" color="text.secondary">
+                        (exit code: {cs.exit_code})
+                      </Typography>
+                    )}
+                    {cs.restart_count > 0 && (
+                      <Typography variant="caption" color={cs.restart_count > 5 ? 'error.main' : 'text.secondary'}>
+                        {cs.restart_count} restart{cs.restart_count === 1 ? '' : 's'}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+              </Box>
+            </Collapse>
+          </TableCell>
+        </TableRow>
+      )}
+    </>
+  );
+};
 
 const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
   if (loading) return <LinearProgress />;
@@ -20,7 +151,7 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
     }
   };
 
-  const podPhaseColor = (phase: string) => {
+  const podPhaseColor = (phase: string): 'success' | 'warning' | 'error' | 'info' | 'default' => {
     switch (phase) {
       case 'Running': return 'success';
       case 'Pending': return 'warning';
@@ -29,6 +160,8 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
       default: return 'default';
     }
   };
+
+  const warningEvents = (status.events || []).filter((e) => e.type === 'Warning');
 
   return (
     <Box>
@@ -78,30 +211,7 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
                 </TableHead>
                 <TableBody>
                   {(chart.pods || []).map((pod) => (
-                    <TableRow key={pod.name}>
-                      <TableCell>
-                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                          {pod.name}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Chip label={pod.phase} size="small" color={podPhaseColor(pod.phase) as 'success' | 'warning' | 'error' | 'info' | 'default'} />
-                      </TableCell>
-                      <TableCell>{pod.ready ? 'Yes' : 'No'}</TableCell>
-                      <TableCell>
-                        <Typography
-                          variant="body2"
-                          color={pod.restart_count > 5 ? 'error' : 'text.primary'}
-                        >
-                          {pod.restart_count}
-                        </Typography>
-                      </TableCell>
-                      <TableCell>
-                        <Typography variant="body2" sx={{ fontFamily: 'monospace', fontSize: '0.75rem' }}>
-                          {pod.image}
-                        </Typography>
-                      </TableCell>
-                    </TableRow>
+                    <PodRow key={pod.name} pod={pod} podPhaseColor={podPhaseColor} />
                   ))}
                 </TableBody>
               </Table>
@@ -109,6 +219,22 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
           )}
         </Paper>
       ))}
+
+      {warningEvents.length > 0 && (
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>Recent Warnings</Typography>
+          {warningEvents.slice(0, 10).map((event, i) => (
+            <Alert key={i} severity="warning" sx={{ mb: 0.5, py: 0, '& .MuiAlert-message': { py: 0.5 } }}>
+              <Typography variant="caption" sx={{ fontWeight: 600 }}>{event.reason}</Typography>
+              {' \u2014 '}
+              <Typography variant="caption">{event.message}</Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ ml: 1 }}>
+                ({event.object}, x{event.count})
+              </Typography>
+            </Alert>
+          ))}
+        </Box>
+      )}
     </Box>
   );
 };

--- a/frontend/src/components/PodStatusDisplay/index.tsx
+++ b/frontend/src/components/PodStatusDisplay/index.tsx
@@ -225,8 +225,8 @@ const PodStatusDisplay = ({ status, loading }: PodStatusDisplayProps) => {
       {warningEvents.length > 0 && (
         <Box sx={{ mt: 2 }}>
           <Typography variant="subtitle2" gutterBottom>Recent Warnings</Typography>
-          {warningEvents.slice(0, 10).map((event, i) => (
-            <Alert key={i} severity="warning" sx={{ mb: 0.5, py: 0, '& .MuiAlert-message': { py: 0.5 } }}>
+          {warningEvents.slice(0, 10).map((event) => (
+            <Alert key={`${event.object}-${event.reason}-${event.last_seen}`} severity="warning" sx={{ mb: 0.5, py: 0, '& .MuiAlert-message': { py: 0.5 } }}>
               <Typography variant="caption" sx={{ fontWeight: 600 }}>{event.reason}</Typography>
               {' \u2014 '}
               <Typography variant="caption">{event.message}</Typography>

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -73,17 +73,49 @@ const getPrimaryUrl = (status: NamespaceStatus): string | null => {
   return null;
 };
 
+type K8sHealthStatus = 'healthy' | 'degraded' | 'error' | 'not_found';
+
+const PodHealthDot = ({ status }: { status?: K8sHealthStatus }) => {
+  if (!status) return null;
+  const colorMap: Record<string, string> = {
+    healthy: 'success.main',
+    progressing: 'info.main',
+    degraded: 'warning.main',
+    error: 'error.main',
+    not_found: 'grey.400',
+  };
+  return (
+    <Tooltip title={`Cluster: ${status}`} arrow>
+      <Box
+        component="span"
+        role="status"
+        aria-label={`Pod health: ${status}`}
+        sx={{
+          width: 8,
+          height: 8,
+          borderRadius: '50%',
+          bgcolor: colorMap[status] || 'grey.400',
+          display: 'inline-block',
+          ml: 1,
+          flexShrink: 0,
+        }}
+      />
+    </Tooltip>
+  );
+};
+
 interface InstanceCardProps {
   instance: StackInstance;
   isSelected: boolean;
   isFavorite: boolean;
   clusterName?: string;
   url?: string;
+  k8sHealth?: K8sHealthStatus;
   onToggleSelect: (id: string) => void;
   onNavigate: (path: string) => void;
 }
 
-const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, onToggleSelect, onNavigate }: InstanceCardProps) => (
+const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, k8sHealth, onToggleSelect, onNavigate }: InstanceCardProps) => (
   <Card
     sx={{
       height: '100%',
@@ -109,7 +141,10 @@ const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, onTo
             {instance.name}
           </Typography>
         </Box>
-        <StatusBadge status={instance.status} />
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <StatusBadge status={instance.status} />
+          <PodHealthDot status={k8sHealth} />
+        </Box>
       </Box>
       <Typography variant="body2" color="text.secondary">Branch: {instance.branch}</Typography>
       <Typography variant="body2" color="text.secondary">Namespace: {instance.namespace}</Typography>
@@ -159,6 +194,7 @@ const Dashboard = () => {
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('All');
   const [instanceUrls, setInstanceUrls] = useState<Record<string, string>>({});
+  const [instanceHealth, setInstanceHealth] = useState<Record<string, K8sHealthStatus>>({});
   const navigate = useNavigate();
   const { showSuccess, showError } = useNotification();
 
@@ -231,14 +267,16 @@ const Dashboard = () => {
       newRunning.map(async (inst) => {
         const st: NamespaceStatus = await instanceService.getStatus(inst.id);
         const url = getPrimaryUrl(st);
-        return { id: inst.id, url };
+        return { id: inst.id, url, health: st.status };
       }),
     ).then((settled) => {
       if (cancelled) return;
       const newUrls: Record<string, string> = {};
+      const newHealth: Record<string, K8sHealthStatus> = {};
       settled.forEach((r, idx) => {
         if (r.status === 'fulfilled') {
           inFlightIdsRef.current.delete(r.value.id);
+          newHealth[r.value.id] = r.value.health;
           if (r.value.url) {
             fetchedStatusIdsRef.current.add(r.value.id);
             newUrls[r.value.id] = r.value.url;
@@ -251,6 +289,9 @@ const Dashboard = () => {
       if (Object.keys(newUrls).length > 0) {
         setInstanceUrls((prev) => ({ ...prev, ...newUrls }));
       }
+      if (Object.keys(newHealth).length > 0) {
+        setInstanceHealth((prev) => ({ ...prev, ...newHealth }));
+      }
     });
 
     return () => { cancelled = true; };
@@ -259,13 +300,22 @@ const Dashboard = () => {
   // Live-update instance statuses via WebSocket.
   const handleWsMessage = useCallback((msg: WsMessage) => {
     if (msg.type === 'deployment.status') {
-      const payload = msg.payload as { instance_id?: string; status?: string };
+      const payload = msg.payload as { instance_id?: string; status?: string; k8s_status?: K8sHealthStatus };
       if (!payload.instance_id || !payload.status) return;
       setInstances((prev) =>
         prev.map((inst) =>
           inst.id === payload.instance_id ? { ...inst, status: payload.status as string } : inst
         )
       );
+      if (payload.k8s_status) {
+        setInstanceHealth((prev) => ({ ...prev, [payload.instance_id!]: payload.k8s_status! }));
+      }
+    }
+    if (msg.type === 'instance.status') {
+      const payload = msg.payload as { instance_id?: string; k8s_status?: K8sHealthStatus };
+      if (payload.instance_id && payload.k8s_status) {
+        setInstanceHealth((prev) => ({ ...prev, [payload.instance_id!]: payload.k8s_status! }));
+      }
     }
   }, []);
 
@@ -680,6 +730,7 @@ const Dashboard = () => {
                   isFavorite={favoriteInstanceIds.has(instance.id)}
                   clusterName={instance.cluster_id ? clusterNameMap.get(instance.cluster_id) : undefined}
                   url={instanceUrls[instance.id]}
+                  k8sHealth={instanceHealth[instance.id]}
                   onToggleSelect={toggleSelect}
                   onNavigate={navigate}
                 />

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -73,7 +73,7 @@ const getPrimaryUrl = (status: NamespaceStatus): string | null => {
   return null;
 };
 
-type K8sHealthStatus = 'healthy' | 'degraded' | 'error' | 'not_found' | 'progressing';
+type K8sHealthStatus = NamespaceStatus['status'];
 
 const PodHealthDot = ({ status }: { status?: K8sHealthStatus }) => {
   if (!status) return null;

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -73,7 +73,7 @@ const getPrimaryUrl = (status: NamespaceStatus): string | null => {
   return null;
 };
 
-type K8sHealthStatus = 'healthy' | 'degraded' | 'error' | 'not_found';
+type K8sHealthStatus = 'healthy' | 'degraded' | 'error' | 'not_found' | 'progressing';
 
 const PodHealthDot = ({ status }: { status?: K8sHealthStatus }) => {
   if (!status) return null;
@@ -312,9 +312,14 @@ const Dashboard = () => {
       }
     }
     if (msg.type === 'instance.status') {
-      const payload = msg.payload as { instance_id?: string; k8s_status?: K8sHealthStatus };
-      if (payload.instance_id && payload.k8s_status) {
-        setInstanceHealth((prev) => ({ ...prev, [payload.instance_id!]: payload.k8s_status! }));
+      const payload = msg.payload as {
+        instance_id?: string;
+        status?: string;
+        namespace_status?: { status?: K8sHealthStatus };
+      };
+      const nextHealth = payload.namespace_status?.status;
+      if (payload.instance_id && nextHealth) {
+        setInstanceHealth((prev) => ({ ...prev, [payload.instance_id!]: nextHealth }));
       }
     }
   }, []);

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -302,16 +302,13 @@ const Dashboard = () => {
   // Live-update instance statuses via WebSocket.
   const handleWsMessage = useCallback((msg: WsMessage) => {
     if (msg.type === 'deployment.status') {
-      const payload = msg.payload as { instance_id?: string; status?: string; k8s_status?: K8sHealthStatus };
+      const payload = msg.payload as { instance_id?: string; status?: string };
       if (!payload.instance_id || !payload.status) return;
       setInstances((prev) =>
         prev.map((inst) =>
           inst.id === payload.instance_id ? { ...inst, status: payload.status as string } : inst
         )
       );
-      if (payload.k8s_status) {
-        setInstanceHealth((prev) => ({ ...prev, [payload.instance_id!]: payload.k8s_status! }));
-      }
     }
     if (msg.type === 'instance.status') {
       const payload = msg.payload as {

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -143,7 +143,9 @@ const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, k8sH
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <StatusBadge status={instance.status} />
-          <PodHealthDot status={k8sHealth} />
+          {(instance.status === 'running' || instance.status === 'deploying') && k8sHealth && (
+            <PodHealthDot status={k8sHealth} />
+          )}
         </Box>
       </Box>
       <Typography variant="body2" color="text.secondary">Branch: {instance.branch}</Typography>

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -85,7 +85,7 @@ const PodHealthDot = ({ status }: { status?: K8sHealthStatus }) => {
     not_found: 'grey.400',
   };
   return (
-    <Tooltip title={`Cluster: ${status}`} arrow>
+    <Tooltip title={`Health: ${status}`} arrow>
       <Box
         component="span"
         role="status"

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -115,7 +115,7 @@ const Detail = () => {
         if (inst.status === 'running' || inst.status === 'deploying' || inst.status === 'error' || inst.status === 'stopping' || inst.status === 'cleaning') {
           try {
             setStatusLoading(true);
-            const status = await instanceService.getStatus(id);
+            const status = await instanceService.getPods(id);
             setK8sStatus(status);
           } catch { /* ignore */ }
           finally { setStatusLoading(false); }
@@ -148,7 +148,7 @@ const Detail = () => {
 
       // Fetch current K8s status for terminal states where resources may exist.
       if (newStatus === 'running' || newStatus === 'error') {
-        instanceService.getStatus(id).then(setK8sStatus).catch(() => {});
+        instanceService.getPods(id).then(setK8sStatus).catch(() => {});
       }
 
       // Refresh deploy logs on terminal states.

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -111,7 +111,7 @@ const Detail = () => {
           setDeployLogs(logs);
         } catch { /* ignore — no logs yet */ }
 
-        // Fetch K8s status if instance is running or deploying
+        // Fetch pod health for active instances (includes container states + events).
         if (inst.status === 'running' || inst.status === 'deploying' || inst.status === 'error' || inst.status === 'stopping' || inst.status === 'cleaning') {
           try {
             setStatusLoading(true);

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -161,10 +161,16 @@ const Detail = () => {
     }
 
     // Live K8s status updates from the watcher (pod state changes, etc.).
+    // Merge with existing status to preserve events (watcher doesn't include them).
     if (msg.type === 'instance.status') {
       const nsPayload = msg.payload as { instance_id?: string; namespace_status?: NamespaceStatus };
       if (nsPayload.namespace_status) {
-        setK8sStatus(nsPayload.namespace_status);
+        setK8sStatus((prev) => {
+          const incoming = nsPayload.namespace_status!;
+          if (!prev || !prev.events?.length) return incoming;
+          // Preserve events from the previous getPods() call.
+          return { ...incoming, events: incoming.events?.length ? incoming.events : prev.events };
+        });
       }
     }
 

--- a/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
@@ -29,6 +29,7 @@ vi.mock('../../../api/client', () => ({
     bulkClean: vi.fn(),
     bulkDelete: vi.fn(),
     getStatus: vi.fn().mockRejectedValue(new Error('no status')),
+    getPods: vi.fn().mockRejectedValue(new Error('no pods')),
   },
   clusterService: {
     list: vi.fn().mockResolvedValue([]),
@@ -837,6 +838,7 @@ describe('Dashboard', () => {
       ]);
       (instanceService.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
         namespace: 'stack-app',
+        status: 'healthy',
         ingresses: [{ url: 'https://app.example.com' }],
         charts: [],
         pods: [],
@@ -853,6 +855,31 @@ describe('Dashboard', () => {
       });
       await waitFor(() => {
         expect(screen.getByText('https://app.example.com')).toBeInTheDocument();
+      });
+    });
+
+    it('shows pod health dot when status is fetched for running instance', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([
+        mockInstance({ id: 'inst-h', name: 'Healthy App', status: 'running', namespace: 'stack-h' }),
+      ]);
+      (instanceService.getStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+        namespace: 'stack-h',
+        status: 'healthy',
+        charts: [],
+        last_checked: '2026-01-01T00:00:00Z',
+      });
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Healthy App')).toBeInTheDocument();
+      });
+      await waitFor(() => {
+        expect(screen.getByRole('status', { name: /pod health: healthy/i })).toBeInTheDocument();
       });
     });
 

--- a/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
@@ -153,7 +153,7 @@ import useCountdown from '../../../hooks/useCountdown';
 
 type MockFn = ReturnType<typeof vi.fn>;
 
-const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: { logs?: unknown[]; status?: unknown; deployLogReject?: boolean; statusReject?: boolean; branchOverrides?: unknown[] } = {}) => {
+const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: { logs?: unknown[]; status?: unknown; podsStatus?: unknown; deployLogReject?: boolean; statusReject?: boolean; branchOverrides?: unknown[] } = {}) => {
   const inst = { ...mockInstance, ...instanceOverrides };
   (instanceService.get as MockFn).mockResolvedValue(inst);
   (definitionService.get as MockFn).mockResolvedValue(mockDefinition);
@@ -169,7 +169,7 @@ const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: 
     (instanceService.getPods as MockFn).mockRejectedValue(new Error('no pods'));
   } else {
     (instanceService.getStatus as MockFn).mockResolvedValue(opts.status ?? null);
-    (instanceService.getPods as MockFn).mockResolvedValue(opts.status ?? null);
+    (instanceService.getPods as MockFn).mockResolvedValue(opts.podsStatus ?? opts.status ?? null);
   }
   return inst;
 };

--- a/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
@@ -153,7 +153,7 @@ import useCountdown from '../../../hooks/useCountdown';
 
 type MockFn = ReturnType<typeof vi.fn>;
 
-const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: { logs?: unknown[]; status?: unknown; podsStatus?: unknown; deployLogReject?: boolean; statusReject?: boolean; branchOverrides?: unknown[] } = {}) => {
+const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: { logs?: unknown[]; k8sStatus?: unknown; podsStatus?: unknown; deployLogReject?: boolean; k8sReject?: boolean; branchOverrides?: unknown[] } = {}) => {
   const inst = { ...mockInstance, ...instanceOverrides };
   (instanceService.get as MockFn).mockResolvedValue(inst);
   (definitionService.get as MockFn).mockResolvedValue(mockDefinition);
@@ -164,12 +164,12 @@ const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: 
   } else {
     (instanceService.getDeployLog as MockFn).mockResolvedValue(opts.logs ?? []);
   }
-  if (opts.statusReject) {
+  if (opts.k8sReject) {
     (instanceService.getStatus as MockFn).mockRejectedValue(new Error('no status'));
     (instanceService.getPods as MockFn).mockRejectedValue(new Error('no pods'));
   } else {
-    (instanceService.getStatus as MockFn).mockResolvedValue(opts.status ?? null);
-    (instanceService.getPods as MockFn).mockResolvedValue(opts.podsStatus ?? opts.status ?? null);
+    (instanceService.getStatus as MockFn).mockResolvedValue(opts.k8sStatus ?? null);
+    (instanceService.getPods as MockFn).mockResolvedValue(opts.podsStatus ?? opts.k8sStatus ?? null);
   }
   return inst;
 };
@@ -497,7 +497,7 @@ describe('StackInstances Detail', () => {
 
   it('shows Cluster Resources for running instance', async () => {
     const mockStatus = { namespace: 'stack-test', pods: [], services: [] };
-    setupMocks({ status: 'running' }, { status: mockStatus });
+    setupMocks({ status: 'running' }, { k8sStatus: mockStatus });
 
     renderDetail();
 
@@ -592,7 +592,7 @@ describe('StackInstances Detail', () => {
 
   it('shows Cluster Resources for stopping instance', async () => {
     const mockStatus = { namespace: 'stack-test', pods: [], services: [] };
-    setupMocks({ status: 'stopping' }, { status: mockStatus });
+    setupMocks({ status: 'stopping' }, { k8sStatus: mockStatus });
 
     renderDetail();
 
@@ -801,7 +801,7 @@ describe('StackInstances Detail', () => {
       ingresses: [{ name: 'web', host: 'app.example.com', path: '/', tls: true, url: 'https://app.example.com' }],
       last_checked: '2025-01-01T00:00:00Z',
     };
-    setupMocks({ status: 'running' }, { status: mockStatus });
+    setupMocks({ status: 'running' }, { k8sStatus: mockStatus });
     renderDetail();
 
     await waitFor(() => {
@@ -822,7 +822,7 @@ describe('StackInstances Detail', () => {
   });
 
   it('does not show Access URLs for running instance without k8s status', async () => {
-    setupMocks({ status: 'running' }, { statusReject: true });
+    setupMocks({ status: 'running' }, { k8sReject: true });
     renderDetail();
 
     await waitFor(() => {

--- a/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
@@ -166,7 +166,7 @@ const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: 
   }
   if (opts.statusReject) {
     (instanceService.getStatus as MockFn).mockRejectedValue(new Error('no status'));
-    (instanceService.getPods as MockFn).mockRejectedValue(new Error('no status'));
+    (instanceService.getPods as MockFn).mockRejectedValue(new Error('no pods'));
   } else {
     (instanceService.getStatus as MockFn).mockResolvedValue(opts.status ?? null);
     (instanceService.getPods as MockFn).mockResolvedValue(opts.status ?? null);

--- a/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Detail.test.tsx
@@ -49,6 +49,7 @@ vi.mock('../../../api/client', () => ({
     clean: vi.fn(),
     getDeployLog: vi.fn(),
     getStatus: vi.fn(),
+    getPods: vi.fn(),
     extend: vi.fn(),
   },
   definitionService: {
@@ -165,8 +166,10 @@ const setupMocks = (instanceOverrides: Partial<typeof mockInstance> = {}, opts: 
   }
   if (opts.statusReject) {
     (instanceService.getStatus as MockFn).mockRejectedValue(new Error('no status'));
+    (instanceService.getPods as MockFn).mockRejectedValue(new Error('no status'));
   } else {
     (instanceService.getStatus as MockFn).mockResolvedValue(opts.status ?? null);
+    (instanceService.getPods as MockFn).mockResolvedValue(opts.status ?? null);
   }
   return inst;
 };
@@ -530,7 +533,7 @@ describe('StackInstances Detail', () => {
     });
 
     await waitFor(() => {
-      expect(instanceService.getStatus).toHaveBeenCalledWith('123');
+      expect(instanceService.getPods).toHaveBeenCalledWith('123');
     });
   });
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -169,7 +169,7 @@ export interface PodInfo {
   ready: boolean;
   restart_count: number;
   image: string;
-  container_states?: ContainerStateInfo[];
+  container_states: ContainerStateInfo[];
   conditions?: PodConditionInfo[];
   start_time?: string;
   node_name?: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -195,7 +195,7 @@ export interface IngressInfo {
 
 export interface NamespaceStatus {
   namespace: string;
-  status: 'healthy' | 'degraded' | 'error' | 'not_found';
+  status: 'healthy' | 'degraded' | 'error' | 'not_found' | 'progressing';
   charts: ChartStatus[];
   ingresses?: IngressInfo[];
   events?: PodEvent[];

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -135,12 +135,44 @@ export interface DeploymentStatusInfo {
   available: boolean;
 }
 
+export interface ContainerStateInfo {
+  name: string;
+  state: 'running' | 'waiting' | 'terminated';
+  reason?: string;
+  message?: string;
+  restart_count: number;
+  ready: boolean;
+  image: string;
+  exit_code?: number;
+}
+
+export interface PodConditionInfo {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+}
+
+export interface PodEvent {
+  type: 'Normal' | 'Warning';
+  reason: string;
+  message: string;
+  object: string;
+  count: number;
+  first_seen: string;
+  last_seen: string;
+}
+
 export interface PodInfo {
   name: string;
   phase: string;
   ready: boolean;
   restart_count: number;
   image: string;
+  container_states?: ContainerStateInfo[];
+  conditions?: PodConditionInfo[];
+  start_time?: string;
+  node_name?: string;
 }
 
 export interface ServiceInfo {
@@ -166,6 +198,7 @@ export interface NamespaceStatus {
   status: 'healthy' | 'degraded' | 'error' | 'not_found';
   charts: ChartStatus[];
   ingresses?: IngressInfo[];
+  events?: PodEvent[];
   last_checked: string;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -137,7 +137,7 @@ export interface DeploymentStatusInfo {
 
 export interface ContainerStateInfo {
   name: string;
-  state: 'running' | 'waiting' | 'terminated';
+  state: 'running' | 'waiting' | 'terminated' | 'unknown';
   reason?: string;
   message?: string;
   restart_count: number;


### PR DESCRIPTION
## Summary

Extends pod status monitoring with container-level state details, Kubernetes events, and at-a-glance health indicators on the Dashboard — addressing the gap where deployed instances could have crashing pods or OOMKills invisible to users.

- **Container states**: Each pod now reports per-container state (running/waiting/terminated) with reasons like `OOMKilled`, `CrashLoopBackOff`, `ImagePullBackOff`, exit codes, and restart counts
- **K8s events**: Namespace Warning events and recent Normal events are fetched and surfaced in the UI
- **Pod health dots**: Dashboard instance cards show green/yellow/red dots reflecting live K8s health status, updated via WebSocket
- **Dedicated endpoint**: `GET /api/v1/stack-instances/:id/pods` for detailed pod health queries

### Backend changes (4 files + swagger docs)
| File | Change |
|------|--------|
| `k8s/status.go` | Extended `PodInfo` with `ContainerStates`, `Conditions`, `StartTime`, `NodeName`; added `ContainerStateInfo`, `PodConditionInfo`, `PodEvent` types; events fetching in `GetNamespaceStatus` |
| `handlers/stack_instances.go` | New `GetInstancePods` handler |
| `routes/routes.go` | Registered `GET /:id/pods` |
| `k8s/status_test.go` | 4 new test cases for container states, events, empty states, pod metadata |

### Frontend changes (6 files)
| File | Change |
|------|--------|
| `types/index.ts` | Added `ContainerStateInfo`, `PodConditionInfo`, `PodEvent` interfaces; extended `PodInfo` and `NamespaceStatus` |
| `api/client.ts` | Added `instanceService.getPods()` |
| `PodStatusDisplay/index.tsx` | Expandable container state rows, warning events section |
| `Dashboard.tsx` | `PodHealthDot` component, per-instance health state via status fetch + WebSocket |
| `PodStatusDisplay.test.tsx` | 8 new tests for container states and events display |
| `Dashboard.test.tsx` | Test for health dot rendering |

Closes #117

## Test plan

- [x] Backend compiles (`go build ./...`)
- [x] All backend tests pass (`go test ./... -short` — 27 packages)
- [x] Frontend type-check passes (`tsc --noEmit`)
- [x] Frontend lint passes (0 errors, 5 pre-existing warnings)
- [x] All 889 frontend tests pass (60 test files)
- [ ] Manual: Deploy an instance, verify pod status table shows container states
- [ ] Manual: Trigger an OOMKill/CrashLoop, verify warning events appear
- [ ] Manual: Verify Dashboard health dots update in real-time via WebSocket

🤖 Generated with [Claude Code](https://claude.com/claude-code)