### PR TITLE
fix: add preStop hooks and startup probe for zero-downtime deploys

### DIFF
--- a/helm/k8s-stack-manager/templates/backend/deployment.yaml
+++ b/helm/k8s-stack-manager/templates/backend/deployment.yaml
@@ -87,6 +87,7 @@ spec:
               path: /health/ready
               port: http
             periodSeconds: 5
+            timeoutSeconds: 5
             failureThreshold: 60
           livenessProbe:
             httpGet:

--- a/helm/k8s-stack-manager/templates/backend/deployment.yaml
+++ b/helm/k8s-stack-manager/templates/backend/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   replicas: {{ .Values.backend.replicas }}
   {{- end }}
   revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "k8s-stack-manager.backend.selectorLabels" . | nindent 6 }}
@@ -36,6 +41,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      terminationGracePeriodSeconds: 35
       {{- if .Values.mysql.enabled }}
       initContainers:
         - name: wait-for-mysql
@@ -72,11 +78,20 @@ spec:
                 name: {{ include "k8s-stack-manager.fullname" . }}-backend
             - secretRef:
                 name: {{ include "k8s-stack-manager.fullname" . }}-backend
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health/live
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
@@ -84,7 +99,6 @@ spec:
             httpGet:
               path: /health/ready
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/k8s-stack-manager/templates/backend/rollout.yaml
+++ b/helm/k8s-stack-manager/templates/backend/rollout.yaml
@@ -57,6 +57,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      terminationGracePeriodSeconds: 35
       {{- if .Values.mysql.enabled }}
       initContainers:
         - name: wait-for-mysql
@@ -93,11 +94,20 @@ spec:
                 name: {{ include "k8s-stack-manager.fullname" . }}-backend
             - secretRef:
                 name: {{ include "k8s-stack-manager.fullname" . }}-backend
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5"]
+          startupProbe:
+            httpGet:
+              path: /health/ready
+              port: http
+            periodSeconds: 5
+            failureThreshold: 60
           livenessProbe:
             httpGet:
               path: /health/live
               port: http
-            initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
@@ -105,7 +115,6 @@ spec:
             httpGet:
               path: /health/ready
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3

--- a/helm/k8s-stack-manager/templates/backend/rollout.yaml
+++ b/helm/k8s-stack-manager/templates/backend/rollout.yaml
@@ -103,6 +103,7 @@ spec:
               path: /health/ready
               port: http
             periodSeconds: 5
+            timeoutSeconds: 5
             failureThreshold: 60
           livenessProbe:
             httpGet:

--- a/helm/k8s-stack-manager/templates/frontend/deployment.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   replicas: {{ .Values.frontend.replicas }}
   {{- end }}
   revisionHistoryLimit: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       {{- include "k8s-stack-manager.frontend.selectorLabels" . | nindent 6 }}
@@ -35,6 +40,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      terminationGracePeriodSeconds: 35
       containers:
         - name: nginx
           image: {{ include "k8s-stack-manager.frontend.image" . }}
@@ -43,6 +49,10 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.port }}
               protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5; nginx -s quit"]
           livenessProbe:
             httpGet:
               path: /

--- a/helm/k8s-stack-manager/templates/frontend/deployment.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/deployment.yaml
@@ -57,7 +57,6 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
@@ -65,7 +64,6 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3

--- a/helm/k8s-stack-manager/templates/frontend/rollout.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/rollout.yaml
@@ -56,6 +56,7 @@ spec:
         seccompProfile:
           type: RuntimeDefault
         {{- end }}
+      terminationGracePeriodSeconds: 35
       containers:
         - name: nginx
           image: {{ include "k8s-stack-manager.frontend.image" . }}
@@ -64,6 +65,10 @@ spec:
             - name: http
               containerPort: {{ .Values.frontend.port }}
               protocol: TCP
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 5; nginx -s quit"]
           livenessProbe:
             httpGet:
               path: /

--- a/helm/k8s-stack-manager/templates/frontend/rollout.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/rollout.yaml
@@ -73,7 +73,6 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 5
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
@@ -81,7 +80,6 @@ spec:
             httpGet:
               path: /
               port: http
-            initialDelaySeconds: 3
             periodSeconds: 10
             timeoutSeconds: 3
             failureThreshold: 3


### PR DESCRIPTION
## Summary

- Add **preStop lifecycle hooks** to backend (`sleep 5`) and frontend (`sleep 5; nginx -s quit`) containers so the endpoint controller has time to deregister the pod before shutdown
- Add **startup probe** on `/health/ready` to backend (5s interval, 60 attempts = 5 min window) to prevent liveness kills during long DB migrations
- Add **explicit RollingUpdate strategy** with `maxSurge: 1, maxUnavailable: 0` to both Deployments
- Set **`terminationGracePeriodSeconds: 35`** (exceeds `SERVER_SHUTDOWN_TIMEOUT` of 30s)
- Remove `initialDelaySeconds` from backend liveness/readiness probes (startup probe gates them now)
- All changes applied to both Deployment and Rollout templates

## Context

Without preStop hooks, terminating pods still receive traffic for a few seconds while the Kubernetes endpoint controller catches up — causing 502 errors during rolling updates.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` renders all new fields correctly
- [ ] Deploy and verify pods restart cleanly with `kubectl rollout restart`
- [ ] Confirm no 502s during rollout under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)