### PR TITLE
feat: expand notification events to cover full stack lifecycle

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -17,6 +17,7 @@ import (
 	"backend/internal/hooks"
 	"backend/internal/k8s"
 	"backend/internal/models"
+	"backend/internal/notifier"
 	"backend/internal/scheduler"
 	"backend/internal/telemetry"
 	"backend/internal/ttl"
@@ -249,6 +250,9 @@ func main() {
 		"actions", actionNames,
 	)
 
+	// Lifecycle notifier — creates in-app notifications for stack events
+	lifecycleNotifier := notifier.NewNotifier(notificationRepo, hub)
+
 	// Deployment manager — uses registry for multi-cluster deploys
 	deployManager := deployer.NewManager(deployer.ManagerConfig{
 		Registry:                   clusterRegistry,
@@ -263,6 +267,7 @@ func main() {
 		WildcardTLSSourceSecret:    cfg.Deployment.WildcardTLSSourceSecret,
 		WildcardTLSTargetSecret:    cfg.Deployment.WildcardTLSTargetSecret,
 		Hooks:                      hookDispatcher,
+		Notifier:                   lifecycleNotifier,
 	})
 
 	// ------------------------------------------------------------------
@@ -322,7 +327,7 @@ func main() {
 		slog.Error("failed to create instance handler", "error", err)
 		os.Exit(1)
 	}
-	instanceHandler.WithHooks(hookDispatcher).WithActions(actionRegistry)
+	instanceHandler.WithHooks(hookDispatcher).WithActions(actionRegistry).WithNotifier(lifecycleNotifier)
 	gitHandler := handlers.NewGitHandler(gitRegistry)
 	auditLogHandler := handlers.NewAuditLogHandler(auditRepo)
 	userHandler := handlers.NewUserHandler(userRepo)

--- a/backend/internal/api/handlers/notifications.go
+++ b/backend/internal/api/handlers/notifications.go
@@ -29,6 +29,7 @@ func NewNotificationHandler(repo models.NotificationRepository) *NotificationHan
 type updatePreferenceRequest struct {
 	EventType string `json:"event_type"`
 	Enabled   bool   `json:"enabled"`
+	Channel   string `json:"channel,omitempty"`
 }
 
 // List godoc
@@ -231,11 +232,16 @@ func (h *NotificationHandler) UpdatePreferences(c *gin.Context) {
 	}
 
 	for _, r := range reqs {
+		channel := r.Channel
+		if channel == "" {
+			channel = "in_app"
+		}
 		pref := &models.NotificationPreference{
 			ID:        generateID(),
 			UserID:    userID,
 			EventType: r.EventType,
 			Enabled:   r.Enabled,
+			Channel:   channel,
 		}
 
 		if err := h.repo.UpdatePreference(c.Request.Context(), pref); err != nil {

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -131,6 +131,7 @@ type InstanceHandler struct {
 	txRunner           database.TxRunner
 	hooks              *hooks.Dispatcher
 	actions            *hooks.ActionRegistry
+	notifier           deployer.LifecycleNotifier
 }
 
 // WithHooks attaches a webhook dispatcher for instance lifecycle events
@@ -145,6 +146,13 @@ func (h *InstanceHandler) WithHooks(d *hooks.Dispatcher) *InstanceHandler {
 // POST /api/v1/stack-instances/:id/actions/:name route. Pass nil to disable.
 func (h *InstanceHandler) WithActions(r *hooks.ActionRegistry) *InstanceHandler {
 	h.actions = r
+	return h
+}
+
+// WithNotifier attaches a lifecycle notifier for in-app notification creation
+// on instance create/delete events. Pass nil to disable.
+func (h *InstanceHandler) WithNotifier(n deployer.LifecycleNotifier) *InstanceHandler {
+	h.notifier = n
 	return h
 }
 
@@ -567,6 +575,11 @@ func (h *InstanceHandler) CreateInstance(c *gin.Context) {
 	// audit logs, etc).
 	_ = h.fireInstanceHook(c.Request.Context(), hooks.EventPostInstanceCreate, &inst)
 
+	if h.notifier != nil {
+		_ = h.notifier.Notify(c.Request.Context(), inst.OwnerID, "instance.created", "Stack created",
+			fmt.Sprintf("Stack %s has been created", inst.Name), "stack_instance", inst.ID)
+	}
+
 	c.JSON(http.StatusCreated, inst)
 }
 
@@ -779,6 +792,11 @@ func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 	}
 
 	_ = h.fireInstanceHook(c.Request.Context(), hooks.EventPostInstanceDelete, inst)
+
+	if h.notifier != nil {
+		_ = h.notifier.Notify(c.Request.Context(), inst.OwnerID, "instance.deleted", "Stack deleted",
+			fmt.Sprintf("Stack %s has been deleted", inst.Name), "stack_instance", inst.ID)
+	}
 
 	c.Status(http.StatusNoContent)
 }

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -854,6 +854,27 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
+	migrator.AddMigration(schema.Migration{
+		Version:     "20260423000035",
+		Name:        "add_channel_to_notification_preferences",
+		Description: "Add channel column to notification_preferences for routing notifications to different delivery channels",
+		Up: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&models.NotificationPreference{}, "Channel") {
+				return nil
+			}
+			if tx.Dialector.Name() == "mysql" {
+				return tx.Exec("ALTER TABLE notification_preferences ADD COLUMN channel VARCHAR(20) NOT NULL DEFAULT 'in_app'").Error // #nosec G202
+			}
+			return tx.Migrator().AddColumn(&models.NotificationPreference{}, "Channel")
+		},
+		Down: func(tx *gorm.DB) error {
+			if tx.Migrator().HasColumn(&models.NotificationPreference{}, "Channel") {
+				return tx.Migrator().DropColumn(&models.NotificationPreference{}, "Channel")
+			}
+			return nil
+		},
+	})
+
 	// Run migrations
 	if err := migrator.MigrateUp(); err != nil {
 		return err

--- a/backend/internal/database/notification_repository.go
+++ b/backend/internal/database/notification_repository.go
@@ -107,7 +107,7 @@ func (r *GORMNotificationRepository) UpdatePreference(ctx context.Context, pref 
 	if err := r.db.WithContext(ctx).
 		Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "user_id"}, {Name: "event_type"}},
-			DoUpdates: clause.AssignmentColumns([]string{"enabled"}),
+			DoUpdates: clause.AssignmentColumns([]string{"enabled", "channel"}),
 		}).
 		Create(pref).Error; err != nil {
 		return dberrors.NewDatabaseError("update_preference", err)

--- a/backend/internal/deployer/broadcast.go
+++ b/backend/internal/deployer/broadcast.go
@@ -82,3 +82,17 @@ func (m *Manager) broadcastLog(instanceID, logID, line string) {
 		m.hub.Broadcast(data)
 	}
 }
