### PR TITLE
fix: stack delete now cleans up K8s resources before removing DB record

### DIFF
--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -684,12 +684,15 @@ func (h *InstanceHandler) UpdateInstance(c *gin.Context) {
 
 // DeleteInstance godoc
 // @Summary     Delete a stack instance
-// @Description Delete a stack instance
+// @Description Deletes a stack instance. If the instance has running resources (status running/stopped/error), a cleanup is initiated first — helm releases are uninstalled and the namespace is deleted before the database record is removed. Returns 204 for immediate deletion (draft instances) or 202 when async cleanup is required.
 // @Tags        stack-instances
 // @Produce     json
 // @Param       id  path     string true "Instance ID"
-// @Success     204 "No Content"
+// @Success     202 {object} map[string]string "Cleanup initiated, instance will be deleted after resources are removed"
+// @Success     204 "No Content — instance deleted immediately (no resources to clean)"
 // @Failure     404 {object} map[string]string
+// @Failure     409 {object} map[string]string "Instance is in a transient state (deploying/stopping/cleaning)"
+// @Failure     503 {object} map[string]string "Deploy manager not configured"
 // @Router      /api/v1/stack-instances/{id} [delete]
 func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 	id := c.Param("id")
@@ -698,30 +701,66 @@ func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 		return
 	}
 
-	// Look up the instance for the hook envelope and the delete itself.
-	// A failed lookup is a real error — don't silently proceed with a nil
-	// snapshot that would make the pre-delete hook a no-op.
-	var snapshot *models.StackInstance
-	if h.hooks != nil {
-		inst, lookupErr := h.instanceRepo.FindByID(id)
-		if lookupErr != nil {
-			status, message := mapError(lookupErr, entityStackInstance)
-			c.JSON(status, gin.H{"error": message})
-			return
-		}
-		snapshot = inst
+	inst, err := h.instanceRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, entityStackInstance)
+		c.JSON(status, gin.H{"error": message})
+		return
 	}
 
 	// Pre-instance-delete hook: a subscriber with failure_policy=fail can block
 	// the delete (e.g. enforce dependency checks).
