### PR TITLE
feat: deployment history and one-click rollback

### DIFF
--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -53,6 +53,18 @@ func (m *mockAdminHelmExecutor) ListReleases(ctx context.Context, namespace stri
 	return []string{}, nil
 }
 
+func (m *mockAdminHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]deployer.ReleaseRevision, error) {
+	return nil, nil
+}
+
+func (m *mockAdminHelmExecutor) Rollback(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
+func (m *mockAdminHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
 func (m *mockAdminHelmExecutor) Timeout() time.Duration {
 	return 30 * time.Second
 }

--- a/backend/internal/api/handlers/clusters_test.go
+++ b/backend/internal/api/handlers/clusters_test.go
@@ -44,6 +44,15 @@ func (m *mockClusterHelmExecutor) Status(_ context.Context, name, _ string) (*de
 func (m *mockClusterHelmExecutor) ListReleases(_ context.Context, _ string) ([]string, error) {
 	return []string{}, nil
 }
+func (m *mockClusterHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]deployer.ReleaseRevision, error) {
+	return nil, nil
+}
+func (m *mockClusterHelmExecutor) Rollback(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+func (m *mockClusterHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
 func (m *mockClusterHelmExecutor) Timeout() time.Duration { return 30 * time.Second }
 
 // setupClusterRouter creates a gin engine wired to ClusterHandler routes.

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -2132,12 +2132,15 @@ func (h *InstanceHandler) buildLockedValuesMap(def *models.StackDefinition) (map
 // @Tags        stack-instances
 // @Accept      json
 // @Produce     json
+// @Security    BearerAuth
 // @Param       id   path     string true "Instance ID"
 // @Param       body body     object false "Optional: {\"target_log_id\": \"...\"}"
 // @Success     202 {object} map[string]string
 // @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
 // @Failure     409 {object} map[string]string
+// @Failure     500 {object} map[string]string
+// @Failure     503 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/rollback [post]
 func (h *InstanceHandler) RollbackInstance(c *gin.Context) {
 	id := c.Param("id")
@@ -2170,7 +2173,10 @@ func (h *InstanceHandler) RollbackInstance(c *gin.Context) {
 		TargetLogID string `json:"target_log_id"`
 	}
 	if c.Request.Body != nil && c.Request.Body != http.NoBody {
-		_ = c.ShouldBindJSON(&body)
+		if bindErr := c.ShouldBindJSON(&body); bindErr != nil && !errors.Is(bindErr, io.EOF) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": msgInvalidRequestFormat})
+			return
+		}
 	}
 
 	def, err := h.definitionRepo.FindByID(inst.StackDefinitionID)
@@ -2219,10 +2225,13 @@ func (h *InstanceHandler) RollbackInstance(c *gin.Context) {
 // @Description Returns the merged Helm values that were used for a specific deployment
 // @Tags        stack-instances
 // @Produce     json
+// @Security    BearerAuth
 // @Param       id    path     string true "Instance ID"
 // @Param       logId path     string true "Deployment Log ID"
 // @Success     200 {object} map[string]string
+// @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
+// @Failure     503 {object} map[string]string
 // @Router      /api/v1/stack-instances/{id}/deploy-log/{logId}/values [get]
 func (h *InstanceHandler) GetDeployLogValues(c *gin.Context) {
 	instanceID := c.Param("id")

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -2125,3 +2125,155 @@ func (h *InstanceHandler) buildLockedValuesMap(def *models.StackDefinition) (map
 	}
 	return lockedMap, nil
 }
+
+// RollbackInstance godoc
+// @Summary     Rollback a stack instance
+// @Description Rollback all Helm releases in a stack instance to their previous revision
+// @Tags        stack-instances
+// @Accept      json
+// @Produce     json
+// @Param       id   path     string true "Instance ID"
+// @Param       body body     object false "Optional: {\"target_log_id\": \"...\"}"
+// @Success     202 {object} map[string]string
+// @Failure     400 {object} map[string]string
+// @Failure     404 {object} map[string]string
+// @Failure     409 {object} map[string]string
+// @Router      /api/v1/stack-instances/{id}/rollback [post]
+func (h *InstanceHandler) RollbackInstance(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msgInstanceIDRequired})
+		return
+	}
+
+	if h.deployManager == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": msgDeployerNotConfigured})
+		return
+	}
+
+	inst, err := h.instanceRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	switch inst.Status {
+	case models.StackStatusRunning, models.StackStatusError:
+		// OK
+	default:
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Cannot rollback: instance is in state %s", inst.Status)})
+		return
+	}
+
+	var body struct {
+		TargetLogID string `json:"target_log_id"`
+	}
+	if c.Request.Body != nil && c.Request.Body != http.NoBody {
+		_ = c.ShouldBindJSON(&body)
+	}
+
+	def, err := h.definitionRepo.FindByID(inst.StackDefinitionID)
+	if err != nil {
+		status, message := mapError(err, entityStackDefinition)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	charts, err := h.chartConfigRepo.ListByDefinition(def.ID)
+	if err != nil {
+		status, message := mapError(err, entityChartConfigs)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	if len(charts) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No charts configured for this stack definition"})
+		return
+	}
+
+	var chartInfos []deployer.ChartDeployInfo
+	for _, ch := range charts {
+		chartInfos = append(chartInfos, deployer.ChartDeployInfo{ChartConfig: ch})
+	}
+
+	logID, err := h.deployManager.Rollback(c.Request.Context(), deployer.RollbackRequest{
+		Instance:    inst,
+		Charts:      chartInfos,
+		TargetLogID: body.TargetLogID,
+	})
+	if err != nil {
+		slog.Error("Failed to start rollback",
+			logKeyInstanceID, id,
+			"error", err,
+		)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{"log_id": logID, "message": "Rollback started"})
+}
+
+// GetDeployLogValues godoc
+// @Summary     Get values snapshot for a deployment log entry
+// @Description Returns the merged Helm values that were used for a specific deployment
+// @Tags        stack-instances
+// @Produce     json
+// @Param       id    path     string true "Instance ID"
+// @Param       logId path     string true "Deployment Log ID"
+// @Success     200 {object} map[string]string
+// @Failure     404 {object} map[string]string
+// @Router      /api/v1/stack-instances/{id}/deploy-log/{logId}/values [get]
+func (h *InstanceHandler) GetDeployLogValues(c *gin.Context) {
+	instanceID := c.Param("id")
+	logID := c.Param("logId")
+	if instanceID == "" || logID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Instance ID and log ID are required"})
+		return
+	}
+
+	if h.deployLogRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "Deployment log service not configured"})
+		return
+	}
+
+	if _, err := h.instanceRepo.FindByID(instanceID); err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	logEntry, err := h.deployLogRepo.FindByID(c.Request.Context(), logID)
+	if err != nil {
+		status, message := mapError(err, "Deployment log")
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	if logEntry.StackInstanceID != instanceID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Deployment log not found for this instance"})
+		return
+	}
+
+	if logEntry.ValuesSnapshot == "" {
+		c.JSON(http.StatusOK, gin.H{
+			"log_id": logID,
+			"values": nil,
+		})
+		return
+	}
+
+	var values map[string]interface{}
+	if err := json.Unmarshal([]byte(logEntry.ValuesSnapshot), &values); err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"log_id": logID,
+			"values": logEntry.ValuesSnapshot,
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"log_id": logID,
+		"values": values,
+	})
+}

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -261,6 +261,18 @@ func (n *noopHelmExecutor) ListReleases(_ context.Context, _ string) ([]string, 
 	return nil, nil
 }
 