+
+// notifyUser sends an in-app notification to a specific user.
+// Silently returns if no notifier is configured.
+func (m *Manager) notifyUser(ownerID, instanceID, notifType, title, message string) {
+	if m.notifier == nil {
+		return
+	}
+
+	if err := m.notifier.Notify(m.shutdownCtx, ownerID, notifType, title, message, "stack_instance", instanceID); err != nil {
+		slog.Error("failed to create lifecycle notification",
+			"instance_id", instanceID, "type", notifType, "error", err)
+	}
+}
+

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -44,6 +44,11 @@ type ClusterResolver interface {
 	GetRegistryConfig(clusterID string) (*models.RegistryConfig, error)
 }
 
+// LifecycleNotifier creates in-app notifications for stack lifecycle events.
+type LifecycleNotifier interface {
+	Notify(ctx context.Context, userID, notifType, title, message, entityType, entityID string) error
+}
+
 // Manager orchestrates asynchronous deployments with concurrency control.
 type Manager struct {
 	registry          ClusterResolver
@@ -67,6 +72,10 @@ type Manager struct {
 	// hooks dispatches lifecycle events to user-configured webhooks.
 	// nil disables all hook dispatch.
 	hooks *hooks.Dispatcher
+
+	// notifier creates in-app notifications for stack lifecycle events.
+	// nil disables notification creation.
+	notifier LifecycleNotifier
 
 	// pendingDeletes tracks instances that should be deleted from the database
 	// after their async clean operation completes successfully.
@@ -97,6 +106,10 @@ type ManagerConfig struct {
 	// as out-of-process action subscribers (see internal/api/routes for the
 	// /actions/{name} router); the core no longer ships any such operations itself.
 	Hooks *hooks.Dispatcher
+
+	// Notifier creates in-app notifications for lifecycle events.
+	// Optional — nil disables notification creation from the deployer.
+	Notifier LifecycleNotifier
 }
 
 // DeployRequest contains everything needed to deploy a stack instance.
@@ -148,7 +161,8 @@ func NewManager(cfg ManagerConfig) *Manager {
 		wildcardTLSSourceSecret: cfg.WildcardTLSSourceSecret,
 		wildcardTLSTargetSecret: wildcardTarget,
 
-		hooks: cfg.Hooks,
+		hooks:    cfg.Hooks,
+		notifier: cfg.Notifier,
 	}
 }
 
@@ -650,6 +664,12 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 		_ = m.fireDeployHook(hookCtx, hooks.EventPostDeploy, instance, deployLog.ID, deployLog.StartedAt)
 	}
 	_ = m.fireDeployHook(hookCtx, hooks.EventDeployFinalized, instance, deployLog.ID, deployLog.StartedAt)
