### PR TITLE
feat: real-time deployment log streaming via WebSocket

### DIFF
--- a/backend/internal/deployer/broadcast.go
+++ b/backend/internal/deployer/broadcast.go
@@ -53,6 +53,8 @@ func (m *Manager) broadcastStatusWithError(instanceID, status, logID, errorMessa
 }
 
 // broadcastLog sends a deployment log line via WebSocket for real-time log streaming.
+// Uses targeted broadcast when the hub supports it, so only clients subscribed to
+// the instance receive the high-volume log output.
 func (m *Manager) broadcastLog(instanceID, logID, line string) {
 	if m.hub == nil {
 		return
@@ -74,5 +76,9 @@ func (m *Manager) broadcastLog(instanceID, logID, line string) {
 		return
 	}
 
-	m.hub.Broadcast(data)
+	if targeted, ok := m.hub.(websocket.TargetedSender); ok {
+		targeted.BroadcastToInstance(instanceID, data)
+	} else {
+		m.hub.Broadcast(data)
+	}
 }

--- a/backend/internal/deployer/executor.go
+++ b/backend/internal/deployer/executor.go
@@ -18,6 +18,15 @@ type HelmExecutor interface {
 	Timeout() time.Duration
 }
 
+// StreamingHelmExecutor extends HelmExecutor with line-by-line output streaming.
+// When the underlying executor supports streaming, the Manager wraps it via
+// WithLineHandler so each line of Helm CLI output is broadcast over WebSocket
+// in real time rather than waiting for the command to finish.
+type StreamingHelmExecutor interface {
+	HelmExecutor
+	WithLineHandler(fn func(string)) HelmExecutor
+}
+
 // ReleaseRevision represents a single entry from helm history.
 type ReleaseRevision struct {
 	Revision    int    `json:"revision"`

--- a/backend/internal/deployer/helm.go
+++ b/backend/internal/deployer/helm.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -319,9 +318,13 @@ func (h *HelmClient) run(ctx context.Context, args []string) (string, error) {
 	return output, nil
 }
 
+const maxScannerLineSize = 256 * 1024
+
 // runStreaming executes a helm command, calling onLine for each line of combined
 // stdout/stderr output as it is produced. The full output is still accumulated
 // and returned so callers can store it in the deployment log.
+// Stdout and stderr are merged via io.MultiReader into a single scanner to
+// preserve deterministic line ordering (same approach as the non-streaming run()).
 func (h *HelmClient) runStreaming(ctx context.Context, args []string, onLine func(string)) (string, error) {
 	if h.kubeconfig != "" {
 		args = append([]string{"--kubeconfig", h.kubeconfig}, args...)
@@ -349,33 +352,18 @@ func (h *HelmClient) runStreaming(ctx context.Context, args []string, onLine fun
 	}
 
 	var combined strings.Builder
-	var mu sync.Mutex
-	var wg sync.WaitGroup
-
-	// Two goroutines scan stdout and stderr concurrently. Lines from both
-	// streams are interleaved non-deterministically in the combined buffer
-	// and in onLine calls — this matches Helm's own combined output behavior.
-	scanPipe := func(r io.Reader) {
-		defer wg.Done()
-		scanner := bufio.NewScanner(r)
-		scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
-		for scanner.Scan() {
-			line := scanner.Text()
-			mu.Lock()
-			combined.WriteString(line)
-			combined.WriteByte('\n')
-			mu.Unlock()
-			onLine(line)
-		}
-		if err := scanner.Err(); err != nil {
-			slog.Warn("scanner error reading helm output", "error", err)
-		}
+	scanner := bufio.NewScanner(io.MultiReader(stdout, stderr))
+	scanner.Buffer(make([]byte, 0, maxScannerLineSize), maxScannerLineSize)
+	for scanner.Scan() {
+		line := scanner.Text()
+		combined.WriteString(line)
+		combined.WriteByte('\n')
+		onLine(line)
 	}
-
-	wg.Add(2)
-	go scanPipe(stdout)
-	go scanPipe(stderr)
-	wg.Wait()
+	if err := scanner.Err(); err != nil {
+		slog.Warn("scanner error reading helm output", "error", err)
+		onLine(fmt.Sprintf("[scanner error: %v]", err))
+	}
 
 	err = cmd.Wait()
 	output := combined.String()

--- a/backend/internal/deployer/helm.go
+++ b/backend/internal/deployer/helm.go
@@ -3,15 +3,18 @@
 package deployer
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -90,6 +93,14 @@ func (h *HelmClient) Timeout() time.Duration {
 // Install runs: helm upgrade --install <release> <chart> -f <valuesFile> -n <namespace> --create-namespace --timeout <timeout>
 // Returns combined stdout+stderr output and error.
 func (h *HelmClient) Install(ctx context.Context, req InstallRequest) (string, error) {
+	args, err := h.buildInstallArgs(req)
+	if err != nil {
+		return "", err
+	}
+	return h.run(ctx, args)
+}
+
+func (h *HelmClient) buildInstallArgs(req InstallRequest) ([]string, error) {
 	// Validate positional arguments to prevent argument injection. Namespace
 	// is validated upstream (RFC 1123 in StackInstance.Validate), but we
 	// re-check here as defense-in-depth since it is security-critical.
@@ -99,7 +110,7 @@ func (h *HelmClient) Install(ctx context.Context, req InstallRequest) (string, e
 		{"namespace", req.Namespace},
 	} {
 		if err := validatePositionalArg(check.name, check.value); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
@@ -123,24 +134,28 @@ func (h *HelmClient) Install(ctx context.Context, req InstallRequest) (string, e
 	if req.SkipCRDs {
 		args = append(args, "--skip-crds")
 	}
-
-	return h.run(ctx, args)
+	return args, nil
 }
 
 // Uninstall runs: helm uninstall <release> -n <namespace>
 // Returns combined stdout+stderr output and error.
 func (h *HelmClient) Uninstall(ctx context.Context, req UninstallRequest) (string, error) {
-	if err := validatePositionalArg("release name", req.ReleaseName); err != nil {
+	args, err := h.buildUninstallArgs(req)
+	if err != nil {
 		return "", err
 	}
+	return h.run(ctx, args)
+}
 
-	args := []string{
+func (h *HelmClient) buildUninstallArgs(req UninstallRequest) ([]string, error) {
+	if err := validatePositionalArg("release name", req.ReleaseName); err != nil {
+		return nil, err
+	}
+	return []string{
 		"uninstall",
 		req.ReleaseName,
 		"-n", req.Namespace,
-	}
-
-	return h.run(ctx, args)
+	}, nil
 }
 
 // Status runs: helm status <release> -n <namespace> -o json
@@ -230,19 +245,24 @@ func (h *HelmClient) History(ctx context.Context, releaseName, namespace string,
 // Rollback runs: helm rollback <release> <revision> -n <namespace>
 // Returns combined stdout+stderr output and error.
 func (h *HelmClient) Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
-	if err := validatePositionalArg("release name", releaseName); err != nil {
+	args, err := h.buildRollbackArgs(releaseName, namespace, revision)
+	if err != nil {
 		return "", err
 	}
+	return h.run(ctx, args)
+}
 
-	args := []string{
+func (h *HelmClient) buildRollbackArgs(releaseName, namespace string, revision int) ([]string, error) {
+	if err := validatePositionalArg("release name", releaseName); err != nil {
+		return nil, err
+	}
+	return []string{
 		"rollback",
 		releaseName,
 		strconv.Itoa(revision),
 		"-n", namespace,
 		"--timeout", h.timeout.String(),
-	}
-
-	return h.run(ctx, args)
+	}, nil
 }
 
 // GetValues runs: helm get values <release> -n <namespace> --revision <revision> -o yaml
@@ -297,4 +317,101 @@ func (h *HelmClient) run(ctx context.Context, args []string) (string, error) {
 	}
 
 	return output, nil
+}
+
+// runStreaming executes a helm command, calling onLine for each line of combined
+// stdout/stderr output as it is produced. The full output is still accumulated
+// and returned so callers can store it in the deployment log.
+func (h *HelmClient) runStreaming(ctx context.Context, args []string, onLine func(string)) (string, error) {
+	if h.kubeconfig != "" {
+		args = append([]string{"--kubeconfig", h.kubeconfig}, args...)
+	}
+
+	slog.Info("executing helm command",
+		"binary", h.binaryPath,
+		"args", args,
+		"streaming", true,
+	)
+
+	cmd := exec.CommandContext(ctx, h.binaryPath, args...) //nolint:gosec // G204: same justification as run()
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("creating stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return "", fmt.Errorf("creating stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return "", fmt.Errorf("starting helm command: %w", err)
+	}
+
+	var combined strings.Builder
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+
+	scanPipe := func(r io.Reader) {
+		defer wg.Done()
+		scanner := bufio.NewScanner(r)
+		for scanner.Scan() {
+			line := scanner.Text()
+			mu.Lock()
+			combined.WriteString(line)
+			combined.WriteByte('\n')
+			mu.Unlock()
+			onLine(line)
+		}
+	}
+
+	wg.Add(2)
+	go scanPipe(stdout)
+	go scanPipe(stderr)
+	wg.Wait()
+
+	err = cmd.Wait()
+	output := combined.String()
+	if err != nil {
+		return output, fmt.Errorf("helm command failed: %w", err)
+	}
+	return output, nil
+}
+
+// WithLineHandler returns a new HelmExecutor that streams each output line to fn.
+// Implements StreamingHelmExecutor. Methods that don't produce significant
+// streaming output (Status, ListReleases, History, GetValues) pass through
+// to the underlying HelmClient unchanged.
+func (h *HelmClient) WithLineHandler(fn func(string)) HelmExecutor {
+	return &streamingHelmClient{HelmClient: h, onLine: fn}
+}
+
+// streamingHelmClient wraps a HelmClient and streams each output line via onLine.
+type streamingHelmClient struct {
+	*HelmClient
+	onLine func(string)
+}
+
+func (s *streamingHelmClient) Install(ctx context.Context, req InstallRequest) (string, error) {
+	args, err := s.buildInstallArgs(req)
+	if err != nil {
+		return "", err
+	}
+	return s.runStreaming(ctx, args, s.onLine)
+}
+
+func (s *streamingHelmClient) Uninstall(ctx context.Context, req UninstallRequest) (string, error) {
+	args, err := s.buildUninstallArgs(req)
+	if err != nil {
+		return "", err
+	}
+	return s.runStreaming(ctx, args, s.onLine)
+}
+
+func (s *streamingHelmClient) Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	args, err := s.buildRollbackArgs(releaseName, namespace, revision)
+	if err != nil {
+		return "", err
+	}
+	return s.runStreaming(ctx, args, s.onLine)
 }

--- a/backend/internal/deployer/helm.go
+++ b/backend/internal/deployer/helm.go
@@ -352,9 +352,13 @@ func (h *HelmClient) runStreaming(ctx context.Context, args []string, onLine fun
 	var mu sync.Mutex
 	var wg sync.WaitGroup
 
+	// Two goroutines scan stdout and stderr concurrently. Lines from both
+	// streams are interleaved non-deterministically in the combined buffer
+	// and in onLine calls — this matches Helm's own combined output behavior.
 	scanPipe := func(r io.Reader) {
 		defer wg.Done()
 		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 256*1024), 256*1024)
 		for scanner.Scan() {
 			line := scanner.Text()
 			mu.Lock()
@@ -362,6 +366,9 @@ func (h *HelmClient) runStreaming(ctx context.Context, args []string, onLine fun
 			combined.WriteByte('\n')
 			mu.Unlock()
 			onLine(line)
+		}
+		if err := scanner.Err(); err != nil {
+			slog.Warn("scanner error reading helm output", "error", err)
 		}
 	}
 

--- a/backend/internal/deployer/helm_test.go
+++ b/backend/internal/deployer/helm_test.go
@@ -552,3 +552,272 @@ func TestHelmClient_GetValues_RevisionZeroOmitsFlag(t *testing.T) {
 		assert.Contains(t, output, "--revision")
 	})
 }
+
+// ---- Streaming & arg builder tests ----
+
+// Compile-time interface compliance check: HelmClient must implement StreamingHelmExecutor.
+var _ StreamingHelmExecutor = (*HelmClient)(nil)
+
+func TestHelmClient_BuildInstallArgs(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "/home/user/.kube/config", 3*time.Minute)
+
+	tests := []struct {
+		name        string
+		req         InstallRequest
+		wantErr     bool
+		errContains string
+		wantArgs    []string // subset of expected args (checked with Contains)
+	}{
+		{
+			name: "minimal valid request",
+			req: InstallRequest{
+				ReleaseName: "my-app",
+				ChartPath:   "nginx",
+				Namespace:   "default",
+			},
+			wantArgs: []string{"upgrade", "--install", "my-app", "nginx", "-n", "default", "--create-namespace", "--timeout", "3m0s"},
+		},
+		{
+			name: "full request with repo, version, values, skip-crds",
+			req: InstallRequest{
+				ReleaseName: "my-app",
+				ChartPath:   "nginx",
+				RepoURL:     "https://charts.example.com",
+				Version:     "1.2.3",
+				ValuesFile:  "/tmp/values.yaml",
+				Namespace:   "prod",
+				SkipCRDs:    true,
+			},
+			wantArgs: []string{"upgrade", "--install", "my-app", "nginx", "-n", "prod", "--repo", "https://charts.example.com", "--version", "1.2.3", "-f", "/tmp/values.yaml", "--skip-crds"},
+		},
+		{
+			name: "optional fields omitted when empty",
+			req: InstallRequest{
+				ReleaseName: "my-app",
+				ChartPath:   "nginx",
+				Namespace:   "default",
+				RepoURL:     "",
+				Version:     "",
+				ValuesFile:  "",
+				SkipCRDs:    false,
+			},
+			wantArgs: []string{"upgrade", "--install", "my-app", "nginx", "-n", "default"},
+		},
+		{
+			name: "dash-prefixed release name rejected",
+			req: InstallRequest{
+				ReleaseName: "--evil",
+				ChartPath:   "nginx",
+				Namespace:   "default",
+			},
+			wantErr:     true,
+			errContains: "release name",
+		},
+		{
+			name: "dash-prefixed chart path rejected",
+			req: InstallRequest{
+				ReleaseName: "ok",
+				ChartPath:   "-bad-chart",
+				Namespace:   "default",
+			},
+			wantErr:     true,
+			errContains: "chart path",
+		},
+		{
+			name: "dash-prefixed namespace rejected",
+			req: InstallRequest{
+				ReleaseName: "ok",
+				ChartPath:   "nginx",
+				Namespace:   "--admin",
+			},
+			wantErr:     true,
+			errContains: "namespace",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args, err := client.buildInstallArgs(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, args)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				assert.True(t, errors.Is(err, errArgDashPrefix))
+			} else {
+				assert.NoError(t, err)
+				for _, want := range tt.wantArgs {
+					assert.Contains(t, args, want)
+				}
+			}
+		})
+	}
+}
+
+func TestHelmClient_BuildUninstallArgs(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 2*time.Minute)
+
+	tests := []struct {
+		name        string
+		req         UninstallRequest
+		wantErr     bool
+		errContains string
+		wantArgs    []string
+	}{
+		{
+			name: "valid request",
+			req: UninstallRequest{
+				ReleaseName: "my-app",
+				Namespace:   "default",
+			},
+			wantArgs: []string{"uninstall", "my-app", "-n", "default"},
+		},
+		{
+			name: "dash-prefixed release name rejected",
+			req: UninstallRequest{
+				ReleaseName: "--kubeconfig=/etc/secret",
+				Namespace:   "default",
+			},
+			wantErr:     true,
+			errContains: "release name",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args, err := client.buildUninstallArgs(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, args)
+				assert.True(t, errors.Is(err, errArgDashPrefix))
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantArgs, args)
+			}
+		})
+	}
+}
+
+func TestHelmClient_BuildRollbackArgs(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 4*time.Minute)
+
+	tests := []struct {
+		name        string
+		release     string
+		namespace   string
+		revision    int
+		wantErr     bool
+		errContains string
+		wantArgs    []string
+	}{
+		{
+			name:      "valid rollback",
+			release:   "my-app",
+			namespace: "prod",
+			revision:  3,
+			wantArgs:  []string{"rollback", "my-app", "3", "-n", "prod", "--timeout", "4m0s"},
+		},
+		{
+			name:      "revision zero",
+			release:   "my-app",
+			namespace: "default",
+			revision:  0,
+			wantArgs:  []string{"rollback", "my-app", "0", "-n", "default", "--timeout", "4m0s"},
+		},
+		{
+			name:        "dash-prefixed release name rejected",
+			release:     "-evil",
+			namespace:   "default",
+			revision:    1,
+			wantErr:     true,
+			errContains: "release name",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			args, err := client.buildRollbackArgs(tt.release, tt.namespace, tt.revision)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, args)
+				assert.True(t, errors.Is(err, errArgDashPrefix))
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantArgs, args)
+			}
+		})
+	}
+}
+
+func TestHelmClient_WithLineHandler_ReturnsValidExecutor(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "/home/user/.kube/config", 7*time.Minute)
+
+	var captured []string
+	executor := client.WithLineHandler(func(line string) {
+		captured = append(captured, line)
+	})
+
+	// The returned executor must not be nil.
+	assert.NotNil(t, executor)
+
+	// It should be a *streamingHelmClient under the hood.
+	streaming, ok := executor.(*streamingHelmClient)
+	assert.True(t, ok, "WithLineHandler should return a *streamingHelmClient")
+	assert.NotNil(t, streaming.onLine)
+
+	// Timeout should delegate to the underlying HelmClient.
+	assert.Equal(t, 7*time.Minute, executor.Timeout())
+}
+
+func TestHelmClient_WithLineHandler_OnLineFuncIsCalled(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 1*time.Minute)
+
+	var captured []string
+	executor := client.WithLineHandler(func(line string) {
+		captured = append(captured, line)
+	})
+
+	// Verify the onLine callback is the one we passed.
+	streaming := executor.(*streamingHelmClient)
+	streaming.onLine("hello")
+	streaming.onLine("world")
+	assert.Equal(t, []string{"hello", "world"}, captured)
+}
+
+func TestHelmClient_WithLineHandler_DifferentHandlersAreIndependent(t *testing.T) {
+	t.Parallel()
+
+	client := NewHelmClient("helm", "", 1*time.Minute)
+
+	var captured1, captured2 []string
+	exec1 := client.WithLineHandler(func(line string) {
+		captured1 = append(captured1, line)
+	})
+	exec2 := client.WithLineHandler(func(line string) {
+		captured2 = append(captured2, line)
+	})
+
+	// Each executor has its own handler.
+	exec1.(*streamingHelmClient).onLine("only-for-1")
+	exec2.(*streamingHelmClient).onLine("only-for-2")
+
+	assert.Equal(t, []string{"only-for-1"}, captured1)
+	assert.Equal(t, []string{"only-for-2"}, captured2)
+}

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -193,6 +193,19 @@ func (m *Manager) fireDeployHook(ctx context.Context, event string, instance *mo
 	return m.hooks.Fire(ctx, event, env)
 }
 