+func (n *noopHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]deployer.ReleaseRevision, error) {
+	return nil, nil
+}
+
+func (n *noopHelmExecutor) Rollback(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
+func (n *noopHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
 func (n *noopHelmExecutor) Timeout() time.Duration {
 	return 30 * time.Second
 }

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1008,3 +1009,318 @@ func TestCleanInstance(t *testing.T) {
 	}
 }
 
+// setupRollbackRouter creates a test gin engine with rollback and deploy-log-values routes.
+func setupRollbackRouter(
+	t *testing.T,
+	instanceRepo *MockStackInstanceRepository,
+	defRepo *MockStackDefinitionRepository,
+	ccRepo *MockChartConfigRepository,
+	deployManager *deployer.Manager,
+	deployLogRepo models.DeploymentLogRepository,
+	callerID, callerUsername string,
+) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		if callerID != "" {
+			c.Set("userID", callerID)
+		}
+		if callerUsername != "" {
+			c.Set("username", callerUsername)
+		}
+		c.Set("role", "user")
+		c.Next()
+	})
+
+	valuesGen := helm.NewValuesGenerator()
+	userRepo := NewMockUserRepository()
+
+	h, err := NewInstanceHandlerWithDeployer(
+		instanceRepo, NewMockValueOverrideRepository(), nil, defRepo, ccRepo,
+		NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(),
+		valuesGen, userRepo,
+		deployManager, nil, nil, deployLogRepo, nil,
+		0, &mockHandlerTxRunner{},
+	)
+	require.NoError(t, err)
+
+	insts := r.Group("/api/v1/stack-instances")
+	{
+		insts.POST("/:id/rollback", h.RollbackInstance)
+		insts.GET("/:id/deploy-log/:logId/values", h.GetDeployLogValues)
+	}
+	return r
+}
+
+// ---- RollbackInstance tests ----
+
+func TestRollbackInstance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		instanceID string
+		body       string
+		setup      func(*MockStackInstanceRepository, *MockStackDefinitionRepository, *MockChartConfigRepository)
+		noManager  bool
+		wantStatus int
+		checkFn    func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name:       "success — running instance returns 202 with log_id",
+			instanceID: "i1",
+			body:       `{}`,
+			setup: func(instRepo *MockStackInstanceRepository, defRepo *MockStackDefinitionRepository, ccRepo *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+				seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+				seedChartConfig(t, ccRepo, "cc1", "d1", "nginx")
+			},
+			wantStatus: http.StatusAccepted,
+			checkFn: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var resp map[string]string
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.NotEmpty(t, resp["log_id"])
+				assert.Equal(t, "Rollback started", resp["message"])
+			},
+		},
+		{
+			name:       "error instance can be rolled back",
+			instanceID: "i2",
+			body:       `{}`,
+			setup: func(instRepo *MockStackInstanceRepository, defRepo *MockStackDefinitionRepository, ccRepo *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i2", "stack-b", "d1", "uid-1", models.StackStatusError)
+				seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+				seedChartConfig(t, ccRepo, "cc2", "d1", "redis")
+			},
+			wantStatus: http.StatusAccepted,
+		},
+		{
+			name:       "draft instance returns 409",
+			instanceID: "i3",
+			setup: func(instRepo *MockStackInstanceRepository, _ *MockStackDefinitionRepository, _ *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i3", "stack-c", "d1", "uid-1", models.StackStatusDraft)
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "stopped instance returns 409",
+			instanceID: "i4",
+			setup: func(instRepo *MockStackInstanceRepository, _ *MockStackDefinitionRepository, _ *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i4", "stack-d", "d1", "uid-1", models.StackStatusStopped)
+			},
+			wantStatus: http.StatusConflict,
+		},
+		{
+			name:       "instance not found returns 404",
+			instanceID: "missing",
+			setup:      func(_ *MockStackInstanceRepository, _ *MockStackDefinitionRepository, _ *MockChartConfigRepository) {},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "no charts configured returns 400",
+			instanceID: "i5",
+			setup: func(instRepo *MockStackInstanceRepository, defRepo *MockStackDefinitionRepository, _ *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i5", "stack-e", "d1", "uid-1", models.StackStatusRunning)
+				seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+				// No charts added to ccRepo.
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "nil deploy manager returns 503",
+			instanceID: "i6",
+			setup: func(instRepo *MockStackInstanceRepository, _ *MockStackDefinitionRepository, _ *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i6", "stack-f", "d1", "uid-1", models.StackStatusRunning)
+			},
+			noManager:  true,
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:       "malformed JSON body returns 400",
+			instanceID: "i7",
+			body:       `{bad json`,
+			setup: func(instRepo *MockStackInstanceRepository, _ *MockStackDefinitionRepository, _ *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i7", "stack-g", "d1", "uid-1", models.StackStatusRunning)
+			},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "optional target_log_id accepted",
+			instanceID: "i8",
+			body:       `{"target_log_id":"log-abc"}`,
+			setup: func(instRepo *MockStackInstanceRepository, defRepo *MockStackDefinitionRepository, ccRepo *MockChartConfigRepository) {
+				seedInstance(t, instRepo, "i8", "stack-h", "d1", "uid-1", models.StackStatusRunning)
+				seedDefinition(t, defRepo, "d1", "My Def", "uid-1")
+				seedChartConfig(t, ccRepo, "cc3", "d1", "postgres")
+			},
+			wantStatus: http.StatusAccepted,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			instRepo := NewMockStackInstanceRepository()
+			defRepo := NewMockStackDefinitionRepository()
+			ccRepo := NewMockChartConfigRepository()
+			logRepo := NewMockDeploymentLogRepository()
+			tt.setup(instRepo, defRepo, ccRepo)
+
+			var mgr *deployer.Manager
+			if !tt.noManager {
+				mgr = newTestManager(instRepo, logRepo)
+			}
+
+			router := setupRollbackRouter(t,
+				instRepo, defRepo, ccRepo,
+				mgr, logRepo,
+				"uid-1", "alice",
+			)
+
+			body := tt.body
+			if body == "" {
+				body = "{}"
+			}
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/stack-instances/"+tt.instanceID+"/rollback", bytes.NewBufferString(body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			if tt.checkFn != nil {
+				tt.checkFn(t, w)
+			}
+		})
+	}
+}
+
+// ---- GetDeployLogValues tests ----
+
+func TestGetDeployLogValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		instanceID string
+		logID      string
+		setup      func(*MockStackInstanceRepository, *MockDeploymentLogRepository)
+		wantStatus int
+		checkFn    func(*testing.T, *httptest.ResponseRecorder)
+	}{
+		{
+			name:       "success — log with values snapshot returns 200",
+			instanceID: "i1",
+			logID:      "log-1",
+			setup: func(instRepo *MockStackInstanceRepository, logRepo *MockDeploymentLogRepository) {
+				seedInstance(t, instRepo, "i1", "stack-a", "d1", "uid-1", models.StackStatusRunning)
+				require.NoError(t, logRepo.Create(context.Background(), &models.DeploymentLog{
+					ID:              "log-1",
+					StackInstanceID: "i1",
+					Action:          models.DeployActionDeploy,
+					Status:          models.DeployLogSuccess,
+					StartedAt:       time.Now().UTC(),
+					ValuesSnapshot:  `{"replicas":3,"image":"myapp:v2"}`,
+				}))
+			},
+			wantStatus: http.StatusOK,
+			checkFn: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var resp map[string]interface{}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, "log-1", resp["log_id"])
+				vals, ok := resp["values"].(map[string]interface{})
+				require.True(t, ok, "values should be a JSON object")
+				assert.Equal(t, float64(3), vals["replicas"])
+			},
+		},
+		{
+			name:       "log exists but no values snapshot returns 200 with null values",
+			instanceID: "i2",
+			logID:      "log-2",
+			setup: func(instRepo *MockStackInstanceRepository, logRepo *MockDeploymentLogRepository) {
+				seedInstance(t, instRepo, "i2", "stack-b", "d1", "uid-1", models.StackStatusRunning)
+				require.NoError(t, logRepo.Create(context.Background(), &models.DeploymentLog{
+					ID:              "log-2",
+					StackInstanceID: "i2",
+					Action:          models.DeployActionDeploy,
+					Status:          models.DeployLogSuccess,
+					StartedAt:       time.Now().UTC(),
+					ValuesSnapshot:  "", // no snapshot
+				}))
+			},
+			wantStatus: http.StatusOK,
+			checkFn: func(t *testing.T, w *httptest.ResponseRecorder) {
+				var resp map[string]interface{}
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, "log-2", resp["log_id"])
+				assert.Nil(t, resp["values"])
+			},
+		},
+		{
+			name:       "log not found returns 404",
+			instanceID: "i3",
+			logID:      "nonexistent-log",
+			setup: func(instRepo *MockStackInstanceRepository, _ *MockDeploymentLogRepository) {
+				seedInstance(t, instRepo, "i3", "stack-c", "d1", "uid-1", models.StackStatusRunning)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "log belongs to different instance returns 404",
+			instanceID: "i4",
+			logID:      "log-other",
+			setup: func(instRepo *MockStackInstanceRepository, logRepo *MockDeploymentLogRepository) {
+				seedInstance(t, instRepo, "i4", "stack-d", "d1", "uid-1", models.StackStatusRunning)
+				// Log belongs to a different instance.
+				require.NoError(t, logRepo.Create(context.Background(), &models.DeploymentLog{
+					ID:              "log-other",
+					StackInstanceID: "i99", // wrong instance
+					Action:          models.DeployActionDeploy,
+					Status:          models.DeployLogSuccess,
+					StartedAt:       time.Now().UTC(),
+					ValuesSnapshot:  `{"key":"val"}`,
+				}))
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:       "instance not found returns 404",
+			instanceID: "missing-inst",
+			logID:      "log-x",
+			setup:      func(_ *MockStackInstanceRepository, _ *MockDeploymentLogRepository) {},
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			instRepo := NewMockStackInstanceRepository()
+			logRepo := NewMockDeploymentLogRepository()
+			tt.setup(instRepo, logRepo)
+
+			router := setupRollbackRouter(t,
+				instRepo, NewMockStackDefinitionRepository(), NewMockChartConfigRepository(),
+				nil, logRepo,
+				"uid-1", "alice",
+			)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet,
+				"/api/v1/stack-instances/"+tt.instanceID+"/deploy-log/"+tt.logID+"/values",
+				nil,
+			)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+			if tt.checkFn != nil {
+				tt.checkFn(t, w)
+			}
+		})
+	}
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -329,6 +329,8 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 				instances.POST("/:id/actions/:name", deps.InstanceHandler.InvokeAction)
 				instances.POST("/:id/extend", deps.InstanceHandler.ExtendTTL)
 				instances.GET("/:id/deploy-log", deps.InstanceHandler.GetDeployLog)