+
+	if deployErr != nil {
+		m.notifyUser(instance.OwnerID, instanceID, "deployment.error", "Deployment failed", fmt.Sprintf("Deployment of %s failed: %s", instance.Name, instance.ErrorMessage))
+	} else {
+		m.notifyUser(instance.OwnerID, instanceID, "deployment.success", "Deployment succeeded", fmt.Sprintf("Deployment of %s completed successfully", instance.Name))
+	}
 }
 
 // StopWithCharts starts an async stop/uninstall with explicit chart information.
@@ -868,6 +888,13 @@ func (m *Manager) finalizeStop(instanceID string, deployLog *models.DeploymentLo
 		m.broadcastStatusWithError(instanceID, models.StackStatusError, deployLog.ID, instance.ErrorMessage)
 	} else {
 		m.broadcastStatus(instanceID, models.StackStatusStopped, deployLog.ID)
+	}
+
+	_ = m.fireDeployHook(m.shutdownCtx, hooks.EventStopCompleted, instance, deployLog.ID, deployLog.StartedAt)
+	if stopErr != nil {
+		m.notifyUser(instance.OwnerID, instanceID, "stop.error", "Stop failed", fmt.Sprintf("Stopping %s failed: %s", instance.Name, instance.ErrorMessage))
+	} else {
+		m.notifyUser(instance.OwnerID, instanceID, "deployment.stopped", "Stack stopped", fmt.Sprintf("Stack %s has been stopped", instance.Name))
 	}
 }
 
@@ -1189,6 +1216,17 @@ func (m *Manager) finalizeClean(instanceID string, deployLog *models.DeploymentL
 	} else {
 		m.broadcastStatus(instanceID, models.StackStatusDraft, deployLog.ID)
 	}
