### PR TITLE
fix: flatten wrapped API responses for definitions and templates

### DIFF
--- a/backend/internal/api/handlers/stack_definitions.go
+++ b/backend/internal/api/handlers/stack_definitions.go
@@ -213,7 +213,7 @@ func (h *DefinitionHandler) CreateDefinition(c *gin.Context) {
 // @Tags        stack-definitions
 // @Produce     json
 // @Param       id  path     string true "Definition ID"
-// @Success     200 {object} models.StackDefinition
+// @Success     200 {object} DefinitionWithChartsResponse
 // @Failure     404 {object} map[string]string
 // @Router      /api/v1/stack-definitions/{id} [get]
 func (h *DefinitionHandler) GetDefinition(c *gin.Context) {
@@ -237,9 +237,9 @@ func (h *DefinitionHandler) GetDefinition(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"definition": def,
-		"charts":     charts,
+	c.JSON(http.StatusOK, DefinitionWithChartsResponse{
+		StackDefinition: *def,
+		Charts:          charts,
 	})
 }
 
@@ -400,7 +400,7 @@ func (h *DefinitionHandler) ExportDefinition(c *gin.Context) {
 // @Accept      json
 // @Produce     json
 // @Param       bundle body     DefinitionExportBundle true "Export bundle"
-// @Success     201    {object} map[string]interface{}
+// @Success     201    {object} DefinitionWithChartsResponse
 // @Failure     400    {object} map[string]string
 // @Failure     500    {object} map[string]string
 // @Router      /api/v1/stack-definitions/import [post]
@@ -501,9 +501,9 @@ func (h *DefinitionHandler) ImportDefinition(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
-		"definition": def,
-		"charts":     createdCharts,
+	c.JSON(http.StatusCreated, DefinitionWithChartsResponse{
+		StackDefinition: def,
+		Charts:          createdCharts,
 	})
 }
 
@@ -633,7 +633,7 @@ func computeUpgradeChanges(defCharts []models.ChartConfig, templateCharts []mode
 // @Accept      json
 // @Produce     json
 // @Param       id  path     string true "Definition ID"
-// @Success     200 {object} map[string]interface{}
+// @Success     200 {object} DefinitionWithChartsResponse
 // @Failure     400 {object} map[string]string
 // @Failure     404 {object} map[string]string
 // @Failure     409 {object} map[string]string
@@ -753,8 +753,8 @@ func (h *DefinitionHandler) ApplyUpgrade(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"definition": def,
-		"charts":     updatedCharts,
+	c.JSON(http.StatusOK, DefinitionWithChartsResponse{
+		StackDefinition: *def,
+		Charts:          updatedCharts,
 	})
 }

--- a/backend/internal/api/handlers/stack_definitions_test.go
+++ b/backend/internal/api/handlers/stack_definitions_test.go
@@ -292,11 +292,13 @@ func TestGetDefinition(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-definitions/d1", nil)
 		router.ServeHTTP(w, req)
 
-		assert.Equal(t, http.StatusOK, w.Code)
-		var resp map[string]interface{}
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp DefinitionWithChartsResponse
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		assert.NotNil(t, resp["definition"])
-		assert.NotNil(t, resp["charts"])
+		assert.Equal(t, "d1", resp.ID)
+		assert.Equal(t, "My Stack", resp.Name)
+		assert.Len(t, resp.Charts, 1)
+		assert.Equal(t, "backend", resp.Charts[0].ChartName)
 	})
 
 	t.Run("not found returns 404", func(t *testing.T) {
@@ -731,15 +733,12 @@ func TestImportDefinition(t *testing.T) {
 			}
 
 			if tt.wantStatus == http.StatusCreated {
-				var resp map[string]json.RawMessage
+				var resp DefinitionWithChartsResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-
-				var def models.StackDefinition
-				require.NoError(t, json.Unmarshal(resp["definition"], &def))
-				assert.NotEmpty(t, def.ID)
-				assert.Equal(t, tt.callerID, def.OwnerID)
-				assert.NotEmpty(t, def.CreatedAt)
-				assert.NotEmpty(t, def.UpdatedAt)
+				assert.NotEmpty(t, resp.ID)
+				assert.Equal(t, tt.callerID, resp.OwnerID)
+				assert.NotEmpty(t, resp.CreatedAt)
+				assert.NotEmpty(t, resp.UpdatedAt)
 			}
 		})
 	}
@@ -783,25 +782,20 @@ func TestExportImportRoundTrip(t *testing.T) {
 
 		require.Equal(t, http.StatusCreated, w2.Code)
 
-		var resp map[string]json.RawMessage
+		var resp DefinitionWithChartsResponse
 		require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
 
-		var importedDef models.StackDefinition
-		require.NoError(t, json.Unmarshal(resp["definition"], &importedDef))
-
 		// Fresh ID, different from original.
-		assert.NotEqual(t, "d1", importedDef.ID)
-		assert.Equal(t, "Round Trip Stack", importedDef.Name)
+		assert.NotEqual(t, "d1", resp.ID)
+		assert.Equal(t, "Round Trip Stack", resp.Name)
 		// Owner is the importing user.
-		assert.Equal(t, "uid-2", importedDef.OwnerID)
+		assert.Equal(t, "uid-2", resp.OwnerID)
 
-		var importedCharts []models.ChartConfig
-		require.NoError(t, json.Unmarshal(resp["charts"], &importedCharts))
-		assert.Len(t, importedCharts, 1)
-		assert.NotEqual(t, "c1", importedCharts[0].ID)
-		assert.Equal(t, importedDef.ID, importedCharts[0].StackDefinitionID)
-		assert.Equal(t, "api", importedCharts[0].ChartName)
-		assert.Equal(t, "https://charts.example.com", importedCharts[0].RepositoryURL)
-		assert.Equal(t, "port: 8080", importedCharts[0].DefaultValues)
+		assert.Len(t, resp.Charts, 1)
+		assert.NotEqual(t, "c1", resp.Charts[0].ID)
+		assert.Equal(t, resp.ID, resp.Charts[0].StackDefinitionID)
+		assert.Equal(t, "api", resp.Charts[0].ChartName)
+		assert.Equal(t, "https://charts.example.com", resp.Charts[0].RepositoryURL)
+		assert.Equal(t, "port: 8080", resp.Charts[0].DefaultValues)
 	})
 }