+// wrapStreaming checks if helm implements StreamingHelmExecutor and, if so,
+// returns a wrapped executor that broadcasts each output line via WebSocket.
+// The returned bool indicates whether streaming is active (used to gate
+// per-chart broadcastLog calls that would duplicate streaming output).
+func (m *Manager) wrapStreaming(helm HelmExecutor, instanceID, logID string) (HelmExecutor, bool) {
+	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		return streamer.WithLineHandler(func(line string) {
+			m.broadcastLog(instanceID, logID, line)
+		}), true
+	}
+	return helm, false
+}
+
 // Shutdown cancels the context used by background deploy/stop goroutines,
 // signalling them to abort at the next cancellation check point.
 func (m *Manager) Shutdown() {
@@ -339,14 +352,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 	var deployErr error
 	defer func() { finishSpan(deployErr) }()
 
-	// Enable line-by-line streaming if the executor supports it.
-	streaming := false
-	if streamer, ok := helm.(StreamingHelmExecutor); ok {
-		helm = streamer.WithLineHandler(func(line string) {
-			m.broadcastLog(instanceID, deployLog.ID, line)
-		})
-		streaming = true
-	}
+	helm, streaming := m.wrapStreaming(helm, instanceID, deployLog.ID)
 
 	// Create a temp directory for values files.
 	tmpDir, err := os.MkdirTemp("", "deploy-"+instanceID+"-")
@@ -746,14 +752,7 @@ func (m *Manager) executeStopWithCharts(helm HelmExecutor, instanceID string, de
 	var stopErr error
 	defer func() { finishSpan(stopErr) }()
 
-	// Enable line-by-line streaming if the executor supports it.
-	streaming := false
-	if streamer, ok := helm.(StreamingHelmExecutor); ok {
-		helm = streamer.WithLineHandler(func(line string) {
-			m.broadcastLog(instanceID, deployLog.ID, line)
-		})
-		streaming = true
-	}
+	helm, streaming := m.wrapStreaming(helm, instanceID, deployLog.ID)
 
 	// Use a bounded context derived from the shutdown context so that
 	// operations are cancelled both on timeout and on server shutdown.
@@ -1016,14 +1015,7 @@ func (m *Manager) executeClean(helm HelmExecutor, k8sClient *k8s.Client, instanc
 	var cleanErr error
 	defer func() { finishSpan(cleanErr) }()
 
-	// Enable line-by-line streaming if the executor supports it.
-	streaming := false
-	if streamer, ok := helm.(StreamingHelmExecutor); ok {
-		helm = streamer.WithLineHandler(func(line string) {
-			m.broadcastLog(instanceID, deployLog.ID, line)
-		})
-		streaming = true
-	}
+	helm, streaming := m.wrapStreaming(helm, instanceID, deployLog.ID)
 
 	// Use a bounded context derived from the shutdown context so that
 	// operations are cancelled both on timeout and on server shutdown.
@@ -1301,15 +1293,7 @@ func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLo
 	var rollbackErr error
 	defer func() { finishSpan(rollbackErr) }()
 
-	// Enable line-by-line streaming if the executor supports it.
-	streaming := false
-	if streamer, ok := helm.(StreamingHelmExecutor); ok {
-		helm = streamer.WithLineHandler(func(line string) {
-			m.broadcastLog(instanceID, deployLog.ID, line)
-		})
-		streaming = true
-	}
-	_ = streaming // used only for broadcastLog gating below
+	helm, streaming := m.wrapStreaming(helm, instanceID, deployLog.ID)
 
 	var timeout time.Duration
 	if helm != nil {

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -199,6 +199,7 @@ func (m *Manager) fireDeployHook(ctx context.Context, event string, instance *mo
 // per-chart broadcastLog calls that would duplicate streaming output).
 func (m *Manager) wrapStreaming(helm HelmExecutor, instanceID, logID string) (HelmExecutor, bool) {
 	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		slog.Info("streaming enabled for helm operations", "instance_id", instanceID, "log_id", logID)
 		return streamer.WithLineHandler(func(line string) {
 			m.broadcastLog(instanceID, logID, line)
 		}), true

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -339,6 +339,15 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 	var deployErr error
 	defer func() { finishSpan(deployErr) }()
 
+	// Enable line-by-line streaming if the executor supports it.
+	streaming := false
+	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		helm = streamer.WithLineHandler(func(line string) {
+			m.broadcastLog(instanceID, deployLog.ID, line)
+		})
+		streaming = true
+	}
+
 	// Create a temp directory for values files.
 	tmpDir, err := os.MkdirTemp("", "deploy-"+instanceID+"-")
 	if err != nil {
@@ -471,7 +480,9 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 		})
 
 		allOutput += fmt.Sprintf("=== Chart: %s ===\n%s\n", chart.ChartConfig.ChartName, output)
-		m.broadcastLog(instanceID, deployLog.ID, output)
+		if !streaming {
+			m.broadcastLog(instanceID, deployLog.ID, output)
+		}
 
 		if err != nil {
 			deployErr = fmt.Errorf("deploying chart %q: %w", chart.ChartConfig.ChartName, err)
@@ -497,7 +508,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 
 	// Roll back successfully installed charts on partial failure.
 	if deployErr != nil && len(installedCharts) > 0 {
-		rollbackOutput := m.rollbackCharts(helm, ctx, instanceID, deployLog.ID, namespace, installedCharts)
+		rollbackOutput := m.rollbackCharts(helm, ctx, instanceID, deployLog.ID, namespace, installedCharts, streaming)
 		allOutput += rollbackOutput
 	}
 
@@ -508,7 +519,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 // a partial deployment failure. It is best-effort: individual uninstall failures
 // are logged but do not stop the remaining rollbacks. Returns the accumulated
 // rollback output for inclusion in the deployment log.
-func (m *Manager) rollbackCharts(helm HelmExecutor, ctx context.Context, instanceID, logID, namespace string, charts []ChartDeployInfo) string {
+func (m *Manager) rollbackCharts(helm HelmExecutor, ctx context.Context, instanceID, logID, namespace string, charts []ChartDeployInfo, streaming bool) string {
 	var rollbackOutput string
 	rollbackOutput += "=== Rolling back installed charts ===\n"
 
@@ -529,7 +540,9 @@ func (m *Manager) rollbackCharts(helm HelmExecutor, ctx context.Context, instanc
 		})
 
 		rollbackOutput += fmt.Sprintf("=== Rollback: %s ===\n%s\n", releaseName, output)
-		m.broadcastLog(instanceID, logID, output)
+		if !streaming {
+			m.broadcastLog(instanceID, logID, output)
+		}
 
 		if err != nil {
 			slog.Error("rollback failed for chart",
@@ -733,6 +746,15 @@ func (m *Manager) executeStopWithCharts(helm HelmExecutor, instanceID string, de
 	var stopErr error
 	defer func() { finishSpan(stopErr) }()
 
+	// Enable line-by-line streaming if the executor supports it.
+	streaming := false
+	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		helm = streamer.WithLineHandler(func(line string) {
+			m.broadcastLog(instanceID, deployLog.ID, line)
+		})
+		streaming = true
+	}
+
 	// Use a bounded context derived from the shutdown context so that
 	// operations are cancelled both on timeout and on server shutdown.
 	var timeout time.Duration
@@ -760,7 +782,9 @@ func (m *Manager) executeStopWithCharts(helm HelmExecutor, instanceID string, de
 		})
 
 		allOutput += fmt.Sprintf("=== Chart: %s ===\n%s\n", chart.ChartConfig.ChartName, output)
-		m.broadcastLog(instanceID, deployLog.ID, output)
+		if !streaming {
+			m.broadcastLog(instanceID, deployLog.ID, output)
+		}
 
 		if err != nil {
 			// If the release is already gone, treat as a no-op.
@@ -992,6 +1016,15 @@ func (m *Manager) executeClean(helm HelmExecutor, k8sClient *k8s.Client, instanc
 	var cleanErr error
 	defer func() { finishSpan(cleanErr) }()
 
+	// Enable line-by-line streaming if the executor supports it.
+	streaming := false
+	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		helm = streamer.WithLineHandler(func(line string) {
+			m.broadcastLog(instanceID, deployLog.ID, line)
+		})
+		streaming = true
+	}
+
 	// Use a bounded context derived from the shutdown context so that
 	// operations are cancelled both on timeout and on server shutdown.
 	var timeout time.Duration
@@ -1020,7 +1053,9 @@ func (m *Manager) executeClean(helm HelmExecutor, k8sClient *k8s.Client, instanc
 		})
 
 		allOutput += fmt.Sprintf("=== Chart: %s ===\n%s\n", chart.ChartConfig.ChartName, output)
-		m.broadcastLog(instanceID, deployLog.ID, output)
+		if !streaming {
+			m.broadcastLog(instanceID, deployLog.ID, output)
+		}
 
 		if err != nil {
 			// If the release is already gone (e.g. instance was stopped),
@@ -1266,6 +1301,16 @@ func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLo
 	var rollbackErr error
 	defer func() { finishSpan(rollbackErr) }()
 
+	// Enable line-by-line streaming if the executor supports it.
+	streaming := false
+	if streamer, ok := helm.(StreamingHelmExecutor); ok {
+		helm = streamer.WithLineHandler(func(line string) {
+			m.broadcastLog(instanceID, deployLog.ID, line)
+		})
+		streaming = true
+	}
+	_ = streaming // used only for broadcastLog gating below
+
 	var timeout time.Duration
 	if helm != nil {
 		timeout = helm.Timeout()
@@ -1303,7 +1348,9 @@ func (m *Manager) executeRollback(helm HelmExecutor, instanceID string, deployLo
 
 		output, err := helm.Rollback(ctx, releaseName, namespace, targetRevision)
 		allOutput += fmt.Sprintf("=== Chart: %s (→ rev %d) ===\n%s\n", releaseName, targetRevision, output)
-		m.broadcastLog(instanceID, deployLog.ID, output)
+		if !streaming {
+			m.broadcastLog(instanceID, deployLog.ID, output)
+		}
 
 		if err != nil {
 			rollbackErr = fmt.Errorf("rolling back chart %q to revision %d: %w", releaseName, targetRevision, err)

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -1445,6 +1445,8 @@ type mockHelmExecutor struct {
 	mu             sync.Mutex
 	installFunc    func(ctx context.Context, req InstallRequest) (string, error)
 	uninstallFunc  func(ctx context.Context, req UninstallRequest) (string, error)
+	historyFunc    func(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error)
+	rollbackFunc   func(ctx context.Context, releaseName, namespace string, revision int) (string, error)
 	installCalls   []InstallRequest
 	uninstallCalls []UninstallRequest
 	timeout        time.Duration
@@ -1478,11 +1480,17 @@ func (m *mockHelmExecutor) ListReleases(_ context.Context, _ string) ([]string, 
 	return nil, nil
 }
 
-func (m *mockHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]ReleaseRevision, error) {
+func (m *mockHelmExecutor) History(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error) {
+	if m.historyFunc != nil {
+		return m.historyFunc(ctx, releaseName, namespace, max)
+	}
 	return nil, nil
 }
 
-func (m *mockHelmExecutor) Rollback(_ context.Context, releaseName string, _ string, _ int) (string, error) {
+func (m *mockHelmExecutor) Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	if m.rollbackFunc != nil {
+		return m.rollbackFunc(ctx, releaseName, namespace, revision)
+	}
 	return "rolled back " + releaseName, nil
 }
 
@@ -3504,6 +3512,76 @@ func TestManager_Deploy_StreamingPartialFailure_StillBroadcastsLines(t *testing.
 		}
 	}
 	assert.Greater(t, logMsgCount, 0, "streaming deploy with failure should still produce per-line log messages")
+}
+
+func TestManager_Rollback_StreamingSupport(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-rollback-stream",
+		StackDefinitionID: "def-1",
+		Name:              "rollback-stream",
+		Namespace:         "stack-rollback-stream",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusRunning,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	helmMock := &streamingMockHelmExecutor{
+		mockHelmExecutor: &mockHelmExecutor{
+			historyFunc: func(_ context.Context, _ string, _ string, _ int) ([]ReleaseRevision, error) {
+				return []ReleaseRevision{
+					{Revision: 1, Status: "deployed"},
+					{Revision: 2, Status: "deployed"},
+				}, nil
+			},
+			rollbackFunc: func(_ context.Context, releaseName string, _ string, _ int) (string, error) {
+				return "rolling back " + releaseName + "\nrollback complete", nil
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	req := RollbackRequest{
+		Instance: inst,
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "web", DeployOrder: 1}},
+		},
+	}
+
+	logID, err := mgr.Rollback(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	time.Sleep(500 * time.Millisecond)
+
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	assert.True(t, helmMock.wasLineHandlerSet(), "streaming helm executor should have WithLineHandler called")
+
+	messages := hub.getMessages()
+	var logMsgCount int
+	for _, msg := range messages {
+		if parseBroadcastMessageType(msg) == "deployment.log" {
+			logMsgCount++
+		}
+	}
+	assert.Greater(t, logMsgCount, 0, "rollback with streaming executor should produce per-line log messages")
 }
 
 // Verify that streamingMockHelmExecutor satisfies StreamingHelmExecutor at compile time.

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -340,6 +340,29 @@ func (m *mockBroadcaster) getMessages() [][]byte {
 	return cp
 }
 
+// ---- helpers ----
+
+// waitForTerminalStatus polls the instance repo until the instance reaches a
+// terminal status (not queued/deploying/stopping/cleaning). This replaces
+// fixed time.Sleep calls, making tests faster and less flaky.
+func waitForTerminalStatus(t *testing.T, repo *mockInstanceRepo, instanceID string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		inst, err := repo.FindByID(instanceID)
+		if err == nil {
+			switch inst.Status {
+			case models.StackStatusQueued, models.StackStatusDeploying,
+				models.StackStatusStopping, models.StackStatusCleaning:
+			default:
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for terminal instance status")
+}
+
 // ---- tests ----
 
 // mockClusterResolver implements ClusterResolver for tests.
@@ -537,7 +560,7 @@ func TestManager_Deploy_WithCharts_Fails(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance status is error.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -820,7 +843,7 @@ func TestManager_Deploy_ChartsSortedByDeployOrder(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// The error should reference the first chart (deploy order 1) since it fails first.
 	finalLog, err := logRepo.FindByID(context.Background(), logID)
@@ -876,7 +899,7 @@ func TestManager_StopWithCharts_ExecutesUninstall(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify final status is error (because helm binary is nonexistent).
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1216,7 +1239,7 @@ func TestManager_StopWithCharts_ReversesDeployOrder(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Wait for async.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// The error should reference the third chart (highest deploy order),
 	// which should be uninstalled first (reverse order).
@@ -1567,7 +1590,7 @@ func TestManager_Deploy_PartialRollback(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance status is error with original failure message.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1646,7 +1669,7 @@ func TestManager_Deploy_PartialRollback_RollbackFails(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance status is error with the ORIGINAL deploy failure (not rollback failure).
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1722,7 +1745,7 @@ func TestManager_Clean_Success(t *testing.T) {
 	assert.Equal(t, models.StackStatusCleaning, updated.Status)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify final status is draft.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1785,7 +1808,7 @@ func TestManager_Clean_Success_NoK8sClient(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify final status is draft (namespace delete skipped).
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1844,7 +1867,7 @@ func TestManager_Clean_HelmFails(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Best-effort: uninstall failures are warnings, not errors.
 	// With no K8s client, namespace deletion is skipped, so the clean succeeds.
@@ -1915,7 +1938,7 @@ func TestManager_Clean_ReleasesAlreadyGone(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Should succeed — "not found" releases are treated as already removed.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -1977,7 +2000,7 @@ func TestManager_Deploy_FirstChartFails_NoRollback(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance is in error state.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -3136,7 +3159,7 @@ func TestManager_Deploy_StreamingBroadcastsPerLine(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify the streaming executor's WithLineHandler was called.
 	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called")
@@ -3216,7 +3239,7 @@ func TestManager_Deploy_NonStreamingBroadcastsPerChart(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance completed successfully.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -3288,7 +3311,7 @@ func TestManager_StopWithCharts_StreamingSupport(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify the streaming executor's WithLineHandler was called.
 	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called for stop")
@@ -3354,7 +3377,7 @@ func TestManager_StopWithCharts_NonStreamingBroadcastsPerChart(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance completed successfully.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -3422,7 +3445,7 @@ func TestManager_Clean_StreamingSupport(t *testing.T) {
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify the streaming executor's WithLineHandler was called.
 	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called for clean")
@@ -3495,7 +3518,7 @@ func TestManager_Deploy_StreamingPartialFailure_StillBroadcastsLines(t *testing.
 	assert.NotEmpty(t, logID)
 
 	// Wait for async completion.
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	// Verify instance ended in error state.
 	final, err := instanceRepo.FindByID(inst.ID)
@@ -3566,7 +3589,7 @@ func TestManager_Rollback_StreamingSupport(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, logID)
 
-	time.Sleep(500 * time.Millisecond)
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
 
 	final, err := instanceRepo.FindByID(inst.ID)
 	require.NoError(t, err)

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -2,6 +2,7 @@ package deployer
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -324,6 +325,19 @@ func (m *mockBroadcaster) messageCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return len(m.messages)
+}
+
+// getMessages returns a thread-safe copy of all broadcast messages.
+func (m *mockBroadcaster) getMessages() [][]byte {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([][]byte, len(m.messages))
+	for i, msg := range m.messages {
+		c := make([]byte, len(msg))
+		copy(c, msg)
+		cp[i] = c
+	}
+	return cp
 }
 
 // ---- tests ----
@@ -2962,3 +2976,535 @@ func TestManager_FinalizeDeploy_LastDeployedValuesNotSetOnError(t *testing.T) {
 	assert.Empty(t, updated.LastDeployedValues)
 	assert.Equal(t, models.StackStatusError, updated.Status)
 }
+
+// ---- streaming helm executor mock ----
+
+// streamingMockHelmExecutor embeds mockHelmExecutor and implements
+// StreamingHelmExecutor. WithLineHandler returns a wrapper that calls fn
+// for each line of output produced by Install/Uninstall/Rollback.
+type streamingMockHelmExecutor struct {
+	*mockHelmExecutor
+	mu2            sync.Mutex
+	lineHandlerSet bool
+}
+
+func (s *streamingMockHelmExecutor) WithLineHandler(fn func(string)) HelmExecutor {
+	s.mu2.Lock()
+	s.lineHandlerSet = true
+	s.mu2.Unlock()
+	return &streamingMockWrapper{inner: s.mockHelmExecutor, onLine: fn}
+}
+
+func (s *streamingMockHelmExecutor) wasLineHandlerSet() bool {
+	s.mu2.Lock()
+	defer s.mu2.Unlock()
+	return s.lineHandlerSet
+}
+
+// streamingMockWrapper wraps mockHelmExecutor and calls onLine for each
+// line in the output before returning.
+type streamingMockWrapper struct {
+	inner  *mockHelmExecutor
+	onLine func(string)
+}
+
+func (w *streamingMockWrapper) Install(ctx context.Context, req InstallRequest) (string, error) {
+	output, err := w.inner.Install(ctx, req)
+	if w.onLine != nil {
+		for _, line := range strings.Split(output, "\n") {
+			if line != "" {
+				w.onLine(line)
+			}
+		}
+	}
+	return output, err
+}
+
+func (w *streamingMockWrapper) Uninstall(ctx context.Context, req UninstallRequest) (string, error) {
+	output, err := w.inner.Uninstall(ctx, req)
+	if w.onLine != nil {
+		for _, line := range strings.Split(output, "\n") {
+			if line != "" {
+				w.onLine(line)
+			}
+		}
+	}
+	return output, err
+}
+
+func (w *streamingMockWrapper) Status(ctx context.Context, releaseName, namespace string) (*ReleaseStatus, error) {
+	return w.inner.Status(ctx, releaseName, namespace)
+}
+
+func (w *streamingMockWrapper) ListReleases(ctx context.Context, namespace string) ([]string, error) {
+	return w.inner.ListReleases(ctx, namespace)
+}
+
+func (w *streamingMockWrapper) History(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error) {
+	return w.inner.History(ctx, releaseName, namespace, max)
+}
+
+func (w *streamingMockWrapper) Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	output, err := w.inner.Rollback(ctx, releaseName, namespace, revision)
+	if w.onLine != nil {
+		for _, line := range strings.Split(output, "\n") {
+			if line != "" {
+				w.onLine(line)
+			}
+		}
+	}
+	return output, err
+}
+
+func (w *streamingMockWrapper) GetValues(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
+	return w.inner.GetValues(ctx, releaseName, namespace, revision)
+}
+
+func (w *streamingMockWrapper) Timeout() time.Duration {
+	return w.inner.Timeout()
+}
+
+// ---- streaming broadcast tests ----
+
+// parseBroadcastMessageType extracts the "type" field from a JSON-encoded
+// websocket.Message. Returns empty string on parse failure.
+func parseBroadcastMessageType(data []byte) string {
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(data, &envelope); err != nil {
+		return ""
+	}
+	return envelope.Type
+}
+
+func TestManager_Deploy_StreamingBroadcastsPerLine(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-stream-deploy",
+		StackDefinitionID: "def-1",
+		Name:              "stream-deploy",
+		Namespace:         "stack-stream-deploy",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	helmMock := &streamingMockHelmExecutor{
+		mockHelmExecutor: &mockHelmExecutor{
+			installFunc: func(_ context.Context, req InstallRequest) (string, error) {
+				// Return multi-line output to simulate real Helm streaming.
+				return fmt.Sprintf("installing %s\nprogress: 50%%\nprogress: 100%%\ndone", req.ReleaseName), nil
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	req := DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "redis", DeployOrder: 1}},
+			{ChartConfig: models.ChartConfig{ChartName: "nginx", DeployOrder: 2}},
+		},
+	}
+
+	logID, err := mgr.Deploy(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the streaming executor's WithLineHandler was called.
+	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called")
+
+	// Verify instance completed successfully.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	// Parse broadcast messages and verify deployment.log messages are present.
+	messages := hub.getMessages()
+	assert.Greater(t, len(messages), 0, "should have broadcast messages")
+
+	var logMsgCount int
+	var statusMsgCount int
+	for _, msg := range messages {
+		msgType := parseBroadcastMessageType(msg)
+		switch msgType {
+		case "deployment.log":
+			logMsgCount++
+		case "deployment.status":
+			statusMsgCount++
+		}
+	}
+
+	// With streaming enabled, per-line broadcasts should appear as deployment.log.
+	// Each chart produces multi-line output (4 non-empty lines), and we have 2 charts.
+	assert.Greater(t, logMsgCount, 0, "streaming deploy should produce deployment.log messages")
+	assert.Greater(t, statusMsgCount, 0, "deploy should still produce deployment.status messages")
+}
+
+func TestManager_Deploy_NonStreamingBroadcastsPerChart(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-nonstream-deploy",
+		StackDefinitionID: "def-1",
+		Name:              "nonstream-deploy",
+		Namespace:         "stack-nonstream-deploy",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	// Regular mockHelmExecutor does NOT implement StreamingHelmExecutor.
+	helmMock := &mockHelmExecutor{
+		installFunc: func(_ context.Context, req InstallRequest) (string, error) {
+			return "installed " + req.ReleaseName, nil
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	req := DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "redis", DeployOrder: 1}},
+			{ChartConfig: models.ChartConfig{ChartName: "nginx", DeployOrder: 2}},
+		},
+	}
+
+	logID, err := mgr.Deploy(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify instance completed successfully.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	// Parse broadcast messages: non-streaming should still produce
+	// deployment.log messages (one per chart, containing full output),
+	// plus deployment.status messages.
+	messages := hub.getMessages()
+	assert.Greater(t, len(messages), 0, "should have broadcast messages")
+
+	var logMsgCount int
+	var statusMsgCount int
+	for _, msg := range messages {
+		msgType := parseBroadcastMessageType(msg)
+		switch msgType {
+		case "deployment.log":
+			logMsgCount++
+		case "deployment.status":
+			statusMsgCount++
+		}
+	}
+
+	// Non-streaming: broadcastLog is called once per chart (not per line).
+	assert.Equal(t, 2, logMsgCount, "non-streaming deploy should produce exactly one deployment.log per chart")
+	assert.Greater(t, statusMsgCount, 0, "deploy should produce deployment.status messages")
+}
+
+func TestManager_StopWithCharts_StreamingSupport(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:        "inst-stream-stop",
+		Name:      "stream-stop",
+		Namespace: "stack-stream-stop",
+		Status:    models.StackStatusRunning,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	helmMock := &streamingMockHelmExecutor{
+		mockHelmExecutor: &mockHelmExecutor{
+			uninstallFunc: func(_ context.Context, req UninstallRequest) (string, error) {
+				return fmt.Sprintf("uninstalling %s\ncleaning up\ndone", req.ReleaseName), nil
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	charts := []ChartDeployInfo{
+		{ChartConfig: models.ChartConfig{ChartName: "redis", DeployOrder: 1}},
+		{ChartConfig: models.ChartConfig{ChartName: "nginx", DeployOrder: 2}},
+	}
+
+	logID, err := mgr.StopWithCharts(context.Background(), inst, charts)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the streaming executor's WithLineHandler was called.
+	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called for stop")
+
+	// Verify instance completed successfully.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusStopped, final.Status)
+
+	// Verify deployment.log messages were streamed.
+	messages := hub.getMessages()
+	assert.Greater(t, len(messages), 0, "should have broadcast messages")
+
+	var logMsgCount int
+	for _, msg := range messages {
+		if parseBroadcastMessageType(msg) == "deployment.log" {
+			logMsgCount++
+		}
+	}
+
+	// With streaming: per-line broadcasts. 2 charts, each produces 3 non-empty lines.
+	assert.Greater(t, logMsgCount, 0, "streaming stop should produce deployment.log messages")
+}
+
+func TestManager_StopWithCharts_NonStreamingBroadcastsPerChart(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:        "inst-nonstream-stop",
+		Name:      "nonstream-stop",
+		Namespace: "stack-nonstream-stop",
+		Status:    models.StackStatusRunning,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	// Regular mockHelmExecutor — no StreamingHelmExecutor.
+	helmMock := &mockHelmExecutor{
+		uninstallFunc: func(_ context.Context, req UninstallRequest) (string, error) {
+			return "uninstalled " + req.ReleaseName, nil
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	charts := []ChartDeployInfo{
+		{ChartConfig: models.ChartConfig{ChartName: "redis", DeployOrder: 1}},
+		{ChartConfig: models.ChartConfig{ChartName: "nginx", DeployOrder: 2}},
+	}
+
+	logID, err := mgr.StopWithCharts(context.Background(), inst, charts)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify instance completed successfully.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusStopped, final.Status)
+
+	// Parse messages.
+	messages := hub.getMessages()
+	assert.Greater(t, len(messages), 0, "should have broadcast messages")
+
+	var logMsgCount int
+	for _, msg := range messages {
+		if parseBroadcastMessageType(msg) == "deployment.log" {
+			logMsgCount++
+		}
+	}
+
+	// Non-streaming: one broadcastLog per chart.
+	assert.Equal(t, 2, logMsgCount, "non-streaming stop should produce exactly one deployment.log per chart")
+}
+
+func TestManager_Clean_StreamingSupport(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	fakeClient := fake.NewSimpleClientset(
+		&corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "stack-stream-clean"}},
+	)
+	k8sClient := k8s.NewClientFromInterface(fakeClient)
+
+	inst := &models.StackInstance{
+		ID:        "inst-stream-clean",
+		Name:      "stream-clean",
+		Namespace: "stack-stream-clean",
+		Status:    models.StackStatusStopped,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	helmMock := &streamingMockHelmExecutor{
+		mockHelmExecutor: &mockHelmExecutor{
+			uninstallFunc: func(_ context.Context, req UninstallRequest) (string, error) {
+				return fmt.Sprintf("uninstalling %s\ncleaned", req.ReleaseName), nil
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock, k8sClient: k8sClient},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	charts := []models.ChartConfig{
+		{ChartName: "redis", DeployOrder: 1},
+	}
+
+	logID, err := mgr.Clean(context.Background(), inst, charts)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify the streaming executor's WithLineHandler was called.
+	assert.True(t, helmMock.wasLineHandlerSet(), "WithLineHandler should have been called for clean")
+
+	// Verify instance returned to draft status.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusDraft, final.Status)
+
+	// Verify deployment.log messages were streamed.
+	messages := hub.getMessages()
+	var logMsgCount int
+	for _, msg := range messages {
+		if parseBroadcastMessageType(msg) == "deployment.log" {
+			logMsgCount++
+		}
+	}
+	assert.Greater(t, logMsgCount, 0, "streaming clean should produce deployment.log messages")
+}
+
+func TestManager_Deploy_StreamingPartialFailure_StillBroadcastsLines(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-stream-fail",
+		StackDefinitionID: "def-1",
+		Name:              "stream-fail",
+		Namespace:         "stack-stream-fail",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	helmMock := &streamingMockHelmExecutor{
+		mockHelmExecutor: &mockHelmExecutor{
+			installFunc: func(_ context.Context, req InstallRequest) (string, error) {
+				if req.ReleaseName == "failing-chart" {
+					return "preparing\nerror: image pull failed", fmt.Errorf("helm command failed: exit status 1")
+				}
+				return "installed " + req.ReleaseName, nil
+			},
+		},
+	}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: helmMock},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	req := DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "good-chart", DeployOrder: 1}},
+			{ChartConfig: models.ChartConfig{ChartName: "failing-chart", DeployOrder: 2}},
+		},
+	}
+
+	logID, err := mgr.Deploy(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	// Wait for async completion.
+	time.Sleep(500 * time.Millisecond)
+
+	// Verify instance ended in error state.
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusError, final.Status)
+
+	// Even with failure, streaming should have broadcast per-line log messages
+	// for both the successful chart and the failing chart's partial output.
+	messages := hub.getMessages()
+	var logMsgCount int
+	for _, msg := range messages {
+		if parseBroadcastMessageType(msg) == "deployment.log" {
+			logMsgCount++
+		}
+	}
+	assert.Greater(t, logMsgCount, 0, "streaming deploy with failure should still produce per-line log messages")
+}
+
+// Verify that streamingMockHelmExecutor satisfies StreamingHelmExecutor at compile time.
+var _ StreamingHelmExecutor = (*streamingMockHelmExecutor)(nil)

--- a/backend/internal/websocket/client.go
+++ b/backend/internal/websocket/client.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"time"
@@ -76,15 +77,14 @@ func (c *Client) readPump() {
 	})
 
 	for {
-		_, _, err := c.conn.ReadMessage()
+		_, data, err := c.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseNormalClosure) {
 				slog.Warn("WebSocket unexpected close", "error", err)
 			}
 			return
 		}
-		// Inbound messages from clients are currently ignored.
-		// Future: route client messages through the hub or a handler.
+		c.handleInbound(data)
 	}
 }
 
@@ -161,4 +161,36 @@ func (c *Client) writeMessage(data []byte) error {
 		return err
 	}
 	return w.Close()
+}
+
+// inboundMsg is the minimal envelope parsed from client-sent JSON.
+type inboundMsg struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type subscribePayload struct {
+	InstanceID string `json:"instance_id"`
+}
+
+// handleInbound routes inbound client messages. Currently supports:
+//   - subscribe: register interest in an instance's deployment logs
+//   - unsubscribe: remove interest
+func (c *Client) handleInbound(data []byte) {
+	var msg inboundMsg
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return
+	}
+	switch msg.Type {
+	case "subscribe":
+		var p subscribePayload
+		if json.Unmarshal(msg.Payload, &p) == nil && p.InstanceID != "" {
+			c.hub.Subscribe(c, p.InstanceID)
+		}
+	case "unsubscribe":
+		var p subscribePayload
+		if json.Unmarshal(msg.Payload, &p) == nil && p.InstanceID != "" {
+			c.hub.Unsubscribe(c, p.InstanceID)
+		}
+	}
 }

--- a/backend/internal/websocket/hub.go
+++ b/backend/internal/websocket/hub.go
@@ -26,11 +26,23 @@ type BroadcastSender interface {
 	Broadcast(message []byte)
 }
 
+// TargetedSender extends BroadcastSender with the ability to send messages
+// only to clients subscribed to a specific instance. Used for high-volume
+// streaming (e.g. deployment logs) to avoid pushing data to uninterested clients.
+type TargetedSender interface {
+	BroadcastSender
+	BroadcastToInstance(instanceID string, message []byte)
+}
+
 // Hub manages the set of active WebSocket clients and broadcasts messages
 // to all of them. It is safe for concurrent use.
 type Hub struct {
 	// clients holds the set of registered clients.
 	clients map[*Client]bool
+
+	// instanceSubs maps instance IDs to the set of clients watching them.
+	// Used by BroadcastToInstance to send deployment logs only to interested clients.
+	instanceSubs map[string]map[*Client]bool
 
 	// broadcast receives messages to send to all clients.
 	broadcast chan []byte
@@ -41,7 +53,7 @@ type Hub struct {
 	// unregister receives clients requesting removal.
 	unregister chan *Client
 
-	// mu protects the clients map for reads outside the Run loop.
+	// mu protects the clients and instanceSubs maps for reads outside the Run loop.
 	mu sync.RWMutex
 
 	// done signals the Run loop to stop.
@@ -54,11 +66,12 @@ type Hub struct {
 // NewHub creates a new Hub ready to accept clients.
 func NewHub() *Hub {
 	return &Hub{
-		clients:    make(map[*Client]bool),
-		broadcast:  make(chan []byte, broadcastBufferSize),
-		register:   make(chan *Client),
-		unregister: make(chan *Client),
-		done:       make(chan struct{}),
+		clients:      make(map[*Client]bool),
+		instanceSubs: make(map[string]map[*Client]bool),
+		broadcast:    make(chan []byte, broadcastBufferSize),
+		register:     make(chan *Client),
+		unregister:   make(chan *Client),
+		done:         make(chan struct{}),
 	}
 }
 
@@ -81,6 +94,7 @@ func (h *Hub) Run() {
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)
 				close(client.send)
+				h.removeClientSubs(client)
 				hubMetrics.connectionsActive.Add(context.Background(), -1)
 			}
 			h.mu.Unlock()
@@ -161,6 +175,80 @@ func (h *Hub) ClientCount() int {
 	return len(h.clients)
 }
 
+// Subscribe registers a client's interest in messages for a specific instance.
+// Must be called with h.mu held (or from within the Run loop).
+func (h *Hub) Subscribe(c *Client, instanceID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	subs, ok := h.instanceSubs[instanceID]
+	if !ok {
+		subs = make(map[*Client]bool)
+		h.instanceSubs[instanceID] = subs
+	}
+	subs[c] = true
+}
+
+// Unsubscribe removes a client's interest in a specific instance.
+func (h *Hub) Unsubscribe(c *Client, instanceID string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if subs, ok := h.instanceSubs[instanceID]; ok {
+		delete(subs, c)
+		if len(subs) == 0 {
+			delete(h.instanceSubs, instanceID)
+		}
+	}
+}
+
+// BroadcastToInstance sends a message only to clients subscribed to the given
+// instance. If no clients are subscribed, the message is silently dropped
+// (no point broadcasting deployment logs nobody is watching).
+func (h *Hub) BroadcastToInstance(instanceID string, message []byte) {
+	h.mu.RLock()
+	subs := h.instanceSubs[instanceID]
+	if len(subs) == 0 {
+		h.mu.RUnlock()
+		return
+	}
+	var slow []*Client
+	var sent int64
+	for client := range subs {
+		select {
+		case client.send <- message:
+			sent++
+		default:
+			slow = append(slow, client)
+		}
+	}
+	h.mu.RUnlock()
+	if sent > 0 {
+		hubMetrics.messagesSentTotal.Add(context.Background(), sent)
+	}
+	if len(slow) > 0 {
+		h.mu.Lock()
+		for _, client := range slow {
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				close(client.send)
+				h.removeClientSubs(client)
+				hubMetrics.connectionsActive.Add(context.Background(), -1)
+			}
+		}
+		h.mu.Unlock()
+	}
+}
+
+// removeClientSubs removes a client from all instance subscriptions.
+// Caller must hold h.mu (write lock).
+func (h *Hub) removeClientSubs(c *Client) {
+	for id, subs := range h.instanceSubs {
+		delete(subs, c)
+		if len(subs) == 0 {
+			delete(h.instanceSubs, id)
+		}
+	}
+}
+
 // closeAllClients removes all clients and closes their send channels.
 func (h *Hub) closeAllClients() {
 	h.mu.Lock()
@@ -170,6 +258,7 @@ func (h *Hub) closeAllClients() {
 		close(client.send)
 		delete(h.clients, client)
 	}
+	h.instanceSubs = make(map[string]map[*Client]bool)
 	if count > 0 {
 		hubMetrics.connectionsActive.Add(context.Background(), -count)
 	}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -306,7 +306,8 @@ export const templateService = {
   get: async (id: string): Promise<StackTemplate> => {
     try {
       const response = await api.get(`/api/v1/templates/${id}`);
-      return { ...response.data, charts: response.data.charts || [] };
+      const { template, charts } = response.data;
+      return { ...template, charts: charts || [] };
     } catch (error) {
       console.error('Failed to fetch template:', error);
       throw error;
@@ -396,7 +397,7 @@ export const templateService = {
   instantiate: async (id: string, data: InstantiateTemplateRequest): Promise<StackDefinition> => {
     try {
       const response = await api.post(`/api/v1/templates/${id}/instantiate`, data);
-      return response.data;
+      return response.data.definition ?? response.data;
     } catch (error) {
       console.error('Failed to instantiate template:', error);
       throw error;

--- a/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
+++ b/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
@@ -153,8 +153,7 @@ describe('DeploymentLogViewer', () => {
     expect(screen.getByText(/Error: release not found/)).toBeVisible();
   });
 
-  it('shows error_message prefixed with "Error:" for error logs', async () => {
-    const user = userEvent.setup();
+  it('shows error_message prefixed with "Error:" for error logs', () => {
     const errorLog: DeploymentLog = {
       id: 'log-err-detail',
       stack_instance_id: 'inst-1',

--- a/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
+++ b/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
@@ -9,29 +9,80 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = () => {};
 });
 
-const mockLogs: DeploymentLog[] = [
-  {
-    id: 'log-1',
-    stack_instance_id: 'inst-1',
-    action: 'deploy',
-    status: 'success',
-    output: 'Release "test" has been upgraded.\nHappy deploying!',
-    started_at: '2026-03-19T10:00:00Z',
-    completed_at: '2026-03-19T10:01:00Z',
-  },
-  {
-    id: 'log-2',
-    stack_instance_id: 'inst-1',
-    action: 'stop',
-    status: 'error',
-    output: 'Attempting to uninstall...',
-    error_message: 'release not found',
-    started_at: '2026-03-19T11:00:00Z',
-    completed_at: '2026-03-19T11:00:30Z',
-  },
-];
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const completedDeployLog: DeploymentLog = {
+  id: 'log-1',
+  stack_instance_id: 'inst-1',
+  action: 'deploy',
+  status: 'success',
+  output: 'Release "test" has been upgraded.\nHappy deploying!',
+  started_at: '2026-03-19T10:00:00Z',
+  completed_at: '2026-03-19T10:01:00Z',
+};
+
+const errorStopLog: DeploymentLog = {
+  id: 'log-2',
+  stack_instance_id: 'inst-1',
+  action: 'stop',
+  status: 'error',
+  output: 'Attempting to uninstall...',
+  error_message: 'release not found',
+  started_at: '2026-03-19T11:00:00Z',
+  completed_at: '2026-03-19T11:00:30Z',
+};
+
+const runningLogNoOutput: DeploymentLog = {
+  id: 'log-running-empty',
+  stack_instance_id: 'inst-1',
+  action: 'deploy',
+  status: 'running',
+  output: '',
+  started_at: '2026-03-19T12:00:00Z',
+};
+
+const runningLogWithOutput: DeploymentLog = {
+  id: 'log-running-output',
+  stack_instance_id: 'inst-1',
+  action: 'deploy',
+  status: 'running',
+  output: 'Helm install started...',
+  started_at: '2026-03-19T13:00:00Z',
+};
+
+const rollbackLog: DeploymentLog = {
+  id: 'log-rollback',
+  stack_instance_id: 'inst-1',
+  action: 'rollback',
+  status: 'success',
+  output: 'Rollback complete',
+  started_at: '2026-03-19T14:00:00Z',
+  completed_at: '2026-03-19T14:00:05Z',
+};
+
+const cleanLog: DeploymentLog = {
+  id: 'log-clean',
+  stack_instance_id: 'inst-1',
+  action: 'clean',
+  status: 'success',
+  output: 'Namespace cleaned',
+  started_at: '2026-03-19T15:00:00Z',
+  completed_at: '2026-03-19T15:00:10Z',
+};
+
+const mockLogs: DeploymentLog[] = [completedDeployLog, errorStopLog];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 describe('DeploymentLogViewer', () => {
+  // -------------------------------------------------------------------------
+  // Basic rendering
+  // -------------------------------------------------------------------------
+
   it('renders "No deployment history" when logs are empty', () => {
     render(<DeploymentLogViewer logs={[]} />);
     expect(screen.getByText('No deployment history')).toBeInTheDocument();
@@ -41,6 +92,12 @@ describe('DeploymentLogViewer', () => {
     render(<DeploymentLogViewer logs={mockLogs} />);
     expect(screen.getByText('deploy')).toBeInTheDocument();
     expect(screen.getByText('stop')).toBeInTheDocument();
+  });
+
+  it('renders status chips for each log', () => {
+    render(<DeploymentLogViewer logs={mockLogs} />);
+    expect(screen.getByText('success')).toBeInTheDocument();
+    expect(screen.getByText('error')).toBeInTheDocument();
   });
 
   it('renders the first log expanded by default with output visible', () => {
@@ -71,6 +128,20 @@ describe('DeploymentLogViewer', () => {
     expect(screen.getByText(/Attempting to uninstall/)).toBeVisible();
   });
 
+  // -------------------------------------------------------------------------
+  // Completed log output
+  // -------------------------------------------------------------------------
+
+  it('shows completed log output text in the terminal box', () => {
+    render(<DeploymentLogViewer logs={[completedDeployLog]} />);
+    expect(screen.getByText(/Release "test" has been upgraded/)).toBeInTheDocument();
+    expect(screen.getByText(/Happy deploying!/)).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Error message rendering
+  // -------------------------------------------------------------------------
+
   it('shows error message in expanded log', async () => {
     const user = userEvent.setup();
     render(<DeploymentLogViewer logs={mockLogs} />);
@@ -79,41 +150,262 @@ describe('DeploymentLogViewer', () => {
     const stopChip = screen.getByText('stop');
     await user.click(stopChip);
 
-    expect(screen.getByText(/release not found/)).toBeVisible();
+    expect(screen.getByText(/Error: release not found/)).toBeVisible();
   });
+
+  it('shows error_message prefixed with "Error:" for error logs', async () => {
+    const user = userEvent.setup();
+    const errorLog: DeploymentLog = {
+      id: 'log-err-detail',
+      stack_instance_id: 'inst-1',
+      action: 'deploy',
+      status: 'error',
+      output: 'Some partial output',
+      error_message: 'timeout waiting for helm',
+      started_at: '2026-03-19T16:00:00Z',
+      completed_at: '2026-03-19T16:01:00Z',
+    };
+    render(<DeploymentLogViewer logs={[errorLog]} />);
+
+    expect(screen.getByText(/Error: timeout waiting for helm/)).toBeInTheDocument();
+  });
+
+  it('does not render error box when error_message is absent', () => {
+    render(<DeploymentLogViewer logs={[completedDeployLog]} />);
+    expect(screen.queryByText(/^Error:/)).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Status chip variants
+  // -------------------------------------------------------------------------
 
   it('shows correct status chips (running=info, success=success, error=error)', () => {
     const logsWithAllStatuses: DeploymentLog[] = [
-      { ...mockLogs[0], id: 'r1', status: 'running' },
-      { ...mockLogs[0], id: 'r2', status: 'success' },
-      { ...mockLogs[0], id: 'r3', status: 'error' },
+      { ...completedDeployLog, id: 'r1', status: 'running' },
+      { ...completedDeployLog, id: 'r2', status: 'success' },
+      { ...completedDeployLog, id: 'r3', status: 'error' },
     ];
     render(<DeploymentLogViewer logs={logsWithAllStatuses} />);
     const chips = screen.getAllByText(/running|success|error/);
     expect(chips.length).toBeGreaterThanOrEqual(3);
   });
 
+  // -------------------------------------------------------------------------
+  // Timestamp and duration
+  // -------------------------------------------------------------------------
+
   it('shows start time and duration for completed logs', () => {
-    render(<DeploymentLogViewer logs={[mockLogs[0]]} />);
+    render(<DeploymentLogViewer logs={[completedDeployLog]} />);
     const startDate = new Date('2026-03-19T10:00:00Z').toLocaleString();
     // Duration should be 1m 0s
     expect(screen.getByText(new RegExp(startDate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeInTheDocument();
     expect(screen.getByText(/1m 0s/)).toBeInTheDocument();
   });
 
+  it('shows only start time for running logs without completed_at', () => {
+    render(<DeploymentLogViewer logs={[runningLogNoOutput]} />);
+    const startDate = new Date('2026-03-19T12:00:00Z').toLocaleString();
+    expect(screen.getByText(new RegExp(startDate.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))).toBeInTheDocument();
+    // Should not show a duration
+    expect(screen.queryByText(/\d+m \d+s/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/\d+s$/)).not.toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Action chip variants
+  // -------------------------------------------------------------------------
+
+  it('renders rollback action chip', () => {
+    render(<DeploymentLogViewer logs={[rollbackLog]} />);
+    expect(screen.getByText('rollback')).toBeInTheDocument();
+  });
+
   it('renders clean action with correct chip color', () => {
-    const cleanLog: DeploymentLog[] = [
-      {
-        id: 'log-clean',
-        stack_instance_id: 'inst-1',
-        action: 'clean',
-        status: 'success',
-        output: 'Namespace cleaned',
-        started_at: '2026-03-19T12:00:00Z',
-        completed_at: '2026-03-19T12:00:10Z',
-      },
-    ];
-    render(<DeploymentLogViewer logs={cleanLog} />);
+    render(<DeploymentLogViewer logs={[cleanLog]} />);
     expect(screen.getByText('clean')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // "Waiting for output..." state
+  // -------------------------------------------------------------------------
+
+  it('shows "Waiting for output..." for running log without output or streaming lines', () => {
+    render(<DeploymentLogViewer logs={[runningLogNoOutput]} />);
+    expect(screen.getByText('Waiting for output...')).toBeInTheDocument();
+  });
+
+  it('shows "Waiting for output..." for running log without output even when streamingLines is empty object', () => {
+    render(<DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={{}} />);
+    expect(screen.getByText('Waiting for output...')).toBeInTheDocument();
+  });
+
+  it('shows "Waiting for output..." when streamingLines has entry but it is an empty array', () => {
+    render(
+      <DeploymentLogViewer
+        logs={[runningLogNoOutput]}
+        streamingLines={{ [runningLogNoOutput.id]: [] }}
+      />,
+    );
+    // lines.length === 0 => isStreaming is false, and output is empty => "Waiting for output..."
+    expect(screen.getByText('Waiting for output...')).toBeInTheDocument();
+  });
+
+  it('shows "No output recorded" for a completed log with empty output', () => {
+    const completedNoOutput: DeploymentLog = {
+      ...completedDeployLog,
+      id: 'log-no-output',
+      output: '',
+    };
+    render(<DeploymentLogViewer logs={[completedNoOutput]} />);
+    expect(screen.getByText('No output recorded')).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // Real-time streaming feature (NEW)
+  // -------------------------------------------------------------------------
+
+  describe('real-time streaming', () => {
+    it('shows streaming lines for a running log', () => {
+      const streamingLines = {
+        [runningLogNoOutput.id]: ['Installing chart kvk-core...', 'Waiting for pods...'],
+      };
+      render(
+        <DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={streamingLines} />,
+      );
+      expect(screen.getByText('Installing chart kvk-core...')).toBeInTheDocument();
+      expect(screen.getByText('Waiting for pods...')).toBeInTheDocument();
+    });
+
+    it('shows LIVE chip when log is running and has streaming lines', () => {
+      const streamingLines = {
+        [runningLogNoOutput.id]: ['line one'],
+      };
+      render(
+        <DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={streamingLines} />,
+      );
+      expect(screen.getByText('LIVE')).toBeInTheDocument();
+    });
+
+    it('does not show LIVE chip for a completed log', () => {
+      render(<DeploymentLogViewer logs={[completedDeployLog]} />);
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('does not show LIVE chip for a completed log even if streamingLines has data', () => {
+      // Edge case: stale streaming data lingering after completion
+      const streamingLines = {
+        [completedDeployLog.id]: ['stale line'],
+      };
+      render(
+        <DeploymentLogViewer logs={[completedDeployLog]} streamingLines={streamingLines} />,
+      );
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('does not show LIVE chip when running log has no streaming lines', () => {
+      render(<DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={{}} />);
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('does not show LIVE chip when running log has empty streaming lines array', () => {
+      const streamingLines = {
+        [runningLogNoOutput.id]: [],
+      };
+      render(
+        <DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={streamingLines} />,
+      );
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('renders streaming output instead of log.output for running log with streaming lines', () => {
+      // This running log has output AND streaming lines.
+      // Streaming lines should win when isStreaming is true.
+      const streamingLines = {
+        [runningLogWithOutput.id]: ['Real-time line A', 'Real-time line B'],
+      };
+      render(
+        <DeploymentLogViewer logs={[runningLogWithOutput]} streamingLines={streamingLines} />,
+      );
+      expect(screen.getByText('Real-time line A')).toBeInTheDocument();
+      expect(screen.getByText('Real-time line B')).toBeInTheDocument();
+    });
+
+    it('falls back to log.output when running log has output but no streaming lines', () => {
+      render(<DeploymentLogViewer logs={[runningLogWithOutput]} />);
+      expect(screen.getByText('Helm install started...')).toBeInTheDocument();
+      expect(screen.queryByText('LIVE')).not.toBeInTheDocument();
+    });
+
+    it('renders multiple streaming lines preserving order', () => {
+      const lines = [
+        'Step 1: Pulling chart...',
+        'Step 2: Running hooks...',
+        'Step 3: Deploying pods...',
+        'Step 4: Checking health...',
+      ];
+      const streamingLines = {
+        [runningLogNoOutput.id]: lines,
+      };
+      render(
+        <DeploymentLogViewer logs={[runningLogNoOutput]} streamingLines={streamingLines} />,
+      );
+      const renderedTexts = lines.map((l) => screen.getByText(l));
+      // Verify all rendered
+      renderedTexts.forEach((el) => expect(el).toBeInTheDocument());
+    });
+
+    it('shows LIVE chip only for the running log, not for completed siblings', () => {
+      const logs: DeploymentLog[] = [runningLogNoOutput, completedDeployLog];
+      const streamingLines = {
+        [runningLogNoOutput.id]: ['streaming data'],
+      };
+      render(
+        <DeploymentLogViewer logs={logs} streamingLines={streamingLines} />,
+      );
+      // Only one LIVE chip should be present
+      const liveChips = screen.getAllByText('LIVE');
+      expect(liveChips).toHaveLength(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-expand behavior
+  // -------------------------------------------------------------------------
+
+  describe('auto-expand', () => {
+    it('auto-expands the most recent (first) log', () => {
+      render(<DeploymentLogViewer logs={[completedDeployLog, errorStopLog]} />);
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true');
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('auto-expands when there is only one log', () => {
+      render(<DeploymentLogViewer logs={[completedDeployLog]} />);
+      const buttons = screen.getAllByRole('button');
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('preserves user expansion when clicking a different accordion', async () => {
+      const user = userEvent.setup();
+      render(<DeploymentLogViewer logs={[completedDeployLog, errorStopLog]} />);
+
+      // Click the second log to expand it
+      await user.click(screen.getByText('stop'));
+
+      const buttons = screen.getAllByRole('button');
+      // First should now be collapsed, second expanded
+      expect(buttons[0]).toHaveAttribute('aria-expanded', 'false');
+      expect(buttons[1]).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  it('does not show "No deployment history" when loading is true even with empty logs', () => {
+    render(<DeploymentLogViewer logs={[]} loading={true} />);
+    expect(screen.queryByText('No deployment history')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/components/DeploymentLogViewer/index.tsx
+++ b/frontend/src/components/DeploymentLogViewer/index.tsx
@@ -78,13 +78,15 @@ const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogVie
     }
   }, [logs]);
 
+  const activeStreamLineCount = expanded && streamingLines?.[expanded]?.length;
+
   // Auto-scroll streaming output to bottom as new lines arrive.
   useEffect(() => {
     const el = streamContainerRef.current;
     if (el) {
       el.scrollTop = el.scrollHeight;
     }
-  }, [streamingLines, expanded]);
+  }, [activeStreamLineCount]);
 
   // Auto-scroll when a running log's output updates
   useEffect(() => {

--- a/frontend/src/components/DeploymentLogViewer/index.tsx
+++ b/frontend/src/components/DeploymentLogViewer/index.tsx
@@ -163,7 +163,7 @@ const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogVie
                   sx={terminalSx}
                 >
                   {lines.map((line, i) => (
-                    <div key={i}>{line || '\u00A0'}</div>
+                    <div key={`line-${i}`}>{line || '\u00A0'}</div>
                   ))}
                 </Box>
               ) : log.output ? (

--- a/frontend/src/components/DeploymentLogViewer/index.tsx
+++ b/frontend/src/components/DeploymentLogViewer/index.tsx
@@ -13,6 +13,7 @@ import type { DeploymentLog } from '../../types';
 interface DeploymentLogViewerProps {
   logs: DeploymentLog[];
   loading?: boolean;
+  streamingLines?: Record<string, string[]>;
 }
 
 const statusColor = (status: string): 'success' | 'error' | 'info' | 'default' => {
@@ -24,11 +25,12 @@ const statusColor = (status: string): 'success' | 'error' | 'info' | 'default' =
   }
 };
 
-const actionColor = (action: string): 'primary' | 'warning' | 'error' => {
+const actionColor = (action: string): 'primary' | 'warning' | 'error' | 'info' => {
   switch (action) {
     case 'deploy': return 'primary';
     case 'stop': return 'warning';
     case 'clean': return 'error';
+    case 'rollback': return 'info';
     default: return 'primary';
   }
 };
@@ -43,8 +45,22 @@ const formatDuration = (startedAt: string, completedAt: string): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-const DeploymentLogViewer = ({ logs, loading }: DeploymentLogViewerProps) => {
+const terminalSx = {
+  p: 2,
+  bgcolor: '#1e1e1e',
+  color: '#d4d4d4',
+  fontFamily: 'monospace',
+  fontSize: '0.8rem',
+  lineHeight: 1.6,
+  maxHeight: 300,
+  overflow: 'auto',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+} as const;
+
+const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogViewerProps) => {
   const bottomRef = useRef<HTMLDivElement>(null);
+  const streamContainerRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState<string | false>(false);
 
   // Expand the most recent log by default, but only when there's no user selection
@@ -61,6 +77,14 @@ const DeploymentLogViewer = ({ logs, loading }: DeploymentLogViewerProps) => {
       });
     }
   }, [logs]);
+
+  // Auto-scroll streaming output to bottom as new lines arrive.
+  useEffect(() => {
+    const el = streamContainerRef.current;
+    if (el) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [streamingLines, expanded]);
 
   // Auto-scroll when a running log's output updates
   useEffect(() => {
@@ -84,65 +108,82 @@ const DeploymentLogViewer = ({ logs, loading }: DeploymentLogViewerProps) => {
 
   return (
     <Box>
-      {logs.map((log) => (
-        <Accordion
-          key={log.id}
-          expanded={expanded === log.id}
-          onChange={handleAccordionChange(log.id)}
-          sx={{ mb: 1, '&:before': { display: 'none' } }}
-        >
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', mr: 1 }}>
-              <Chip
-                label={log.action}
-                size="small"
-                color={actionColor(log.action)}
-                variant="outlined"
-              />
-              <Chip
-                label={log.status}
-                size="small"
-                color={statusColor(log.status)}
-              />
-              <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
-                {new Date(log.started_at).toLocaleString()}
-                {log.completed_at && ` (${formatDuration(log.started_at, log.completed_at)})`}
-              </Typography>
-            </Box>
-          </AccordionSummary>
-          <AccordionDetails sx={{ p: 0 }}>
-            {log.output ? (
-              <Box
-                sx={{
-                  p: 2,
-                  bgcolor: '#1e1e1e',
-                  color: '#d4d4d4',
-                  fontFamily: 'monospace',
-                  fontSize: '0.8rem',
-                  lineHeight: 1.6,
-                  maxHeight: 300,
-                  overflow: 'auto',
-                  whiteSpace: 'pre-wrap',
-                  wordBreak: 'break-all',
-                }}
-              >
-                {log.output}
-                {log.error_message && (
-                  <Box sx={{ color: '#f44336', mt: 1 }}>
-                    Error: {log.error_message}
-                  </Box>
+      {logs.map((log) => {
+        const lines = streamingLines?.[log.id];
+        const isStreaming = log.status === 'running' && lines && lines.length > 0;
+        const isExpanded = expanded === log.id;
+
+        return (
+          <Accordion
+            key={log.id}
+            expanded={isExpanded}
+            onChange={handleAccordionChange(log.id)}
+            sx={{ mb: 1, '&:before': { display: 'none' } }}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, width: '100%', mr: 1 }}>
+                <Chip
+                  label={log.action}
+                  size="small"
+                  color={actionColor(log.action)}
+                  variant="outlined"
+                />
+                <Chip
+                  label={log.status}
+                  size="small"
+                  color={statusColor(log.status)}
+                />
+                {isStreaming && (
+                  <Chip
+                    label="LIVE"
+                    size="small"
+                    color="info"
+                    variant="filled"
+                    sx={{
+                      animation: 'pulse 2s infinite',
+                      '@keyframes pulse': {
+                        '0%, 100%': { opacity: 1 },
+                        '50%': { opacity: 0.5 },
+                      },
+                    }}
+                  />
                 )}
-              </Box>
-            ) : (
-              <Box sx={{ p: 2 }}>
-                <Typography variant="body2" color="text.secondary">
-                  {log.status === 'running' ? 'Waiting for output...' : 'No output recorded'}
+                <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+                  {new Date(log.started_at).toLocaleString()}
+                  {log.completed_at && ` (${formatDuration(log.started_at, log.completed_at)})`}
                 </Typography>
               </Box>
-            )}
-          </AccordionDetails>
-        </Accordion>
-      ))}
+            </AccordionSummary>
+            <AccordionDetails sx={{ p: 0 }}>
+              {isStreaming ? (
+                <Box
+                  ref={isExpanded ? streamContainerRef : undefined}
+                  sx={terminalSx}
+                >
+                  {lines.map((line, i) => (
+                    <div key={i}>{line || '\u00A0'}</div>
+                  ))}
+                </Box>
+              ) : log.output ? (
+                <Box sx={terminalSx}>
+                  {log.output}
+                  {log.error_message && (
+                    <Box sx={{ color: '#f44336', mt: 1 }}>
+                      Error: {log.error_message}
+                    </Box>
+                  )}
+                </Box>
+              ) : (
+                <Box sx={{ p: 2 }}>
+                  <Typography variant="body2" color="text.secondary">
+                    {log.status === 'running' ? 'Waiting for output...' : 'No output recorded'}
+                  </Typography>
+                </Box>
+              )}
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
       <div ref={bottomRef} />
     </Box>
   );

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -59,6 +59,8 @@ const Detail = () => {
   const [cleanDialogOpen, setCleanDialogOpen] = useState(false);
   const [deployLogs, setDeployLogs] = useState<DeploymentLog[]>([]);
   const [streamingLines, setStreamingLines] = useState<Record<string, string[]>>({});
+  const streamingBufferRef = useRef<Record<string, string[]>>({});
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [k8sStatus, setK8sStatus] = useState<NamespaceStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(false);
   const [extending, setExtending] = useState(false);
@@ -155,7 +157,7 @@ const Detail = () => {
       // On active states, insert a placeholder log entry so streaming lines
       // have an accordion to attach to before the REST refresh completes.
       const logId = (payload as { log_id?: string }).log_id;
-      if ((newStatus === 'deploying' || newStatus === 'stopping' || newStatus === 'cleaning') && logId) {
+      if ((newStatus === 'deploying' || newStatus === 'stopping' || newStatus === 'cleaning' || newStatus === 'rolling_back') && logId) {
         const actionMap: Record<string, DeploymentLog['action']> = {
           deploying: 'deploy', stopping: 'stop', cleaning: 'clean', rolling_back: 'rollback',
         };
@@ -176,6 +178,11 @@ const Detail = () => {
       if (newStatus === 'running' || newStatus === 'stopped' || newStatus === 'error' || newStatus === 'draft') {
         instanceService.getDeployLog(id).then(setDeployLogs).catch(() => {});
         setStreamingLines({});
+        streamingBufferRef.current = {};
+        if (flushTimerRef.current) {
+          clearTimeout(flushTimerRef.current);
+          flushTimerRef.current = null;
+        }
         setDeploying(false);
         setStopping(false);
         setCleaning(false);
@@ -183,17 +190,34 @@ const Detail = () => {
     }
 
     // Real-time log line streaming from active deployments.
+    // Lines are buffered and flushed in batches (50ms) to reduce GC pressure
+    // and React re-renders during high-throughput output (e.g. helm --debug).
     if (msg.type === 'deployment.log') {
       const logPayload = msg.payload as { log_id?: string; line?: string };
       if (logPayload.log_id && logPayload.line !== undefined) {
-        const MAX_STREAMING_LINES = 5000;
-        setStreamingLines((prev) => {
-          const existing = prev[logPayload.log_id!] || [];
-          const updated = existing.length >= MAX_STREAMING_LINES
-            ? [...existing.slice(existing.length - MAX_STREAMING_LINES + 1), logPayload.line!]
-            : [...existing, logPayload.line!];
-          return { ...prev, [logPayload.log_id!]: updated };
-        });
+        const buf = streamingBufferRef.current;
+        if (!buf[logPayload.log_id!]) buf[logPayload.log_id!] = [];
+        buf[logPayload.log_id!].push(logPayload.line!);
+
+        if (!flushTimerRef.current) {
+          flushTimerRef.current = setTimeout(() => {
+            flushTimerRef.current = null;
+            const pending = { ...streamingBufferRef.current };
+            streamingBufferRef.current = {};
+            setStreamingLines((prev) => {
+              const MAX_STREAMING_LINES = 5000;
+              const next = { ...prev };
+              for (const [logId, newLines] of Object.entries(pending)) {
+                const existing = next[logId] || [];
+                const merged = [...existing, ...newLines];
+                next[logId] = merged.length > MAX_STREAMING_LINES
+                  ? merged.slice(merged.length - MAX_STREAMING_LINES)
+                  : merged;
+              }
+              return next;
+            });
+          }, 50);
+        }
       }
     }
 
@@ -213,7 +237,15 @@ const Detail = () => {
 
   }, [id]);
 
-  useWebSocket(handleWsMessage);
+  const { send } = useWebSocket(handleWsMessage);
+
+  useEffect(() => {
+    if (!id) return;
+    send('subscribe', { instance_id: id });
+    return () => {
+      send('unsubscribe', { instance_id: id });
+    };
+  }, [id, send]);
 
   const handleChartBranchChange = async (chartId: string, newBranch: string) => {
     if (!id) return;

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -58,6 +58,7 @@ const Detail = () => {
   const [cleaning, setCleaning] = useState(false);
   const [cleanDialogOpen, setCleanDialogOpen] = useState(false);
   const [deployLogs, setDeployLogs] = useState<DeploymentLog[]>([]);
+  const [streamingLines, setStreamingLines] = useState<Record<string, string[]>>({});
   const [k8sStatus, setK8sStatus] = useState<NamespaceStatus | null>(null);
   const [statusLoading, setStatusLoading] = useState(false);
   const [extending, setExtending] = useState(false);
@@ -151,12 +152,44 @@ const Detail = () => {
         instanceService.getPods(id).then(setK8sStatus).catch(() => {});
       }
 
-      // Refresh deploy logs on terminal states.
+      // On active states, insert a placeholder log entry so streaming lines
+      // have an accordion to attach to before the REST refresh completes.
+      const logId = (payload as { log_id?: string }).log_id;
+      if ((newStatus === 'deploying' || newStatus === 'stopping' || newStatus === 'cleaning') && logId) {
+        const actionMap: Record<string, DeploymentLog['action']> = {
+          deploying: 'deploy', stopping: 'stop', cleaning: 'clean',
+        };
+        setDeployLogs((prev) => {
+          if (prev.some((l) => l.id === logId)) return prev;
+          return [{
+            id: logId,
+            stack_instance_id: id,
+            action: actionMap[newStatus] || 'deploy',
+            status: 'running' as const,
+            output: '',
+            started_at: new Date().toISOString(),
+          }, ...prev];
+        });
+      }
+
+      // Refresh deploy logs on terminal states and clear streaming lines.
       if (newStatus === 'running' || newStatus === 'stopped' || newStatus === 'error' || newStatus === 'draft') {
         instanceService.getDeployLog(id).then(setDeployLogs).catch(() => {});
+        setStreamingLines({});
         setDeploying(false);
         setStopping(false);
         setCleaning(false);
+      }
+    }
+
+    // Real-time log line streaming from active deployments.
+    if (msg.type === 'deployment.log') {
+      const logPayload = msg.payload as { log_id?: string; line?: string };
+      if (logPayload.log_id && logPayload.line !== undefined) {
+        setStreamingLines((prev) => ({
+          ...prev,
+          [logPayload.log_id!]: [...(prev[logPayload.log_id!] || []), logPayload.line!],
+        }));
       }
     }
 
@@ -626,7 +659,7 @@ const Detail = () => {
           <Typography variant="h6" sx={{ mb: 1 }}>
             Deployment History ({deployLogs.length})
           </Typography>
-          <DeploymentLogViewer logs={deployLogs} />
+          <DeploymentLogViewer logs={deployLogs} streamingLines={streamingLines} />
         </Box>
       )}
 

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -157,7 +157,7 @@ const Detail = () => {
       const logId = (payload as { log_id?: string }).log_id;
       if ((newStatus === 'deploying' || newStatus === 'stopping' || newStatus === 'cleaning') && logId) {
         const actionMap: Record<string, DeploymentLog['action']> = {
-          deploying: 'deploy', stopping: 'stop', cleaning: 'clean',
+          deploying: 'deploy', stopping: 'stop', cleaning: 'clean', rolling_back: 'rollback',
         };
         setDeployLogs((prev) => {
           if (prev.some((l) => l.id === logId)) return prev;
@@ -186,10 +186,14 @@ const Detail = () => {
     if (msg.type === 'deployment.log') {
       const logPayload = msg.payload as { log_id?: string; line?: string };
       if (logPayload.log_id && logPayload.line !== undefined) {
-        setStreamingLines((prev) => ({
-          ...prev,
-          [logPayload.log_id!]: [...(prev[logPayload.log_id!] || []), logPayload.line!],
-        }));
+        const MAX_STREAMING_LINES = 5000;
+        setStreamingLines((prev) => {
+          const existing = prev[logPayload.log_id!] || [];
+          const updated = existing.length >= MAX_STREAMING_LINES
+            ? [...existing.slice(existing.length - MAX_STREAMING_LINES + 1), logPayload.line!]
+            : [...existing, logPayload.line!];
+          return { ...prev, [logPayload.log_id!]: updated };
+        });
       }
     }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -110,7 +110,7 @@ export interface StackInstance {
 export interface DeploymentLog {
   id: string;
   stack_instance_id: string;
-  action: 'deploy' | 'stop' | 'clean';
+  action: 'deploy' | 'stop' | 'clean' | 'rollback';
   status: 'running' | 'success' | 'error';
   output: string;
   error_message?: string;


### PR DESCRIPTION
## Summary
- Stream Helm output line-by-line over WebSocket during deploy, stop, clean, and rollback operations
- Add per-instance subscription model so deployment logs only reach clients viewing that instance
- Frontend `DeploymentLogViewer` shows live terminal output with auto-scroll and LIVE indicator
- `StreamingHelmExecutor` interface extends `HelmExecutor` with `WithLineHandler` for line callbacks
- Batched React state updates (50ms debounce) to handle high-throughput output without GC pressure

## Key changes
- **Backend**: `hub.go` gains `Subscribe`/`Unsubscribe`/`BroadcastToInstance`; `client.go` parses inbound subscribe/unsubscribe messages; `helm.go` uses `io.MultiReader` for deterministic stdout+stderr scanning; `broadcast.go` uses targeted send when available
- **Frontend**: `Detail.tsx` sends subscribe/unsubscribe on mount/unmount, buffers streaming lines via `useRef`; `DeploymentLogViewer` renders live terminal with streaming lines per log ID
- **Tests**: 18 `time.Sleep(500ms)` replaced with `waitForTerminalStatus` polling helper; new streaming-specific tests for deploy, stop, clean, rollback, and partial failure scenarios

## Test plan
- [x] All 28 backend packages pass (`go test ./...`)
- [x] Frontend type-checks clean (`npx tsc --noEmit`)
- [ ] Manual: deploy an instance, verify live log lines appear in the terminal
- [ ] Manual: open two browser tabs, verify only the tab viewing the instance receives log lines
- [ ] Manual: verify logs persist correctly after deployment completes (accordion shows full output)

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)