### PR TITLE
feat: add name query param to ListDefinitions endpoint

### DIFF
--- a/backend/internal/api/handlers/mock_domain_repositories_test.go
+++ b/backend/internal/api/handlers/mock_domain_repositories_test.go
@@ -462,6 +462,21 @@ func (m *MockStackDefinitionRepository) FindByID(id string) (*models.StackDefini
 	return &cp, nil
 }
 
+func (m *MockStackDefinitionRepository) FindByName(name string) ([]models.StackDefinition, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	var result []models.StackDefinition
+	for _, d := range m.items {
+		if d.Name == name {
+			result = append(result, *d)
+		}
+	}
+	return result, nil
+}
+
 func (m *MockStackDefinitionRepository) Update(d *models.StackDefinition) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/api/handlers/stack_definitions.go
+++ b/backend/internal/api/handlers/stack_definitions.go
@@ -111,6 +111,7 @@ func NewDefinitionHandlerWithVersions(
 // @Description List stack definitions with server-side pagination
 // @Tags        stack-definitions
 // @Produce     json
+// @Param       name     query    string false "Filter by exact name"
 // @Param       page     query    int false "Page number (default 1)"     minimum(1)
 // @Param       pageSize query    int false "Items per page (default 25, max 100)" minimum(1) maximum(100)
 // @Param       limit    query    int false "Max items to return (default 25, max 100)" minimum(1) maximum(100)
@@ -119,6 +120,25 @@ func NewDefinitionHandlerWithVersions(
 // @Failure     500 {object} map[string]string
 // @Router      /api/v1/stack-definitions [get]
 func (h *DefinitionHandler) ListDefinitions(c *gin.Context) {
+	if name := c.Query("name"); name != "" {
+		defs, err := h.definitionRepo.FindByName(name)
+		if err != nil {
+			status, message := mapError(err, entityStackDefinition)
+			c.JSON(status, gin.H{"error": message})
+			return
+		}
+		if defs == nil {
+			defs = []models.StackDefinition{}
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"data":     defs,
+			"total":    len(defs),
+			"page":     1,
+			"pageSize": len(defs),
+		})
+		return
+	}
+
 	pageSize := listPageSizeDefault
 	offset := 0
 	page := 1

--- a/backend/internal/api/handlers/stack_definitions_test.go
+++ b/backend/internal/api/handlers/stack_definitions_test.go
@@ -200,6 +200,59 @@ func TestListDefinitions(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, w.Code)
 	})
+
+	t.Run("filters by name query param", func(t *testing.T) {
+		t.Parallel()
+		defRepo := NewMockStackDefinitionRepository()
+		seedDefinition(t, defRepo, "d1", "klaravik-dev", "owner-1")
+		seedDefinition(t, defRepo, "d2", "klaravik-staging", "owner-1")
+
+		router := setupDefinitionRouter(defRepo, NewMockChartConfigRepository(), NewMockStackInstanceRepository(), "uid-1", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-definitions?name=klaravik-dev", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+		var data []models.StackDefinition
+		require.NoError(t, json.Unmarshal(resp["data"], &data))
+		assert.Len(t, data, 1)
+		assert.Equal(t, "klaravik-dev", data[0].Name)
+	})
+
+	t.Run("name filter returns empty when no match", func(t *testing.T) {
+		t.Parallel()
+		defRepo := NewMockStackDefinitionRepository()
+		seedDefinition(t, defRepo, "d1", "klaravik-dev", "owner-1")
+
+		router := setupDefinitionRouter(defRepo, NewMockChartConfigRepository(), NewMockStackInstanceRepository(), "uid-1", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-definitions?name=nonexistent", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+		var data []models.StackDefinition
+		require.NoError(t, json.Unmarshal(resp["data"], &data))
+		assert.Empty(t, data)
+	})
+
+	t.Run("name filter with repository error returns 500", func(t *testing.T) {
+		t.Parallel()
+		defRepo := NewMockStackDefinitionRepository()
+		defRepo.SetError(errInternal)
+
+		router := setupDefinitionRouter(defRepo, NewMockChartConfigRepository(), NewMockStackInstanceRepository(), "uid-1", "user")
+		w := httptest.NewRecorder()
+		req, _ := http.NewRequest(http.MethodGet, "/api/v1/stack-definitions?name=klaravik-dev", nil)
+		router.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+	})
 }
 
 // ---- CreateDefinition ----

--- a/backend/internal/database/stack_definition_repository.go
+++ b/backend/internal/database/stack_definition_repository.go
@@ -53,6 +53,15 @@ func (r *GORMStackDefinitionRepository) FindByID(id string) (*models.StackDefini
 	return &definition, nil
 }
 
+// FindByName returns all stack definitions with the given exact name.
+func (r *GORMStackDefinitionRepository) FindByName(name string) ([]models.StackDefinition, error) {
+	var definitions []models.StackDefinition
+	if err := r.db.Where("name = ?", name).Find(&definitions).Error; err != nil {
+		return nil, dberrors.NewDatabaseError("find_by_name", err)
+	}
+	return definitions, nil
+}
+
 // Update persists changes to an existing stack definition.
 func (r *GORMStackDefinitionRepository) Update(definition *models.StackDefinition) error {
 	definition.UpdatedAt = time.Now().UTC()

--- a/backend/internal/deployer/cleanup_expiry_test.go
+++ b/backend/internal/deployer/cleanup_expiry_test.go
@@ -45,6 +45,18 @@ func (m *mockDefinitionRepo) FindByID(id string) (*models.StackDefinition, error
 	return d, nil
 }
 
+func (m *mockDefinitionRepo) FindByName(name string) ([]models.StackDefinition, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	var result []models.StackDefinition
+	for _, d := range m.items {
+		if d.Name == name {
+			result = append(result, *d)
+		}
+	}
+	return result, nil
+}
+
 func (m *mockDefinitionRepo) Update(d *models.StackDefinition) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/models/stack_definition.go
+++ b/backend/internal/models/stack_definition.go
@@ -19,6 +19,7 @@ type StackDefinition struct {
 type StackDefinitionRepository interface {
 	Create(definition *StackDefinition) error
 	FindByID(id string) (*StackDefinition, error)
+	FindByName(name string) ([]StackDefinition, error)
 	Update(definition *StackDefinition) error
 	Delete(id string) error
 	List() ([]StackDefinition, error)


### PR DESCRIPTION
## Summary
- Adds `?name=` query parameter to `GET /api/v1/stack-definitions` for exact-match filtering by definition name
- Adds `FindByName` to `StackDefinitionRepository` interface and GORM implementation
- Updates all mock repositories (handler tests + deployer tests) to satisfy the interface
- Backend support for stackctl#48 — allows the CLI to resolve definition names to IDs

## Test plan
- [x] `TestListDefinitions/filters_by_name_query_param` — single match returns correct definition
- [x] `TestListDefinitions/name_filter_returns_empty_when_no_match` — no match returns empty `data: []`
- [x] `TestListDefinitions/name_filter_with_repository_error_returns_500` — error path covered
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)