--- a/backend/internal/api/handlers/stack_templates.go
+++ b/backend/internal/api/handlers/stack_templates.go
@@ -82,6 +82,20 @@ type TemplateListItem struct {
 	OwnerUsername   string `json:"owner_username,omitempty"`
 }
 
+// TemplateDetailResponse is a flat response for GET /templates/:id that embeds
+// chart configs directly instead of wrapping in a "template" key.
+type TemplateDetailResponse struct {
+	models.StackTemplate
+	Charts []models.TemplateChartConfig `json:"charts"`
+}
+
+// DefinitionWithChartsResponse is a flat response for endpoints that return a
+// stack definition together with its chart configs.
+type DefinitionWithChartsResponse struct {
+	models.StackDefinition
+	Charts []models.ChartConfig `json:"charts"`
+}
+
 // ListTemplates godoc
 // @Summary     List stack templates
 // @Description List published templates for regular users, all templates for devops/admin. Includes definition_count and owner_username. Supports server-side pagination.
@@ -223,7 +237,7 @@ func (h *TemplateHandler) CreateTemplate(c *gin.Context) {
 // @Tags        templates
 // @Produce     json
 // @Param       id  path     string true "Template ID"
-// @Success     200 {object} models.StackTemplate
+// @Success     200 {object} TemplateDetailResponse
 // @Failure     404 {object} map[string]string
 // @Router      /api/v1/templates/{id} [get]
 func (h *TemplateHandler) GetTemplate(c *gin.Context) {
@@ -247,9 +261,12 @@ func (h *TemplateHandler) GetTemplate(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
-		"template": tmpl,
-		"charts":   charts,
+	if charts == nil {
+		charts = []models.TemplateChartConfig{}
+	}
+	c.JSON(http.StatusOK, TemplateDetailResponse{
+		StackTemplate: *tmpl,
+		Charts:        charts,
 	})
 }
 
@@ -468,7 +485,7 @@ func (h *TemplateHandler) UnpublishTemplate(c *gin.Context) {
 // @Produce     json
 // @Param       id   path     string                true "Template ID"
 // @Param       body body     models.StackDefinition true "Definition overrides (name, description)"
-// @Success     201  {object} models.StackDefinition
+// @Success     201  {object} DefinitionWithChartsResponse
 // @Failure     400  {object} map[string]string
 // @Failure     404  {object} map[string]string
 // @Router      /api/v1/templates/{id}/instantiate [post]
@@ -525,9 +542,9 @@ func (h *TemplateHandler) InstantiateTemplate(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, gin.H{
-		"definition": def,
-		"charts":     chartConfigs,
+	c.JSON(http.StatusCreated, DefinitionWithChartsResponse{
+		StackDefinition: *def,
+		Charts:          chartConfigs,
 	})
 }
 

--- a/backend/internal/api/handlers/stack_templates_test.go
+++ b/backend/internal/api/handlers/stack_templates_test.go
@@ -300,6 +300,45 @@ func TestGetTemplate(t *testing.T) {
 			assert.Equal(t, tt.wantStatus, w.Code)
 		})
 	}
+
+	t.Run("response is flat with charts array", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMockStackTemplateRepository()
+		seedTemplate(t, repo, "t1", "My Template", "owner-1", true)
+		chartRepo := NewMockTemplateChartConfigRepository()
+		require.NoError(t, chartRepo.Create(&models.TemplateChartConfig{
+			ID:              "tc1",
+			StackTemplateID: "t1",
+			ChartName:       "backend",
+		}))
+
+		router := setupTemplateRouter(repo, chartRepo, NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), "uid-1", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/templates/t1", nil)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		var resp TemplateDetailResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Equal(t, "t1", resp.ID)
+		assert.Equal(t, "My Template", resp.Name)
+		assert.Len(t, resp.Charts, 1)
+		assert.Equal(t, "backend", resp.Charts[0].ChartName)
+	})
+
+	t.Run("response has empty array not null when no charts", func(t *testing.T) {
+		t.Parallel()
+		repo := NewMockStackTemplateRepository()
+		seedTemplate(t, repo, "t2", "Empty Template", "owner-1", false)
+
+		router := setupTemplateRouter(repo, NewMockTemplateChartConfigRepository(), NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), "uid-1", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/templates/t2", nil)
+		router.ServeHTTP(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"charts":[]`)
+	})
 }
 
 // ---- UpdateTemplate ----
@@ -496,20 +535,16 @@ func TestInstantiateTemplate(t *testing.T) {
 		router.ServeHTTP(w, req)
 
 		assert.Equal(t, http.StatusCreated, w.Code)
-		var resp map[string]json.RawMessage
+		var resp DefinitionWithChartsResponse
 		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
-		var def models.StackDefinition
-		require.NoError(t, json.Unmarshal(resp["definition"], &def))
-		assert.Equal(t, "my-def", def.Name)
-		assert.Equal(t, "t1", def.SourceTemplateID)
-		assert.Equal(t, "uid-1", def.OwnerID)
+		assert.Equal(t, "my-def", resp.Name)
+		assert.Equal(t, "t1", resp.SourceTemplateID)
+		assert.Equal(t, "uid-1", resp.OwnerID)
 
 		// Verify that created chart configs are returned (non-empty).
-		var charts []models.ChartConfig
-		require.NoError(t, json.Unmarshal(resp["charts"], &charts))
-		assert.Len(t, charts, 1, "response should contain the copied chart config")
-		assert.Equal(t, "my-service", charts[0].ChartName)
-		assert.Equal(t, def.ID, charts[0].StackDefinitionID)
+		assert.Len(t, resp.Charts, 1, "response should contain the copied chart config")
+		assert.Equal(t, "my-service", resp.Charts[0].ChartName)
+		assert.Equal(t, resp.ID, resp.Charts[0].StackDefinitionID)
 	})
 
 	t.Run("template not found returns 404", func(t *testing.T) {

--- a/backend/internal/api/handlers/template_versions_test.go
+++ b/backend/internal/api/handlers/template_versions_test.go
@@ -551,20 +551,15 @@ func TestApplyUpgrade(t *testing.T) {
 			wantStatus: http.StatusOK,
 			check: func(t *testing.T, w *httptest.ResponseRecorder, ccRepo *MockChartConfigRepository) {
 				t.Helper()
-				var resp map[string]json.RawMessage
+				var resp DefinitionWithChartsResponse
 				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+				assert.Equal(t, "2.0", resp.SourceTemplateVersion)
 
-				var def models.StackDefinition
-				require.NoError(t, json.Unmarshal(resp["definition"], &def))
-				assert.Equal(t, "2.0", def.SourceTemplateVersion)
-
-				var charts []models.ChartConfig
-				require.NoError(t, json.Unmarshal(resp["charts"], &charts))
 				// Should have: frontend (updated), user-custom (preserved), backend (added)
-				assert.Len(t, charts, 3)
+				assert.Len(t, resp.Charts, 3)
 
 				chartMap := make(map[string]models.ChartConfig)
-				for _, ch := range charts {
+				for _, ch := range resp.Charts {
 					chartMap[ch.ChartName] = ch
 				}
 				assert.Equal(t, "port: 8080", chartMap["frontend"].DefaultValues)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -306,9 +306,7 @@ export const templateService = {
   get: async (id: string): Promise<StackTemplate> => {
     try {
       const response = await api.get(`/api/v1/templates/${id}`);
-      // API returns { template: {...}, charts: [...] }
-      const { template, charts } = response.data;
-      return { ...template, charts: charts || [] };
+      return { ...response.data, charts: response.data.charts || [] };
     } catch (error) {
       console.error('Failed to fetch template:', error);
       throw error;
@@ -398,8 +396,7 @@ export const templateService = {
   instantiate: async (id: string, data: InstantiateTemplateRequest): Promise<StackDefinition> => {
     try {
       const response = await api.post(`/api/v1/templates/${id}/instantiate`, data);
-      // API returns { definition: {...}, charts: [...] }
-      return response.data.definition;
+      return response.data;
     } catch (error) {
       console.error('Failed to instantiate template:', error);
       throw error;


### PR DESCRIPTION
## Summary
- Flatten `GET /stack-definitions/:id`, `POST /stack-definitions/:id/upgrade`, `GET /templates/:id`, and `POST /templates/:id/instantiate` to return flat JSON with embedded `charts` array instead of `{"definition": {...}, "charts": [...]}`
- Update frontend `client.ts` to consume the new flat response shape
- Add null guard so empty charts returns `[]` not `null`
- Update Swagger annotations to reference `TemplateDetailResponse` and `DefinitionWithChartsResponse`
- Fix all affected handler and version tests

## Test plan
- [x] `go test ./internal/api/handlers/...` — all pass
- [ ] Verify frontend template detail page loads correctly
- [ ] Verify template instantiate flow works end-to-end
- [ ] Verify definition import/export round-trip

Companion CLI PR: omattsson/stackctl#39 (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)