-	if err := h.fireInstanceHook(c.Request.Context(), hooks.EventPreInstanceDelete, snapshot); err != nil {
+	if err := h.fireInstanceHook(c.Request.Context(), hooks.EventPreInstanceDelete, inst); err != nil {
 		slog.Error("pre-instance-delete hook failed", logKeyInstanceID, id, "error", err)
 		c.JSON(http.StatusForbidden, gin.H{"error": "pre-instance-delete hook rejected the request"})
 		return
 	}
 
+	switch inst.Status {
+	case models.StackStatusDeploying, models.StackStatusStopping, models.StackStatusCleaning, models.StackStatusQueued:
+		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Cannot delete: instance is currently %s", inst.Status)})
+		return
+
+	case models.StackStatusRunning, models.StackStatusStopped, models.StackStatusError:
+		if h.deployManager == nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": msgDeployerNotConfigured})
+			return
+		}
+
+		def, err := h.definitionRepo.FindByID(inst.StackDefinitionID)
+		if err != nil {
+			status, message := mapError(err, entityStackDefinition)
+			c.JSON(status, gin.H{"error": message})
+			return
+		}
+		charts, err := h.chartConfigRepo.ListByDefinition(def.ID)
+		if err != nil {
+			status, message := mapError(err, entityChartConfigs)
+			c.JSON(status, gin.H{"error": message})
+			return
+		}
+
+		h.deployManager.ScheduleDeleteAfterClean(id)
+
+		logID, err := h.deployManager.Clean(c.Request.Context(), inst, charts)
+		if err != nil {
+			slog.Error("Failed to start clean for delete",
+				logKeyInstanceID, id, "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+			return
+		}
+
+		c.JSON(http.StatusAccepted, gin.H{
+			"log_id":  logID,
+			"message": "Cleanup initiated; instance will be deleted after resources are removed",
+		})
+		return
+
+	default:
+		// draft or unknown — no resources to clean, delete immediately
+	}
+
 	if h.txRunner != nil {
-		// Transactional path — branch override cleanup + instance delete are atomic.
 		txErr := h.txRunner.RunInTx(func(repos database.TxRepos) error {
 			if err := repos.BranchOverride.DeleteByInstance(id); err != nil {
 				return err
@@ -739,8 +778,7 @@ func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 		return
 	}
 
-	// Post-instance-delete hook: notify only; the delete is committed.
-	_ = h.fireInstanceHook(c.Request.Context(), hooks.EventPostInstanceDelete, snapshot)
+	_ = h.fireInstanceHook(c.Request.Context(), hooks.EventPostInstanceDelete, inst)
 
 	c.Status(http.StatusNoContent)
 }

--- a/backend/internal/api/handlers/stack_instances_hooks_test.go
+++ b/backend/internal/api/handlers/stack_instances_hooks_test.go
@@ -191,7 +191,7 @@ func TestDeleteInstance_FiresPreAndPostHooks(t *testing.T) {
 
 	instRepo := NewMockStackInstanceRepository()
 	defRepo := NewMockStackDefinitionRepository()
-	seedInstance(t, instRepo, "i-1", "to-delete", "d1", "uid-1", "running")
+	seedInstance(t, instRepo, "i-1", "to-delete", "d1", "uid-1", "draft")
 
 	router := setupInstanceRouterWithHooks(instRepo, defRepo,
 		rec.dispatcher(t, hooks.FailurePolicyIgnore), "uid-1", "alice")

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -66,6 +66,10 @@ type Manager struct {
 	// hooks dispatches lifecycle events to user-configured webhooks.
 	// nil disables all hook dispatch.
 	hooks *hooks.Dispatcher
+
+	// pendingDeletes tracks instances that should be deleted from the database
+	// after their async clean operation completes successfully.
+	pendingDeletes sync.Map
 }
 
 // ManagerConfig holds the dependencies for creating a Manager.
@@ -145,6 +149,13 @@ func NewManager(cfg ManagerConfig) *Manager {
 
 		hooks: cfg.Hooks,
 	}
+}
+
+// ScheduleDeleteAfterClean marks an instance for DB deletion once its async
+// clean operation finishes successfully. If the clean fails, the instance
+// remains in the database with an error status.
+func (m *Manager) ScheduleDeleteAfterClean(instanceID string) {
+	m.pendingDeletes.Store(instanceID, struct{}{})
 }
 
 // fireDeployHook dispatches event to configured hook subscribers using a
@@ -1077,8 +1088,31 @@ func (m *Manager) finalizeClean(instanceID string, deployLog *models.DeploymentL
 		}
 	}
 
+	_, shouldDelete := m.pendingDeletes.LoadAndDelete(instanceID)
+
 	if cleanErr != nil {
 		m.broadcastStatusWithError(instanceID, models.StackStatusError, deployLog.ID, instance.ErrorMessage)
+	} else if shouldDelete {
+		if m.txRunner != nil {
+			if err := m.txRunner.RunInTx(func(repos database.TxRepos) error {
+				if err := repos.BranchOverride.DeleteByInstance(instanceID); err != nil {
+					return fmt.Errorf("deleting branch overrides: %w", err)
+				}
+				return repos.StackInstance.Delete(instanceID)
+			}); err != nil {
+				slog.Error("failed to delete instance after clean",
+					"instance_id", instanceID, "error", err)
+				m.broadcastStatus(instanceID, models.StackStatusDraft, deployLog.ID)
+			} else {
+				slog.Info("instance deleted after clean",
+					"instance_id", instanceID, "log_id", deployLog.ID)
+			}
+		} else {
+			if err := m.instanceRepo.Delete(instanceID); err != nil {
+				slog.Error("failed to delete instance after clean",
+					"instance_id", instanceID, "error", err)
+			}
+		}
 	} else {
 		m.broadcastStatus(instanceID, models.StackStatusDraft, deployLog.ID)
 	}


### PR DESCRIPTION
## Summary
- `DELETE /stack-instances/:id` previously only deleted the database record, leaving helm releases and the namespace orphaned
- Now checks instance status: running/stopped/error instances trigger an async clean (helm uninstall + namespace delete) before the DB record is removed; draft instances are deleted immediately
- Returns 202 Accepted when async cleanup is needed, 204 No Content for immediate deletion, 409 Conflict for transient states

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] Updated hook test to use draft status (tests hook firing, not cleanup)
- [ ] Manual test: delete a running stack → verify helm releases uninstalled + namespace deleted + DB record removed
- [ ] Manual test: delete a draft stack → verify immediate 204 response
- [ ] Manual test: delete a deploying stack → verify 409 Conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)