+				instances.GET("/:id/deploy-log/:logId/values", deps.InstanceHandler.GetDeployLogValues)
+				instances.POST("/:id/rollback", deps.InstanceHandler.RollbackInstance)
 				instances.GET("/:id/status", deps.InstanceHandler.GetInstanceStatus)
 				instances.GET("/:id/pods", deps.InstanceHandler.GetInstancePods)
 

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -771,6 +771,26 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
+	migrator.AddMigration(schema.Migration{
+		Version:     "20231201000032",
+		Name:        "add_deployment_log_rollback_columns",
+		Description: "Add values_snapshot and target_log_id columns to deployment_logs for rollback support",
+		Up: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&models.DeploymentLog{})
+		},
+		Down: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&models.DeploymentLog{}, "values_snapshot") {
+				if err := tx.Migrator().DropColumn(&models.DeploymentLog{}, "values_snapshot"); err != nil {
+					return err
+				}
+			}
+			if tx.Migrator().HasColumn(&models.DeploymentLog{}, "target_log_id") {
+				return tx.Migrator().DropColumn(&models.DeploymentLog{}, "target_log_id")
+			}
+			return nil
+		},
+	})
+
 	// Run migrations
 	if err := migrator.MigrateUp(); err != nil {
 		return err

--- a/backend/internal/deployer/executor.go
+++ b/backend/internal/deployer/executor.go
@@ -12,5 +12,18 @@ type HelmExecutor interface {
 	Uninstall(ctx context.Context, req UninstallRequest) (string, error)
 	Status(ctx context.Context, releaseName, namespace string) (*ReleaseStatus, error)
 	ListReleases(ctx context.Context, namespace string) ([]string, error)
+	History(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error)
+	Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error)
+	GetValues(ctx context.Context, releaseName, namespace string, revision int) (string, error)
 	Timeout() time.Duration
+}
+
+// ReleaseRevision represents a single entry from helm history.
+type ReleaseRevision struct {
+	Revision    int    `json:"revision"`
+	Updated     string `json:"updated"`
+	Status      string `json:"status"`
+	Chart       string `json:"chart"`
+	AppVersion  string `json:"app_version"`
+	Description string `json:"description"`
 }