+
+	_ = m.fireDeployHook(m.shutdownCtx, hooks.EventCleanCompleted, instance, deployLog.ID, deployLog.StartedAt)
+
+	if cleanErr != nil {
+		m.notifyUser(instance.OwnerID, instanceID, "clean.error", "Cleanup failed", fmt.Sprintf("Cleanup of %s failed: %s", instance.Name, instance.ErrorMessage))
+	} else if shouldDelete {
+		m.notifyUser(instance.OwnerID, instanceID, "instance.deleted", "Stack deleted", fmt.Sprintf("Stack %s has been deleted", instance.Name))
+		_ = m.fireDeployHook(m.shutdownCtx, hooks.EventDeleteCompleted, instance, deployLog.ID, deployLog.StartedAt)
+	} else {
+		m.notifyUser(instance.OwnerID, instanceID, "clean.completed", "Cleanup completed", fmt.Sprintf("Stack %s has been cleaned and returned to draft", instance.Name))
+	}
 }
 
 // RollbackRequest contains everything needed to rollback a stack instance.
@@ -1451,8 +1489,12 @@ func (m *Manager) finalizeRollback(instanceID string, deployLog *models.Deployme
 	}
 
 	hookCtx := m.shutdownCtx
+	_ = m.fireDeployHook(hookCtx, hooks.EventRollbackCompleted, instance, deployLog.ID, deployLog.StartedAt)
 	if rollbackErr == nil {
 		_ = m.fireDeployHook(hookCtx, hooks.EventPostRollback, instance, deployLog.ID, deployLog.StartedAt)
+		m.notifyUser(instance.OwnerID, instanceID, "rollback.completed", "Rollback completed", fmt.Sprintf("Stack %s has been rolled back successfully", instance.Name))
+	} else {
+		m.notifyUser(instance.OwnerID, instanceID, "rollback.error", "Rollback failed", fmt.Sprintf("Rollback of %s failed: %s", instance.Name, instance.ErrorMessage))
 	}
 }
 

