### PR TITLE
feat: add name query param to ListInstances for CLI name resolution

### DIFF
--- a/backend/api/main_test.go
+++ b/backend/api/main_test.go
@@ -474,6 +474,8 @@ func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
+
 func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }

--- a/backend/internal/api/handlers/cleanup_policies_test.go
+++ b/backend/internal/api/handlers/cleanup_policies_test.go
@@ -717,6 +717,9 @@ func (r *cleanupMockInstanceRepo) List() ([]models.StackInstance, error) { retur
 func (r *cleanupMockInstanceRepo) ListByOwner(_ string) ([]models.StackInstance, error) {
 	return nil, nil
 }
+func (r *cleanupMockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
 func (r *cleanupMockInstanceRepo) FindByCluster(id string) ([]models.StackInstance, error) {
 	var result []models.StackInstance
 	for _, inst := range r.instances {

--- a/backend/internal/api/handlers/mock_domain_repositories_test.go
+++ b/backend/internal/api/handlers/mock_domain_repositories_test.go
@@ -795,6 +795,21 @@ func (m *MockStackInstanceRepository) ListByOwner(ownerID string) ([]models.Stac
 	return out, nil
 }
 
+func (m *MockStackInstanceRepository) FindByName(name string) ([]models.StackInstance, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	var out []models.StackInstance
+	for _, i := range m.items {
+		if i.Name == name {
+			out = append(out, *i)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockStackInstanceRepository) FindByCluster(clusterID string) ([]models.StackInstance, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -252,10 +252,11 @@ const listPageSizeMax = 100
 
 // ListInstances godoc
 // @Summary     List stack instances
-// @Description List stack instances with server-side pagination. Supports page/pageSize or legacy limit/offset params. Use owner=me to filter by the authenticated user.
+// @Description List stack instances with server-side pagination. Supports page/pageSize or legacy limit/offset params. Use owner=me to filter by the authenticated user. Filter precedence: owner > name > pagination (only the first matching filter is applied).
 // @Tags        stack-instances
 // @Produce     json
 // @Param       owner    query    string false "Filter by owner (use 'me' for current user)"
+// @Param       name     query    string false "Filter by exact instance name"
 // @Param       page     query    int    false "Page number (1-based, default: 1)"
 // @Param       pageSize query    int    false "Results per page (default: 25, max: 100)"
 // @Param       limit    query    int    false "Legacy: maximum number of results"
@@ -270,6 +271,23 @@ func (h *InstanceHandler) ListInstances(c *gin.Context) {
 	if owner == "me" {
 		userID := middleware.GetUserIDFromContext(c)
 		instances, err := h.instanceRepo.ListByOwner(userID)
+		if err != nil {
+			status, message := mapError(err, entityStackInstance)
+			c.JSON(status, gin.H{"error": message})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"data":     instances,
+			"total":    len(instances),
+			"page":     1,
+			"pageSize": len(instances),
+		})
+		return
+	}
+
+	// Name-filtered list — exact match, no pagination needed.
+	if name := c.Query("name"); name != "" {
+		instances, err := h.instanceRepo.FindByName(name)
 		if err != nil {
 			status, message := mapError(err, entityStackInstance)
 			c.JSON(status, gin.H{"error": message})

--- a/backend/internal/api/handlers/stack_instances_test.go
+++ b/backend/internal/api/handlers/stack_instances_test.go
@@ -195,6 +195,55 @@ func TestListInstances(t *testing.T) {
 		assert.Equal(t, 1, resp.Total)
 	})
 
+	t.Run("filters by name", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		seedInstance(t, instRepo, "i1", "my-stack", "d1", "uid-1", models.StackStatusRunning)
+		seedInstance(t, instRepo, "i2", "other-stack", "d1", "uid-2", models.StackStatusDraft)
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances?name=my-stack", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp pagedResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Len(t, resp.Data, 1)
+		assert.Equal(t, "my-stack", resp.Data[0].Name)
+		assert.Equal(t, 1, resp.Total)
+	})
+
+	t.Run("filters by name returns empty when no match", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		seedInstance(t, instRepo, "i1", "my-stack", "d1", "uid-1", models.StackStatusRunning)
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances?name=nonexistent", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp pagedResponse
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+		assert.Len(t, resp.Data, 0)
+		assert.Equal(t, 0, resp.Total)
+	})
+
+	t.Run("name filter with repository error returns 500", func(t *testing.T) {
+		t.Parallel()
+		instRepo := NewMockStackInstanceRepository()
+		instRepo.SetError(errInternal)
+
+		router := setupInstanceRouter(instRepo, NewMockValueOverrideRepository(), NewMockStackDefinitionRepository(), NewMockChartConfigRepository(), NewMockStackTemplateRepository(), NewMockTemplateChartConfigRepository(), "uid-1", "alice", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-instances?name=my-stack", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
+
 	t.Run("repository error returns 500", func(t *testing.T) {
 		t.Parallel()
 		instRepo := NewMockStackInstanceRepository()

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -791,6 +791,26 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
+	// Migration 33: Add index on stack_instances.name for name-based lookup
+	migrator.AddMigration(schema.Migration{
+		Version:     "20231201000033",
+		Name:        "add_stack_instances_name_index",
+		Description: "Add index on stack_instances(name) for FindByName queries used by CLI name resolution",
+		Up: func(tx *gorm.DB) error {
+			var count int64
+			tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?",
+				"stack_instances", "idx_stack_instances_name").Scan(&count)
+			if count > 0 {
+				return nil
+			}
+			return tx.Exec("CREATE INDEX idx_stack_instances_name ON stack_instances(name)").Error
+		},
+		Down: func(tx *gorm.DB) error {
+			_ = tx.Exec("DROP INDEX idx_stack_instances_name ON stack_instances").Error
+			return nil
+		},
+	})
+
 	// Run migrations
 	if err := migrator.MigrateUp(); err != nil {
 		return err

--- a/backend/internal/database/stack_instance_repository.go
+++ b/backend/internal/database/stack_instance_repository.go
@@ -131,6 +131,15 @@ func (r *GORMStackInstanceRepository) ListByOwner(ownerID string) ([]models.Stac
 	return instances, nil
 }
 
+// FindByName returns all stack instances with the given exact name.
+func (r *GORMStackInstanceRepository) FindByName(name string) ([]models.StackInstance, error) {
+	var instances []models.StackInstance
+	if err := r.db.Select(listColumns).Where("name = ?", name).Find(&instances).Error; err != nil {
+		return nil, dberrors.NewDatabaseError("find_by_name", err)
+	}
+	return instances, nil
+}
+
 // FindByCluster returns all stack instances targeting the given cluster.
 func (r *GORMStackInstanceRepository) FindByCluster(clusterID string) ([]models.StackInstance, error) {
 	var instances []models.StackInstance

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -149,6 +149,8 @@ func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
+
 func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }

--- a/backend/internal/k8s/watcher_test.go
+++ b/backend/internal/k8s/watcher_test.go
@@ -140,6 +140,8 @@ func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
+
 func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -43,6 +43,7 @@ type StackInstanceRepository interface {
 	List() ([]StackInstance, error)
 	ListPaged(limit, offset int) ([]StackInstance, int, error)
 	ListByOwner(ownerID string) ([]StackInstance, error)
+	FindByName(name string) ([]StackInstance, error)
 	FindByCluster(clusterID string) ([]StackInstance, error)
 	CountByClusterAndOwner(clusterID, ownerID string) (int, error)
 	CountAll() (int, error)

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -130,6 +130,7 @@ func (r *mockInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]stri
 func (r *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, error) {
 	return nil, nil
 }
+func (r *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
 
 // mockAuditRepo is a minimal in-memory mock for AuditLogRepository.
 type mockAuditRepo struct {

--- a/backend/internal/ttl/reaper_test.go
+++ b/backend/internal/ttl/reaper_test.go
@@ -84,6 +84,8 @@ func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
+
 func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()


### PR DESCRIPTION
## Summary

- Add `FindByName` method to `StackInstanceRepository` interface and GORM implementation
- Add `?name=` query parameter to `GET /api/v1/stack-instances` with documented filter precedence (owner > name > pagination)
- Add DB migration (v33) creating `idx_stack_instances_name` index
- Add tests for name filter: match, no-match, and repository error paths

## Context

Backend counterpart for omattsson/stackctl#40 — enables the CLI to resolve stack names to IDs via the API.

## Test plan

- [x] `go test ./...` passes (all packages)
- [x] New handler tests cover name filter happy path, empty result, and 500 error
- [x] Mock repositories updated across all test files (6 stubs + 1 full mock)
- [x] Manual: `curl /api/v1/stack-instances?name=foo` returns filtered results

🤖 Generated with [Claude Code](https://claude.com/claude-code)