--- a/backend/internal/deployer/helm.go
+++ b/backend/internal/deployer/helm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -192,6 +193,81 @@ func (h *HelmClient) ListReleases(ctx context.Context, namespace string) ([]stri
 	}
 
 	return releases, nil
+}
+
+// History runs: helm history <release> -n <namespace> --max <max> -o json
+// Returns parsed release revision history.
+func (h *HelmClient) History(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error) {
+	if err := validatePositionalArg("release name", releaseName); err != nil {
+		return nil, err
+	}
+
+	if max <= 0 {
+		max = 256
+	}
+
+	args := []string{
+		"history",
+		releaseName,
+		"-n", namespace,
+		"--max", strconv.Itoa(max),
+		"-o", "json",
+	}
+
+	output, err := h.run(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("helm history: %w", err)
+	}
+
+	var revisions []ReleaseRevision
+	if err := json.Unmarshal([]byte(output), &revisions); err != nil {
+		return nil, fmt.Errorf("parsing helm history output: %w", err)
+	}
+
+	return revisions, nil
+}
+
+// Rollback runs: helm rollback <release> <revision> -n <namespace>
+// Returns combined stdout+stderr output and error.
+func (h *HelmClient) Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	if err := validatePositionalArg("release name", releaseName); err != nil {
+		return "", err
+	}
+
+	args := []string{
+		"rollback",
+		releaseName,
+		strconv.Itoa(revision),
+		"-n", namespace,
+		"--timeout", h.timeout.String(),
+	}
+
+	return h.run(ctx, args)
+}
+
+// GetValues runs: helm get values <release> -n <namespace> --revision <revision> -o yaml
+// Returns the values YAML for the given release revision.
+func (h *HelmClient) GetValues(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	if err := validatePositionalArg("release name", releaseName); err != nil {
+		return "", err
+	}
+
+	args := []string{
+		"get", "values",
+		releaseName,
+		"-n", namespace,
+		"-o", "yaml",
+	}
+	if revision > 0 {
+		args = append(args, "--revision", strconv.Itoa(revision))
+	}
+
+	output, err := h.run(ctx, args)
+	if err != nil {
+		return "", fmt.Errorf("helm get values: %w", err)
+	}
+
+	return output, nil
 }
 
 // run executes a helm command with the given arguments and returns the combined output.