--- a/backend/internal/deployer/notifications_test.go
+++ b/backend/internal/deployer/notifications_test.go
@@ -1,0 +1,381 @@
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"backend/internal/database"
+	"backend/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// noopBranchOverrideRepo satisfies ChartBranchOverrideRepository with no-ops.
+type noopBranchOverrideRepo struct{}
+
+func (noopBranchOverrideRepo) List(string) ([]*models.ChartBranchOverride, error) { return nil, nil }
+func (noopBranchOverrideRepo) Get(string, string) (*models.ChartBranchOverride, error) {
+	return nil, fmt.Errorf("not found")
+}
+func (noopBranchOverrideRepo) Set(*models.ChartBranchOverride) error { return nil }
+func (noopBranchOverrideRepo) Delete(string, string) error           { return nil }
+func (noopBranchOverrideRepo) DeleteByInstance(string) error         { return nil }
+
+// txRunnerWithBranchOverride extends mockTxRunner to include a BranchOverride repo,
+// needed for tests that exercise the delete-after-clean path.
+type txRunnerWithBranchOverride struct {
+	instanceRepo models.StackInstanceRepository
+	logRepo      models.DeploymentLogRepository
+	boRepo       models.ChartBranchOverrideRepository
+}
+
+func (m *txRunnerWithBranchOverride) RunInTx(fn func(repos database.TxRepos) error) error {
+	return fn(database.TxRepos{
+		StackInstance:  m.instanceRepo,
+		DeploymentLog:  m.logRepo,
+		BranchOverride: m.boRepo,
+	})
+}
+
+// mockNotifier records all Notify calls for assertion.
+type mockNotifier struct {
+	mu    sync.Mutex
+	calls []notifyCall
+}
+
+type notifyCall struct {
+	UserID     string
+	Type       string
+	Title      string
+	Message    string
+	EntityType string
+	EntityID   string
+}
+
+func (m *mockNotifier) Notify(_ context.Context, userID, notifType, title, message, entityType, entityID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, notifyCall{
+		UserID:     userID,
+		Type:       notifType,
+		Title:      title,
+		Message:    message,
+		EntityType: entityType,
+		EntityID:   entityID,
+	})
+	return nil
+}
+
+func (m *mockNotifier) getCalls() []notifyCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]notifyCall, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// waitForNotification polls until the notifier has at least n calls.
+func (m *mockNotifier) waitForCalls(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		count := len(m.calls)
+		m.mu.Unlock()
+		if count >= n {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d notification calls, got %d", n, len(m.getCalls()))
+}
+
+func newNotificationTestManager(notif *mockNotifier) (*Manager, *mockInstanceRepo, *mockDeployLogRepo) {
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: NewHelmClient("/nonexistent/helm", "", 1*time.Second)},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+		Notifier:      notif,
+	})
+
+	return mgr, instanceRepo, logRepo
+}
+
+func seedInstance(t *testing.T, repo *mockInstanceRepo, id, name, ownerID string) *models.StackInstance {
+	t.Helper()
+	inst := &models.StackInstance{
+		ID:                id,
+		StackDefinitionID: "def-1",
+		Name:              name,
+		Namespace:         "ns-" + id,
+		OwnerID:           ownerID,
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, repo.Create(inst))
+	return inst
+}
+
+func TestNotification_DeploySuccess(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	mgr, instanceRepo, _ := newNotificationTestManager(notif)
+
+	inst := seedInstance(t, instanceRepo, "inst-notif-deploy", "my-stack", "user-42")
+
+	_, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "user-42", calls[0].UserID)
+	assert.Equal(t, "deployment.success", calls[0].Type)
+	assert.Contains(t, calls[0].Message, "my-stack")
+	assert.Equal(t, "stack_instance", calls[0].EntityType)
+	assert.Equal(t, "inst-notif-deploy", calls[0].EntityID)
+}
+
+func TestNotification_DeployError(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	failHelm := &failingHelmExecutor{err: "helm install failed: timeout"}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: failHelm},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+		Notifier:      notif,
+	})
+
+	inst := seedInstance(t, instanceRepo, "inst-notif-err", "err-stack", "user-99")
+
+	_, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "failing-chart", DeployOrder: 1}},
+		},
+	})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "deployment.error", calls[0].Type)
+	assert.Equal(t, "user-99", calls[0].UserID)
+}
+
+func TestNotification_StopCompleted(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	mgr, instanceRepo, _ := newNotificationTestManager(notif)
+
+	inst := seedInstance(t, instanceRepo, "inst-stop", "stop-stack", "user-10")
+	inst.Status = models.StackStatusRunning
+	require.NoError(t, instanceRepo.Update(inst))
+
+	_, err := mgr.StopWithCharts(context.Background(), inst, []ChartDeployInfo{})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "deployment.stopped", calls[0].Type)
+	assert.Equal(t, "user-10", calls[0].UserID)
+	assert.Contains(t, calls[0].Message, "stop-stack")
+}
+
+func TestNotification_CleanCompleted(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	mgr, instanceRepo, _ := newNotificationTestManager(notif)
+
+	inst := seedInstance(t, instanceRepo, "inst-clean", "clean-stack", "user-20")
+	inst.Status = models.StackStatusRunning
+	require.NoError(t, instanceRepo.Update(inst))
+
+	_, err := mgr.Clean(context.Background(), inst, []models.ChartConfig{})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "clean.completed", calls[0].Type)
+	assert.Equal(t, "user-20", calls[0].UserID)
+	assert.Contains(t, calls[0].Message, "clean-stack")
+}
+
+func TestNotification_DeleteAfterClean(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: NewHelmClient("/nonexistent/helm", "", 1*time.Second)},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner: &txRunnerWithBranchOverride{
+			instanceRepo: instanceRepo,
+			logRepo:      logRepo,
+			boRepo:       noopBranchOverrideRepo{},
+		},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+		Notifier:      notif,
+	})
+
+	inst := seedInstance(t, instanceRepo, "inst-del", "del-stack", "user-30")
+	inst.Status = models.StackStatusRunning
+	require.NoError(t, instanceRepo.Update(inst))
+
+	mgr.ScheduleDeleteAfterClean("inst-del")
+
+	_, err := mgr.Clean(context.Background(), inst, []models.ChartConfig{})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "instance.deleted", calls[0].Type)
+	assert.Equal(t, "user-30", calls[0].UserID)
+	assert.Contains(t, calls[0].Message, "del-stack")
+}
+
+func TestNotification_RollbackCompleted(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	mgr, instanceRepo, _ := newNotificationTestManager(notif)
+
+	inst := seedInstance(t, instanceRepo, "inst-rb", "rb-stack", "user-40")
+	inst.Status = models.StackStatusRunning
+	require.NoError(t, instanceRepo.Update(inst))
+
+	_, err := mgr.Rollback(context.Background(), RollbackRequest{
+		Instance: inst,
+		Charts:   []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "rollback.completed", calls[0].Type)
+	assert.Equal(t, "user-40", calls[0].UserID)
+	assert.Contains(t, calls[0].Message, "rb-stack")
+}
+
+func TestNotification_RollbackError(t *testing.T) {
+	t.Parallel()
+	notif := &mockNotifier{}
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	failHelm := &failingHelmExecutor{err: "rollback failed: timeout"}
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: failHelm},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+		Notifier:      notif,
+	})
+
+	inst := seedInstance(t, instanceRepo, "inst-rb-err", "rb-err-stack", "user-41")
+	inst.Status = models.StackStatusRunning
+	require.NoError(t, instanceRepo.Update(inst))
+
+	_, err := mgr.Rollback(context.Background(), RollbackRequest{
+		Instance: inst,
+		Charts: []ChartDeployInfo{
+			{ChartConfig: models.ChartConfig{ChartName: "fail-chart", DeployOrder: 1}},
+		},
+	})
+	require.NoError(t, err)
+
+	notif.waitForCalls(t, 1)
+	calls := notif.getCalls()
+	assert.Equal(t, "rollback.error", calls[0].Type)
+	assert.Equal(t, "user-41", calls[0].UserID)
+}
+
+func TestNotification_NilNotifier(t *testing.T) {
+	t.Parallel()
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: NewHelmClient("/nonexistent/helm", "", 1*time.Second)},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+	})
+
+	inst := seedInstance(t, instanceRepo, "inst-nil-notif", "nil-stack", "user-50")
+
+	_, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
+	// No panic, no error — nil notifier is silently skipped.
+}
+
+// failingHelmExecutor returns errors for all operations.
+type failingHelmExecutor struct {
+	err string
+}
+
+func (f *failingHelmExecutor) Install(_ context.Context, _ InstallRequest) (string, error) {
+	return "", fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) Uninstall(_ context.Context, _ UninstallRequest) (string, error) {
+	return "", fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) Status(_ context.Context, _, _ string) (*ReleaseStatus, error) {
+	return nil, fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) ListReleases(_ context.Context, _ string) ([]string, error) {
+	return nil, fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) History(_ context.Context, _ string, _ string, _ int) ([]ReleaseRevision, error) {
+	return nil, fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) Rollback(_ context.Context, _, _ string, _ int) (string, error) {
+	return "", fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) GetValues(_ context.Context, _, _ string, _ int) (string, error) {
+	return "", fmt.Errorf("%s", f.err)
+}
+
+func (f *failingHelmExecutor) Timeout() time.Duration {
+	return 30 * time.Second
+}