--- a/backend/internal/deployer/helm_test.go
+++ b/backend/internal/deployer/helm_test.go
@@ -251,3 +251,304 @@ func TestHelmClient_Status_ArgumentInjection(t *testing.T) {
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, errArgDashPrefix))
 }
+
+// ---- History tests ----
+
+func TestHelmClient_History(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		binary  string
+		release string
+		ns      string
+		max     int
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "invalid binary returns error",
+			binary:  "/nonexistent/helm",
+			release: "my-release",
+			ns:      "test-ns",
+			max:     10,
+			wantErr: true,
+			errMsg:  "helm history",
+		},
+		{
+			name:    "invalid JSON output returns parse error",
+			binary:  "echo",
+			release: "my-release",
+			ns:      "test-ns",
+			max:     10,
+			wantErr: true,
+			errMsg:  "parsing helm history output",
+		},
+		{
+			name:    "zero max uses default 256",
+			binary:  "echo",
+			release: "my-release",
+			ns:      "test-ns",
+			max:     0, // should default to 256
+			wantErr: true,
+			errMsg:  "parsing helm history output",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := NewHelmClient(tt.binary, "", 1*time.Minute)
+
+			revisions, err := client.History(context.Background(), tt.release, tt.ns, tt.max)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Nil(t, revisions)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHelmClient_History_ArgumentInjection(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 1*time.Minute)
+
+	tests := []struct {
+		name    string
+		release string
+	}{
+		{
+			name:    "release name with single dash prefix",
+			release: "-malicious",
+		},
+		{
+			name:    "release name with double dash prefix",
+			release: "--kubeconfig=/etc/secret",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := client.History(context.Background(), tt.release, "test-ns", 10)
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, errArgDashPrefix))
+		})
+	}
+}
+
+// ---- Rollback tests ----
+
+func TestHelmClient_Rollback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		binary   string
+		release  string
+		ns       string
+		revision int
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "invalid binary returns error",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 1,
+			wantErr:  true,
+			errMsg:   "helm command failed",
+		},
+		{
+			name:     "revision 0 rolls back to previous",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 0,
+			wantErr:  true,
+			errMsg:   "helm command failed",
+		},
+		{
+			name:     "specific revision",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 3,
+			wantErr:  true,
+			errMsg:   "helm command failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := NewHelmClient(tt.binary, "", 1*time.Minute)
+
+			output, err := client.Rollback(context.Background(), tt.release, tt.ns, tt.revision)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				_ = output
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHelmClient_Rollback_ArgumentInjection(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 1*time.Minute)
+
+	tests := []struct {
+		name    string
+		release string
+	}{
+		{
+			name:    "release name with single dash prefix",
+			release: "-malicious",
+		},
+		{
+			name:    "release name with flag injection",
+			release: "--post-renderer=evil",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := client.Rollback(context.Background(), tt.release, "test-ns", 1)
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, errArgDashPrefix))
+		})
+	}
+}
+
+// ---- GetValues tests ----
+
+func TestHelmClient_GetValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		binary   string
+		release  string
+		ns       string
+		revision int
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "invalid binary returns error",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 1,
+			wantErr:  true,
+			errMsg:   "helm get values",
+		},
+		{
+			name:     "revision 0 omits --revision flag",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 0, // no --revision flag added
+			wantErr:  true,
+			errMsg:   "helm get values",
+		},
+		{
+			name:     "specific revision passes --revision flag",
+			binary:   "/nonexistent/helm",
+			release:  "my-release",
+			ns:       "test-ns",
+			revision: 5,
+			wantErr:  true,
+			errMsg:   "helm get values",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := NewHelmClient(tt.binary, "", 1*time.Minute)
+
+			output, err := client.GetValues(context.Background(), tt.release, tt.ns, tt.revision)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				assert.Empty(t, output)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHelmClient_GetValues_ArgumentInjection(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 1*time.Minute)
+
+	tests := []struct {
+		name    string
+		release string
+	}{
+		{
+			name:    "release name with single dash prefix",
+			release: "-malicious",
+		},
+		{
+			name:    "release name with flag injection",
+			release: "--kubeconfig=/etc/secret",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := client.GetValues(context.Background(), tt.release, "test-ns", 0)
+			assert.Error(t, err)
+			assert.True(t, errors.Is(err, errArgDashPrefix))
+		})
+	}
+}
+
+func TestHelmClient_GetValues_RevisionZeroOmitsFlag(t *testing.T) {
+	t.Parallel()
+
+	// Use "echo" as the binary: it prints its args to stdout and exits 0.
+	// When revision is 0, "--revision" should NOT appear in the args.
+	// When revision > 0, "--revision" should appear.
+	// Because echo exits 0 the output will just be the args — we can inspect whether
+	// --revision is present to verify branching behaviour.
+	client := NewHelmClient("echo", "", 1*time.Minute)
+
+	t.Run("revision 0 — no --revision flag in output", func(t *testing.T) {
+		t.Parallel()
+		output, err := client.GetValues(context.Background(), "my-release", "test-ns", 0)
+		assert.NoError(t, err)
+		assert.NotContains(t, output, "--revision")
+	})
+
+	t.Run("revision 5 — --revision flag appears in output", func(t *testing.T) {
+		t.Parallel()
+		output, err := client.GetValues(context.Background(), "my-release", "test-ns", 5)
+		assert.NoError(t, err)
+		assert.Contains(t, output, "--revision")
+	})
+}

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -525,6 +525,7 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 		instance.LastDeployedAt = &now
 		instance.LastDeployedValues = lastDeployedValues
 		deployLog.Status = models.DeployLogSuccess
+		deployLog.ValuesSnapshot = lastDeployedValues
 
 		slog.Info("deployment succeeded",
 			"instance_id", instanceID,
@@ -1078,6 +1079,231 @@ func (m *Manager) finalizeClean(instanceID string, deployLog *models.DeploymentL
 		m.broadcastStatusWithError(instanceID, models.StackStatusError, deployLog.ID, instance.ErrorMessage)
 	} else {
 		m.broadcastStatus(instanceID, models.StackStatusDraft, deployLog.ID)
+	}
+}
+
+// RollbackRequest contains everything needed to rollback a stack instance.
+type RollbackRequest struct {
+	Instance    *models.StackInstance
+	Charts      []ChartDeployInfo
+	TargetLogID string
+}
+
+// Rollback starts an async rollback of all charts in a stack instance to their
+// previous Helm revision. Each chart release is rolled back by one revision.
+// Returns the deployment log ID immediately.
+func (m *Manager) Rollback(ctx context.Context, req RollbackRequest) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", fmt.Errorf("request cancelled: %w", err)
+	}
+	if m.shuttingDown.Load() {
+		return "", fmt.Errorf("server is shutting down")
+	}
+	if m.registry == nil {
+		return "", fmt.Errorf("cluster registry is not configured")
+	}
+
+	clusterID, err := m.registry.ResolveClusterID(req.Instance.ClusterID)
+	if err != nil {
+		return "", fmt.Errorf("resolving cluster: %w", err)
+	}
+	helmExec, err := m.registry.GetHelmExecutor(clusterID)
+	if err != nil {
+		return "", fmt.Errorf("getting cluster clients: %w", err)
+	}
+	if helmExec == nil {
+		return "", fmt.Errorf("getting cluster clients: helm executor is nil")
+	}
+
+	logID := uuid.New().String()
+
+	if err := m.fireDeployHook(ctx, hooks.EventPreRollback, req.Instance, logID, time.Time{}); err != nil {
+		return "", fmt.Errorf("pre-rollback hook: %w", err)
+	}
+
+	now := time.Now().UTC()
+
+	deployLog := &models.DeploymentLog{
+		ID:              logID,
+		StackInstanceID: req.Instance.ID,
+		Action:          models.DeployActionRollback,
+		Status:          models.DeployLogRunning,
+		StartedAt:       now,
+		TargetLogID:     req.TargetLogID,
+	}
+	req.Instance.Status = models.StackStatusDeploying
+	req.Instance.ErrorMessage = ""
+
+	if m.txRunner != nil {
+		if err := m.txRunner.RunInTx(func(repos database.TxRepos) error {
+			if err := repos.DeploymentLog.Create(ctx, deployLog); err != nil {
+				return fmt.Errorf("creating deployment log: %w", err)
+			}
+			if err := repos.StackInstance.Update(req.Instance); err != nil {
+				return fmt.Errorf("updating instance status: %w", err)
+			}
+			return nil
+		}); err != nil {
+			return "", err
+		}
+	} else {
+		if err := m.logRepo.Create(ctx, deployLog); err != nil {
+			return "", fmt.Errorf("creating deployment log: %w", err)
+		}
+		if err := m.instanceRepo.Update(req.Instance); err != nil {
+			return "", fmt.Errorf("updating instance status: %w", err)
+		}
+	}
+
+	m.broadcastStatus(req.Instance.ID, models.StackStatusDeploying, logID)
+
+	charts := make([]ChartDeployInfo, len(req.Charts))
+	copy(charts, req.Charts)
+	sort.Slice(charts, func(i, j int) bool {
+		return charts[i].ChartConfig.DeployOrder < charts[j].ChartConfig.DeployOrder
+	})
+
+	m.wg.Add(1)
+	go m.executeRollback(helmExec, req.Instance.ID, deployLog, req.Instance.Namespace, charts)
+
+	return logID, nil
+}
+
+// executeRollback rolls back each chart release by one Helm revision.
+func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLog *models.DeploymentLog, namespace string, charts []ChartDeployInfo) {
+	defer m.wg.Done()
+	m.semaphore <- struct{}{}
+	defer func() { <-m.semaphore }()
+
+	_, _, finishSpan := startDeploySpan(context.Background(), "deployer.rollback", //nolint:gosec // G118: intentional — Helm operations must outlive HTTP request
+		attribute.String("instance.id", instanceID),
+		attribute.String("namespace", namespace),
+		attribute.String("log.id", deployLog.ID),
+	)
+
+	var allOutput string
+	var rollbackErr error
+	defer func() { finishSpan(rollbackErr) }()
+
+	var timeout time.Duration
+	if helm != nil {
+		timeout = helm.Timeout()
+	} else {
+		timeout = 5 * time.Minute
+	}
+	ctx, cancel := context.WithTimeout(m.shutdownCtx, timeout)
+	defer cancel()
+
+	for _, chart := range charts {
+		releaseName := chart.ChartConfig.ChartName
+
+		slog.Info("rolling back chart",
+			"instance_id", instanceID,
+			"chart", releaseName,
+			"namespace", namespace,
+		)
+
+		// Query Helm history to find the current revision, then roll back by one.
+		revisions, err := helm.History(ctx, releaseName, namespace, 2)
+		if err != nil {
+			rollbackErr = fmt.Errorf("getting history for chart %q: %w", releaseName, err)
+			allOutput += fmt.Sprintf("ERROR: %s\n", rollbackErr.Error())
+			break
+		}
+
+		if len(revisions) < 2 {
+			allOutput += fmt.Sprintf("=== Chart: %s === (skipped: only %d revision)\n", releaseName, len(revisions))
+			continue
+		}
+
+		// Helm history is sorted ascending by revision; second-to-last is the target.
+		targetRevision := revisions[len(revisions)-2].Revision
+
+		output, err := helm.Rollback(ctx, releaseName, namespace, targetRevision)
+		allOutput += fmt.Sprintf("=== Chart: %s (→ rev %d) ===\n%s\n", releaseName, targetRevision, output)
+		m.broadcastLog(instanceID, deployLog.ID, output)
+
+		if err != nil {
+			rollbackErr = fmt.Errorf("rolling back chart %q to revision %d: %w", releaseName, targetRevision, err)
+			allOutput += fmt.Sprintf("ERROR: %s\n", rollbackErr.Error())
+			break
+		}
+	}
+
+	m.finalizeRollback(instanceID, deployLog, allOutput, rollbackErr)
+}
+
+// finalizeRollback updates the instance and deployment log with the final rollback status.
+func (m *Manager) finalizeRollback(instanceID string, deployLog *models.DeploymentLog, output string, rollbackErr error) {
+	now := time.Now().UTC()
+
+	instance, err := m.instanceRepo.FindByID(instanceID)
+	if err != nil {
+		slog.Error("failed to find instance for rollback finalization",
+			"instance_id", instanceID, "error", err)
+		return
+	}
+
+	deployLog.Output = truncateString(output, maxOutputLen)
+	deployLog.CompletedAt = &now
+
+	if rollbackErr != nil {
+		sanitized := sanitizeDeployError(rollbackErr)
+		instance.Status = models.StackStatusError
+		instance.ErrorMessage = truncateString(sanitized, maxInstanceErrorLen)
+		deployLog.Status = models.DeployLogError
+		deployLog.ErrorMessage = truncateString(sanitized, maxLogErrorLen)
+
+		slog.Error("rollback failed",
+			"instance_id", instanceID,
+			"log_id", deployLog.ID,
+			"error", rollbackErr,
+		)
+	} else {
+		instance.Status = models.StackStatusRunning
+		instance.ErrorMessage = ""
+		instance.LastDeployedAt = &now
+		deployLog.Status = models.DeployLogSuccess
+
+		slog.Info("rollback succeeded",
+			"instance_id", instanceID,
+			"log_id", deployLog.ID,
+		)
+	}
+
+	if m.txRunner != nil {
+		if err := m.txRunner.RunInTx(func(repos database.TxRepos) error {
+			if err := repos.StackInstance.Update(instance); err != nil {
+				return fmt.Errorf("updating instance: %w", err)
+			}
+			if err := repos.DeploymentLog.Update(context.Background(), deployLog); err != nil {
+				return fmt.Errorf("updating deploy log: %w", err)
+			}
+			return nil
+		}); err != nil {
+			slog.Error("failed to finalize rollback atomically",
+				"instance_id", instanceID, "error", err)
+		}
+	} else {
+		if err := m.instanceRepo.Update(instance); err != nil {
+			slog.Error("failed to update instance after rollback",
+				"instance_id", instanceID, "deploy_log_id", deployLog.ID, "error", err)
+		}
+		if err := m.logRepo.Update(m.shutdownCtx, deployLog); err != nil {
+			slog.Error("failed to update deploy log after rollback",
+				"instance_id", instanceID, "deploy_log_id", deployLog.ID, "error", err)
+		}
+	}
+
+	if rollbackErr != nil {
+		m.broadcastStatusWithError(instanceID, models.StackStatusError, deployLog.ID, instance.ErrorMessage)
+	} else {
+		m.broadcastStatus(instanceID, models.StackStatusRunning, deployLog.ID)
+	}
+
+	hookCtx := m.shutdownCtx
+	if rollbackErr == nil {
+		_ = m.fireDeployHook(hookCtx, hooks.EventPostRollback, instance, deployLog.ID, deployLog.StartedAt)
 	}
 }
 

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
@@ -791,7 +792,7 @@ func (m *Manager) finalizeStop(instanceID string, deployLog *models.DeploymentLo
 }
 
 // sanitizeDeployError extracts the relevant error message from Helm/K8s