--- a/backend/internal/hooks/config.go
+++ b/backend/internal/hooks/config.go
@@ -73,7 +73,11 @@ func isKnownEvent(e string) bool {
 		EventPreInstanceCreate, EventPostInstanceCreate,
 		EventPreInstanceDelete, EventPostInstanceDelete,
 		EventPreNamespaceCreate, EventPostNamespaceCreate,
-		EventDeployFinalized:
+		EventPreRollback, EventPostRollback,
+		EventDeployFinalized,
+		EventStopCompleted, EventCleanCompleted,
+		EventRollbackCompleted, EventDeleteCompleted,
+		EventInstanceCreated:
 		return true
 	}
 	return false

--- a/backend/internal/hooks/types.go
+++ b/backend/internal/hooks/types.go
@@ -21,6 +21,11 @@ const (
 	EventPreRollback         = "pre-rollback"
 	EventPostRollback        = "post-rollback"
 	EventDeployFinalized     = "deploy-finalized"
+	EventStopCompleted       = "stop-completed"
+	EventCleanCompleted      = "clean-completed"
+	EventRollbackCompleted   = "rollback-completed"
+	EventDeleteCompleted     = "delete-completed"
+	EventInstanceCreated     = "instance-created"
 )
 
 // FailurePolicy controls how dispatch errors propagate to the caller.