-// command output for deploy, stop, and clean operations, stripping verbose output.
+// command output for deploy, stop, clean, and rollback operations, stripping verbose output.
 // The full Helm output may contain sensitive data
 // (cluster names, internal URLs, credentials in env vars) and must not be
 // exposed in user-visible fields like StackInstance.ErrorMessage. The raw
@@ -813,6 +814,7 @@ func sanitizeDeployError(err error) string {
 	for _, prefix := range []string{
 		"deploying chart ", "uninstalling chart ", "deleting namespace ", "creating temp directory",
 		"scaling down ", "scaling up ", "waiting for MySQL", "running PVC cleanup",
+		"getting history for chart ", "rolling back chart ",
 	} {
 		if strings.HasPrefix(msg, prefix) {
 			// Find the chart name in quotes if present.
@@ -1216,8 +1218,9 @@ func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLo
 			continue
 		}
 
-		// Helm history is sorted ascending by revision; second-to-last is the target.
-		targetRevision := revisions[len(revisions)-2].Revision
+		// Helm history returns revisions sorted ascending (oldest first).
+		// With max=2 we get [previous, current]; index 0 is the rollback target.
+		targetRevision := revisions[0].Revision
 
 		output, err := helm.Rollback(ctx, releaseName, namespace, targetRevision)
 		allOutput += fmt.Sprintf("=== Chart: %s (→ rev %d) ===\n%s\n", releaseName, targetRevision, output)
@@ -1230,11 +1233,41 @@ func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLo
 		}
 	}
 