--- a/backend/internal/models/notification.go
+++ b/backend/internal/models/notification.go
@@ -18,12 +18,14 @@ type Notification struct {
 	IsRead     bool      `json:"is_read" gorm:"default:false;index"`
 }
 
-// NotificationPreference controls whether a user receives a specific event type.
+// NotificationPreference controls whether a user receives a specific event type
+// and which channel it is delivered to.
 type NotificationPreference struct {
 	ID        string `json:"id" gorm:"primaryKey;size:36"`
 	UserID    string `json:"user_id" gorm:"size:36;uniqueIndex:idx_user_event;not null"`
 	EventType string `json:"event_type" gorm:"size:50;uniqueIndex:idx_user_event;not null"`
 	Enabled   bool   `json:"enabled" gorm:"default:true"`
+	Channel   string `json:"channel" gorm:"size:20;default:in_app;not null"`
 }
 
 // PaginatedNotifications wraps a page of notification results with metadata.

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -44,8 +44,14 @@ import LoadingState from '../../components/LoadingState';
 const EVENT_TYPE_LABELS: Record<string, string> = {
   'deployment.success': 'Deployment succeeded',
   'deployment.error': 'Deployment failed',
-  'deployment.stopped': 'Deployment stopped',
-  'instance.deleted': 'Instance deleted',
+  'deployment.stopped': 'Stack stopped',
+  'stop.error': 'Stop failed',
+  'instance.created': 'Stack created',
+  'instance.deleted': 'Stack deleted',
+  'clean.completed': 'Cleanup completed',
+  'clean.error': 'Cleanup failed',
+  'rollback.completed': 'Rollback completed',
+  'rollback.error': 'Rollback failed',
 };
 
 const DEFAULT_EVENT_TYPES = Object.keys(EVENT_TYPE_LABELS);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -554,6 +554,7 @@ export interface NotificationPreference {
   user_id?: string;
   event_type: string;
   enabled: boolean;
+  channel?: string;
 }
 
 export interface NotificationListResponse {

--- a/frontend/src/utils/__tests__/notificationHelpers.test.tsx
+++ b/frontend/src/utils/__tests__/notificationHelpers.test.tsx
@@ -73,6 +73,36 @@ describe('notificationHelpers', () => {
       expect(icon.props.color).toBe('action');
     });
 
+    it('returns success icon for completed type', () => {
+      const icon = notificationIcon('clean.completed');
+      expect(icon).toBeTruthy();
+      expect(icon.props.color).toBe('success');
+    });
+
+    it('returns success icon for rollback.completed', () => {
+      const icon = notificationIcon('rollback.completed');
+      expect(icon).toBeTruthy();
+      expect(icon.props.color).toBe('success');
+    });
+
+    it('returns error icon for clean.error', () => {
+      const icon = notificationIcon('clean.error');
+      expect(icon).toBeTruthy();
+      expect(icon.props.color).toBe('error');
+    });
+
+    it('returns error icon for rollback.error', () => {
+      const icon = notificationIcon('rollback.error');
+      expect(icon).toBeTruthy();
+      expect(icon.props.color).toBe('error');
+    });
+
+    it('returns success icon for instance.created', () => {
+      const icon = notificationIcon('instance.created');
+      expect(icon).toBeTruthy();
+      expect(icon.props.color).toBe('success');
+    });
+
     it('returns info icon for unknown type', () => {
       const icon = notificationIcon('something.else');
       expect(icon).toBeTruthy();

--- a/frontend/src/utils/notificationHelpers.tsx
+++ b/frontend/src/utils/notificationHelpers.tsx
@@ -2,6 +2,7 @@ import CheckCircleOutlined from '@mui/icons-material/CheckCircleOutlined';
 import ErrorOutlined from '@mui/icons-material/ErrorOutlined';
 import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
+import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 
 /**
@@ -27,10 +28,11 @@ export function timeAgo(dateStr: string): string {
  * Returns an MUI icon element appropriate for the notification type.
  */
 export function notificationIcon(type: string) {
-  if (type.includes('success')) return <CheckCircleOutlined color="success" fontSize="small" />;
   if (type.includes('error')) return <ErrorOutlined color="error" fontSize="small" />;
+  if (type.includes('success') || type.includes('completed')) return <CheckCircleOutlined color="success" fontSize="small" />;
   if (type.includes('stopped')) return <StopCircleOutlined color="warning" fontSize="small" />;
   if (type.includes('deleted')) return <DeleteOutlined color="action" fontSize="small" />;
+  if (type.includes('created')) return <AddCircleOutlined color="success" fontSize="small" />;
   return <InfoOutlined color="info" fontSize="small" />;
 }
 


### PR DESCRIPTION
## Summary
- Expand in-app notifications and hook events beyond `deploy-finalized` to cover the full stack lifecycle: stop, clean, rollback, create, and delete
- Wire the `Notifier` into the deployer `Manager` and API handlers so users receive real-time notifications for all lifecycle events
- Add `channel` field to `NotificationPreference` for future channel routing (default: `in_app`)

## Changes

### Backend
- **New hook events**: `stop-completed`, `clean-completed`, `rollback-completed`, `delete-completed`, `instance-created`
- **`LifecycleNotifier` interface** in deployer package — decouples deployer from notifier
- **Notifications emitted from**: `finalizeDeploy` (success/error), `finalizeStop` (stopped/error), `finalizeClean` (completed/error/deleted), `finalizeRollback` (completed/error), `CreateInstance`, `DeleteInstance`
- **`Channel` field** on `NotificationPreference` model + DB migration + upsert update
- **`isKnownEvent()`** updated with all new + previously missing rollback events
- **Notifier wired** into `main.go` for both Manager and InstanceHandler

### Frontend
- **10 event types** in Profile preferences (up from 4): `deployment.success`, `deployment.error`, `deployment.stopped`, `stop.error`, `instance.created`, `instance.deleted`, `clean.completed`, `clean.error`, `rollback.completed`, `rollback.error`
- **Notification icons** for created, completed, and error states
- **`channel`** field added to TypeScript `NotificationPreference` type

### Known limitation
- `Notifier.Notify()` does not yet consult user preferences (`enabled` flag) before creating notifications — this is a pre-existing limitation, not introduced here

## Related issues
Closes #184 (Phase 1)

Phase 2 items tracked separately:
- #189 — `stack-expiring` TTL warning
- #190 — `quota-warning` cluster resource limits
- #191 — `secret-expiring` ACR/TLS certs
- #192 — `cleanup-policy-executed` automated removals
- #193 — `deploy-timeout` stuck Helm operations

## Test plan
- [x] 8 new deployer notification tests (deploy success/error, stop, clean, delete-after-clean, rollback success/error, nil notifier)
- [x] 5 new frontend icon tests for new event types
- [x] Full backend suite passes (28 packages)
- [x] Full frontend suite passes (60 files, 920 tests)
- [ ] Manual: create a stack instance → verify `instance.created` notification appears
- [ ] Manual: deploy → verify `deployment.success` notification
- [ ] Manual: stop → verify `deployment.stopped` notification
- [ ] Manual: clean → verify `clean.completed` notification
- [ ] Manual: delete → verify `instance.deleted` notification
- [ ] Manual: Profile page shows all 10 event type toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)