-	m.finalizeRollback(instanceID, deployLog, allOutput, rollbackErr)
+	// Collect post-rollback values for snapshot.
+	var valuesSnapshot string
+	if rollbackErr == nil {
+		valuesSnapshot = m.collectChartValues(context.Background(), helm, namespace, charts) //nolint:gosec // G118: intentional — must outlive HTTP request
+	}
+
+	m.finalizeRollback(instanceID, deployLog, allOutput, rollbackErr, valuesSnapshot)
+}
+
+// collectChartValues gathers the current Helm values for all charts and returns
+// them as a JSON string for storage in the deployment log values snapshot.
+func (m *Manager) collectChartValues(ctx context.Context, helm HelmExecutor, namespace string, charts []ChartDeployInfo) string {
+	allValues := make(map[string]interface{})
+	for _, chart := range charts {
+		vals, err := helm.GetValues(ctx, chart.ChartConfig.ChartName, namespace, 0)
+		if err != nil {
+			continue
+		}
+		var parsed interface{}
+		if jsonErr := json.Unmarshal([]byte(vals), &parsed); jsonErr == nil {
+			allValues[chart.ChartConfig.ChartName] = parsed
+		}
+	}
+	if len(allValues) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(allValues)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }
 
 // finalizeRollback updates the instance and deployment log with the final rollback status.
-func (m *Manager) finalizeRollback(instanceID string, deployLog *models.DeploymentLog, output string, rollbackErr error) {
+func (m *Manager) finalizeRollback(instanceID string, deployLog *models.DeploymentLog, output string, rollbackErr error, valuesSnapshot string) {
 	now := time.Now().UTC()
 
 	instance, err := m.instanceRepo.FindByID(instanceID)
@@ -1264,6 +1297,11 @@ func (m *Manager) finalizeRollback(instanceID string, deployLog *models.Deployme
 		instance.ErrorMessage = ""
 		instance.LastDeployedAt = &now
 		deployLog.Status = models.DeployLogSuccess
+
+		if valuesSnapshot != "" {
+			instance.LastDeployedValues = valuesSnapshot
+			deployLog.ValuesSnapshot = valuesSnapshot
+		}
 
 		slog.Info("rollback succeeded",
 			"instance_id", instanceID,

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -1457,6 +1457,18 @@ func (m *mockHelmExecutor) ListReleases(_ context.Context, _ string) ([]string, 
 	return nil, nil
 }
 
+func (m *mockHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]ReleaseRevision, error) {
+	return nil, nil
+}
+
+func (m *mockHelmExecutor) Rollback(_ context.Context, releaseName string, _ string, _ int) (string, error) {
+	return "rolled back " + releaseName, nil
+}
+
+func (m *mockHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ int) (string, error) {
+	return "", nil
+}
+
 func (m *mockHelmExecutor) Timeout() time.Duration {
 	if m.timeout > 0 {
 		return m.timeout

--- a/backend/internal/hooks/types.go
+++ b/backend/internal/hooks/types.go
@@ -18,6 +18,8 @@ const (
 	EventPostInstanceDelete  = "post-instance-delete"
 	EventPreNamespaceCreate  = "pre-namespace-create"
 	EventPostNamespaceCreate = "post-namespace-create"
+	EventPreRollback         = "pre-rollback"
+	EventPostRollback        = "post-rollback"
 	EventDeployFinalized     = "deploy-finalized"
 )
 

--- a/backend/internal/models/deployment_log.go
+++ b/backend/internal/models/deployment_log.go
@@ -11,17 +11,20 @@ type DeploymentLog struct {
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
 	ID              string     `json:"id" gorm:"primaryKey;size:36"`
 	StackInstanceID string     `json:"stack_instance_id" gorm:"size:36"`
-	Action          string     `json:"action" gorm:"size:50"` // "deploy", "stop", "clean"
+	Action          string     `json:"action" gorm:"size:50"` // "deploy", "stop", "clean", "rollback"
 	Status          string     `json:"status" gorm:"size:50"` // "running", "success", "error"
 	Output          string     `json:"output" gorm:"type:longtext"`
 	ErrorMessage    string     `json:"error_message,omitempty" gorm:"type:text"`
+	ValuesSnapshot  string     `json:"values_snapshot,omitempty" gorm:"type:longtext"`
+	TargetLogID     string     `json:"target_log_id,omitempty" gorm:"size:36"`
 }
 
 // Deployment log action constants.
 const (
-	DeployActionDeploy    = "deploy"
-	DeployActionStop      = "stop"
-	DeployActionClean     = "clean"
+	DeployActionDeploy   = "deploy"
+	DeployActionStop     = "stop"
+	DeployActionClean    = "clean"
+	DeployActionRollback = "rollback"
 )
 
 // Deployment log status constants.


### PR DESCRIPTION
## Summary
- Adds `History()`, `Rollback()`, and `GetValues()` to the `HelmExecutor` interface with full CLI wrapper implementations
- Extends `DeploymentLog` model with `values_snapshot` and `target_log_id` fields, stored on each successful deploy
- Implements async `Manager.Rollback()` that rolls each chart back by one Helm revision (same concurrency pattern as deploy)
- Adds `POST /:id/rollback` and `GET /:id/deploy-log/:logId/values` API endpoints
- Adds `pre-rollback` and `post-rollback` hook events
- Includes DB migration for new columns

Closes #114

## Test plan
- [ ] All existing backend tests pass (`go test ./...`)
- [ ] Mock executor stubs added to all test files that use HelmExecutor
- [ ] Test rollback API endpoint with a running stack instance
- [ ] Verify values snapshot is stored after a successful deploy
- [ ] Verify rollback creates a new deploy log with action "rollback"

🤖 Generated with [Claude Code](https://claude.com/claude-code)