### PR TITLE
feat: Phase 2 notification events (#189–#193)

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -251,7 +251,7 @@ func main() {
 	)
 
 	// Lifecycle notifier — creates in-app notifications for stack events
-	lifecycleNotifier := notifier.NewNotifier(notificationRepo, hub)
+	lifecycleNotifier := notifier.NewNotifier(notificationRepo, hub, userRepo)
 
 	// Deployment manager — uses registry for multi-cluster deploys
 	deployManager := deployer.NewManager(deployer.ManagerConfig{
@@ -362,7 +362,7 @@ func main() {
 	// Phase 6.2: Cleanup policies
 	// ------------------------------------------------------------------
 	cleanupExecutor := deployer.NewCleanupExecutor(deployManager, definitionRepo, chartConfigRepo, instanceRepo)
-	cleanupScheduler := scheduler.NewScheduler(cleanupPolicyRepo, instanceRepo, auditRepo, cleanupExecutor)
+	cleanupScheduler := scheduler.NewScheduler(cleanupPolicyRepo, instanceRepo, auditRepo, cleanupExecutor, lifecycleNotifier)
 	cleanupPolicyHandler := handlers.NewCleanupPolicyHandler(cleanupPolicyRepo, cleanupScheduler)
 
 	// Auto-create admin user on startup if ADMIN_PASSWORD is set.
@@ -409,6 +409,29 @@ func main() {
 	expiryStopper := deployer.NewExpiryStopper(deployManager, definitionRepo, chartConfigRepo)
 	reaper := ttl.NewReaper(instanceRepo, auditRepo, hub, expiryStopper, 60*time.Second)
 	go reaper.Start()
+
+	// Start TTL expiry warner — warns users before their stack expires (#189).
+	expiryWarner := ttl.NewWarner(instanceRepo, lifecycleNotifier, 30*time.Minute, 60*time.Second)
+	go expiryWarner.Start()
+
+	// Start quota monitor — alerts admins when cluster resource usage is high (#190).
+	quotaMonitor := cluster.NewQuotaMonitor(cluster.QuotaMonitorConfig{
+		ClusterRepo:  clusterRepo,
+		InstanceRepo: instanceRepo,
+		QuotaRepo:    quotaRepo,
+		Registry:     clusterRegistry,
+		Notifier:     lifecycleNotifier,
+	})
+	quotaMonitor.Start()
+
+	// Start secret expiry monitor — alerts admins before secrets expire (#191).
+	secretMonitor := cluster.NewSecretMonitor(cluster.SecretMonitorConfig{
+		ClusterRepo:  clusterRepo,
+		InstanceRepo: instanceRepo,
+		Registry:     clusterRegistry,
+		Notifier:     lifecycleNotifier,
+	})
+	secretMonitor.Start()
 
 	// Periodically clean up expired refresh tokens (every hour).
 	refreshTokenCleanupCtx, refreshTokenCleanupCancel := context.WithCancel(context.Background())
@@ -488,10 +511,13 @@ func main() {
 	gracefulShutdown(srv, shutdownTimeout, shutdownDeps{
 		telemetry:        tel,
 		reaper:           reaper,
+		expiryWarner:     expiryWarner,
 		cleanupScheduler: cleanupScheduler,
 		deployManager:    deployManager,
 		healthPoller:     healthPoller,
 		secretRefresher:  secretRefresher,
+		quotaMonitor:     quotaMonitor,
+		secretMonitor:    secretMonitor,
 		k8sWatcher:       k8sWatcher,
 		hub:              hub,
 		clusterRegistry:  clusterRegistry,
@@ -505,10 +531,13 @@ func main() {
 type shutdownDeps struct {
 	telemetry        *telemetry.Telemetry
 	reaper           *ttl.Reaper
+	expiryWarner     *ttl.Warner
 	cleanupScheduler *scheduler.Scheduler
 	deployManager    *deployer.Manager
 	healthPoller     *cluster.HealthPoller
 	secretRefresher  *cluster.SecretRefresher
+	quotaMonitor     *cluster.QuotaMonitor
+	secretMonitor    *cluster.SecretMonitor
 	k8sWatcher       *k8s.Watcher
 	hub              *websocket.Hub
 	clusterRegistry  *cluster.Registry
@@ -529,6 +558,9 @@ func gracefulShutdown(srv *http.Server, timeout time.Duration, deps shutdownDeps
 
 	// 2. Stop producers of deploy work.
 	deps.reaper.Stop()
+	if deps.expiryWarner != nil {
+		deps.expiryWarner.Stop()
+	}
 	deps.cleanupScheduler.Stop()
 
 	// 3. Now safe to wait for in-flight deploys.
@@ -538,6 +570,12 @@ func gracefulShutdown(srv *http.Server, timeout time.Duration, deps shutdownDeps
 	deps.healthPoller.Stop()
 	if deps.secretRefresher != nil {
 		deps.secretRefresher.Stop()
+	}
+	if deps.quotaMonitor != nil {
+		deps.quotaMonitor.Stop()
+	}
+	if deps.secretMonitor != nil {
+		deps.secretMonitor.Stop()
 	}
 	if deps.k8sWatcher != nil {
 		deps.k8sWatcher.Stop()

--- a/backend/api/main_test.go
+++ b/backend/api/main_test.go
@@ -480,6 +480,10 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
 // ---- extractAPIServerURL tests ----
 
 func TestExtractAPIServerURL(t *testing.T) {
@@ -895,7 +899,7 @@ func TestGracefulShutdown(t *testing.T) {
 	})
 	healthPoller.Start()
 
-	cleanupScheduler := scheduler.NewScheduler(&stubPolicyRepo{}, newMockInstanceRepo(), nil, nil)
+	cleanupScheduler := scheduler.NewScheduler(&stubPolicyRepo{}, newMockInstanceRepo(), nil, nil, nil)
 	// Start the scheduler so Stop() can signal it to exit.
 	_ = cleanupScheduler.Start()
 
@@ -957,7 +961,7 @@ func TestGracefulShutdown_RepoCloseError(t *testing.T) {
 	})
 	healthPoller.Start()
 
-	cleanupScheduler := scheduler.NewScheduler(&stubPolicyRepo{}, newMockInstanceRepo(), nil, nil)
+	cleanupScheduler := scheduler.NewScheduler(&stubPolicyRepo{}, newMockInstanceRepo(), nil, nil, nil)
 	_ = cleanupScheduler.Start()
 
 	deployManager := deployer.NewManager(deployer.ManagerConfig{MaxConcurrent: 1})

--- a/backend/internal/api/handlers/cleanup_policies_test.go
+++ b/backend/internal/api/handlers/cleanup_policies_test.go
@@ -445,7 +445,7 @@ func TestRunCleanupPolicy(t *testing.T) {
 			}
 			auditRepo := &cleanupMockAuditRepo{}
 
-			sched := scheduler.NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+			sched := scheduler.NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 			_ = sched.Start()
 			defer sched.Stop()
 
@@ -759,6 +759,9 @@ func (r *cleanupMockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]st
 	return nil, nil
 }
 func (r *cleanupMockInstanceRepo) ListExpired() ([]*models.StackInstance, error) { return nil, nil }
+func (r *cleanupMockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 // cleanupMockAuditRepo implements models.AuditLogRepository for handler tests.
 type cleanupMockAuditRepo struct {

--- a/backend/internal/api/handlers/mock_domain_repositories_test.go
+++ b/backend/internal/api/handlers/mock_domain_repositories_test.go
@@ -162,6 +162,22 @@ func (m *MockUserRepository) Count() (int64, error) {
 	return int64(len(m.users)), nil
 }
 
+func (m *MockUserRepository) ListByRoles(roles []string) ([]models.User, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	roleSet := make(map[string]struct{}, len(roles))
+	for _, r := range roles {
+		roleSet[r] = struct{}{}
+	}
+	var out []models.User
+	for _, u := range m.users {
+		if _, ok := roleSet[u.Role]; ok {
+			out = append(out, *u)
+		}
+	}
+	return out, nil
+}
+
 func (m *MockUserRepository) SetCreateError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -925,6 +941,24 @@ func (m *MockStackInstanceRepository) ListExpired() ([]*models.StackInstance, er
 	var out []*models.StackInstance
 	for _, i := range m.items {
 		if i.Status == models.StackStatusRunning && i.ExpiresAt != nil && i.ExpiresAt.Before(now) {
+			cp := *i
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}
+
+func (m *MockStackInstanceRepository) ListExpiringSoon(threshold time.Duration) ([]*models.StackInstance, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	now := time.Now()
+	deadline := now.Add(threshold)
+	var out []*models.StackInstance
+	for _, i := range m.items {
+		if i.Status == models.StackStatusRunning && i.ExpiresAt != nil && i.ExpiresAt.After(now) && !i.ExpiresAt.After(deadline) {
 			cp := *i
 			out = append(out, &cp)
 		}

--- a/backend/internal/api/middleware/combined_auth_test.go
+++ b/backend/internal/api/middleware/combined_auth_test.go
@@ -103,6 +103,7 @@ func (r *testUserRepo) Update(user *models.User) error   { return nil }
 func (r *testUserRepo) Delete(id string) error           { return nil }
 func (r *testUserRepo) List() ([]models.User, error)     { return nil, nil }
 func (r *testUserRepo) Count() (int64, error)            { return 0, nil }
+func (r *testUserRepo) ListByRoles(_ []string) ([]models.User, error) { return nil, nil }
 
 // ---- helpers ----
 

--- a/backend/internal/api/routes/routes_test.go
+++ b/backend/internal/api/routes/routes_test.go
@@ -32,6 +32,7 @@ func (s *stubUserRepo) Update(_ *models.User) error                           { 
 func (s *stubUserRepo) Delete(_ string) error                                 { return nil }
 func (s *stubUserRepo) List() ([]models.User, error)                          { return nil, nil }
 func (s *stubUserRepo) Count() (int64, error)                                 { return 0, nil }
+func (s *stubUserRepo) ListByRoles(_ []string) ([]models.User, error)         { return nil, nil }
 
 type stubAPIKeyRepo struct{}
 

--- a/backend/internal/cluster/quota_monitor.go
+++ b/backend/internal/cluster/quota_monitor.go
@@ -1,0 +1,275 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"backend/internal/models"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// QuotaNotifier sends system-wide notifications for quota warnings.
+type QuotaNotifier interface {
+	NotifySystem(ctx context.Context, notifType, title, message, entityType, entityID string) error
+}
+
+// QuotaMonitorConfig holds constructor dependencies.
+type QuotaMonitorConfig struct {
+	ClusterRepo  models.ClusterRepository
+	InstanceRepo models.StackInstanceRepository
+	QuotaRepo    models.ResourceQuotaRepository
+	Registry     *Registry
+	Notifier     QuotaNotifier
+	Interval     time.Duration
+	Threshold    float64 // 0.0–1.0, default 0.8
+}
+
+// QuotaMonitor periodically checks cluster resource usage against configured
+// quotas and emits system notifications when usage exceeds a threshold.
+type QuotaMonitor struct {
+	clusterRepo  models.ClusterRepository
+	instanceRepo models.StackInstanceRepository
+	quotaRepo    models.ResourceQuotaRepository
+	registry     *Registry
+	notifier     QuotaNotifier
+	interval     time.Duration
+	threshold    float64
+	stopCh       chan struct{}
+	done         chan struct{}
+	stopOnce     sync.Once
+	started      atomic.Bool
+
+	// cooldown tracks recently alerted clusters to avoid spam.
+	mu       sync.Mutex
+	cooldown map[string]time.Time
+}
+
+const (
+	defaultQuotaMonitorInterval = 5 * time.Minute
+	defaultQuotaThreshold       = 0.8
+	quotaCooldownDuration       = 1 * time.Hour
+)
+
+// NewQuotaMonitor creates a new quota monitor.
+func NewQuotaMonitor(cfg QuotaMonitorConfig) *QuotaMonitor {
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultQuotaMonitorInterval
+	}
+	threshold := cfg.Threshold
+	if threshold <= 0 {
+		threshold = defaultQuotaThreshold
+	}
+	return &QuotaMonitor{
+		clusterRepo:  cfg.ClusterRepo,
+		instanceRepo: cfg.InstanceRepo,
+		quotaRepo:    cfg.QuotaRepo,
+		registry:     cfg.Registry,
+		notifier:     cfg.Notifier,
+		interval:     interval,
+		threshold:    threshold,
+		stopCh:       make(chan struct{}),
+		done:         make(chan struct{}),
+		cooldown:     make(map[string]time.Time),
+	}
+}
+
+// Start begins the background monitoring goroutine.
+func (m *QuotaMonitor) Start() {
+	if !m.started.CompareAndSwap(false, true) {
+		return
+	}
+	go m.run()
+}
+
+// Stop requests a graceful shutdown and waits for the goroutine to exit.
+func (m *QuotaMonitor) Stop() {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+	if m.started.Load() {
+		<-m.done
+	}
+}
+
+func (m *QuotaMonitor) run() {
+	defer close(m.done)
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	slog.Info("Quota monitor started", "interval", m.interval, "threshold", m.threshold)
+
+	m.check()
+
+	for {
+		select {
+		case <-m.stopCh:
+			slog.Info("Quota monitor stopped")
+			return
+		case <-ticker.C:
+			m.check()
+		}
+	}
+}
+
+func (m *QuotaMonitor) check() {
+	if m.quotaRepo == nil || m.notifier == nil {
+		return
+	}
+
+	m.pruneCooldowns()
+
+	clusters, err := m.clusterRepo.List()
+	if err != nil {
+		slog.Error("quota monitor: failed to list clusters", "error", err)
+		return
+	}
+
+	for i := range clusters {
+		cl := &clusters[i]
+		m.checkCluster(cl)
+	}
+}
+
+func (m *QuotaMonitor) pruneCooldowns() {
+	cutoff := time.Now().Add(-2 * quotaCooldownDuration)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, t := range m.cooldown {
+		if t.Before(cutoff) {
+			delete(m.cooldown, k)
+		}
+	}
+}
+
+func (m *QuotaMonitor) checkCluster(cl *models.Cluster) {
+	quotaCfg, err := m.quotaRepo.GetByClusterID(context.Background(), cl.ID)
+	if err != nil || quotaCfg == nil {
+		return
+	}
+
+	instances, err := m.instanceRepo.FindByCluster(cl.ID)
+	if err != nil {
+		slog.Error("quota monitor: failed to list instances", "cluster_id", cl.ID, "error", err)
+		return
+	}
+
+	var running int
+	var namespaces []string
+	for j := range instances {
+		if instances[j].Status == models.StackStatusRunning || instances[j].Status == models.StackStatusDeploying {
+			running++
+			if instances[j].Namespace != "" {
+				namespaces = append(namespaces, instances[j].Namespace)
+			}
+		}
+	}
+
+	k8sClient, err := m.registry.GetK8sClient(cl.ID)
+	if err != nil {
+		slog.Warn("quota monitor: failed to get k8s client", "cluster_id", cl.ID, "error", err)
+		return
+	}
+
+	var warnings []string
+
+	// Check aggregate resource usage across managed namespaces.
+	var totalCPUUsed, totalCPULimit, totalMemUsed, totalMemLimit int64
+	var totalPods int
+	for _, ns := range namespaces {
+		usage, usageErr := k8sClient.GetNamespaceResourceUsage(context.Background(), ns)
+		if usageErr != nil {
+			continue
+		}
+		totalCPUUsed += parseMilliCPU(usage.CPUUsed)
+		totalMemUsed += parseBytes(usage.MemoryUsed)
+		totalPods += usage.PodCount
+	}
+
+	totalCPULimit = parseMilliCPU(quotaCfg.CPULimit)
+	totalMemLimit = parseBytes(quotaCfg.MemoryLimit)
+
+	// Quotas are per-namespace; the effective cluster limit is quota × namespace count.
+	nsCount := int64(max(len(namespaces), 1))
+
+	if totalCPULimit > 0 {
+		ratio := float64(totalCPUUsed) / float64(totalCPULimit*nsCount)
+		if ratio >= m.threshold {
+			warnings = append(warnings, fmt.Sprintf("CPU at %.0f%% of quota", ratio*100))
+		}
+	}
+
+	if totalMemLimit > 0 {
+		ratio := float64(totalMemUsed) / float64(totalMemLimit*nsCount)
+		if ratio >= m.threshold {
+			warnings = append(warnings, fmt.Sprintf("Memory at %.0f%% of quota", ratio*100))
+		}
+	}
+
+	if quotaCfg.PodLimit > 0 {
+		podLimit := quotaCfg.PodLimit * int(nsCount)
+		ratio := float64(totalPods) / float64(podLimit)
+		if ratio >= m.threshold {
+			warnings = append(warnings, fmt.Sprintf("Pods at %.0f%% of limit (%d/%d)", ratio*100, totalPods, podLimit))
+		}
+	}
+
+	if len(warnings) == 0 {
+		return
+	}
+
+	// Debounce: skip if we alerted this cluster recently.
+	m.mu.Lock()
+	if last, ok := m.cooldown[cl.ID]; ok && time.Since(last) < quotaCooldownDuration {
+		m.mu.Unlock()
+		return
+	}
+	m.cooldown[cl.ID] = time.Now()
+	m.mu.Unlock()
+
+	msg := fmt.Sprintf("Cluster %q: %s (%d running stacks)", cl.Name, joinWarnings(warnings), running)
+	_ = m.notifier.NotifySystem(context.Background(),
+		"quota.warning",
+		"Cluster resource quota warning",
+		msg,
+		"cluster", cl.ID,
+	)
+	slog.Warn("quota monitor: threshold exceeded", "cluster_id", cl.ID, "warnings", warnings)
+}
+
+func parseMilliCPU(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0
+	}
+	return q.MilliValue()
+}
+
+func parseBytes(s string) int64 {
+	if s == "" {
+		return 0
+	}
+	q, err := resource.ParseQuantity(s)
+	if err != nil {
+		return 0
+	}
+	return q.Value()
+}
+
+func joinWarnings(w []string) string {
+	if len(w) == 1 {
+		return w[0]
+	}
+	result := w[0]
+	for i := 1; i < len(w); i++ {
+		result += "; " + w[i]
+	}
+	return result
+}

--- a/backend/internal/cluster/quota_monitor_test.go
+++ b/backend/internal/cluster/quota_monitor_test.go
@@ -1,0 +1,158 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"backend/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Quota monitor test mocks ---
+
+type mockQuotaNotifier struct {
+	mu    sync.Mutex
+	calls []quotaNotifyCall
+}
+
+type quotaNotifyCall struct {
+	notifType, title, message, entityType, entityID string
+}
+
+func (m *mockQuotaNotifier) NotifySystem(_ context.Context, notifType, title, message, entityType, entityID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, quotaNotifyCall{notifType, title, message, entityType, entityID})
+	return nil
+}
+
+func (m *mockQuotaNotifier) getCalls() []quotaNotifyCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]quotaNotifyCall, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+type mockQuotaRepo struct {
+	configs map[string]*models.ResourceQuotaConfig
+}
+
+func (m *mockQuotaRepo) GetByClusterID(_ context.Context, clusterID string) (*models.ResourceQuotaConfig, error) {
+	c := m.configs[clusterID]
+	return c, nil
+}
+
+func (m *mockQuotaRepo) Upsert(_ context.Context, _ *models.ResourceQuotaConfig) error { return nil }
+func (m *mockQuotaRepo) Delete(_ context.Context, _ string) error                      { return nil }
+
+// --- Tests ---
+
+func TestQuotaMonitor_StartStop(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	m.Start()
+	m.Start() // idempotent
+
+	m.Stop()
+	m.Stop() // safe to call twice
+}
+
+func TestQuotaMonitor_SkipsWhenNilQuotaRepo(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Notifier:     &mockQuotaNotifier{},
+	})
+	// quotaRepo is nil — check() should return without panic.
+	m.check()
+}
+
+func TestQuotaMonitor_SkipsWhenNilNotifier(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		QuotaRepo:    &mockQuotaRepo{configs: make(map[string]*models.ResourceQuotaConfig)},
+	})
+	// notifier is nil — check() should return without panic.
+	m.check()
+}
+
+func TestQuotaMonitor_PruneCooldowns(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	stale := time.Now().Add(-3 * quotaCooldownDuration)
+	fresh := time.Now().Add(-30 * time.Minute)
+
+	m.mu.Lock()
+	m.cooldown["stale-cluster"] = stale
+	m.cooldown["fresh-cluster"] = fresh
+	m.mu.Unlock()
+
+	m.pruneCooldowns()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, hasStale := m.cooldown["stale-cluster"]
+	_, hasFresh := m.cooldown["fresh-cluster"]
+
+	assert.False(t, hasStale, "stale entry should have been pruned")
+	assert.True(t, hasFresh, "fresh entry should be kept")
+}
+
+func TestQuotaMonitor_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+	})
+
+	require.Equal(t, defaultQuotaMonitorInterval, m.interval)
+	require.InDelta(t, defaultQuotaThreshold, m.threshold, 0.001)
+}
+
+func TestQuotaMonitor_CooldownPreventsRepeatNotification(t *testing.T) {
+	t.Parallel()
+
+	m := NewQuotaMonitor(QuotaMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	// Simulate that cluster-1 was just alerted.
+	m.mu.Lock()
+	m.cooldown["cluster-1"] = time.Now()
+	m.mu.Unlock()
+
+	// The debounce check compares time.Since(last) < quotaCooldownDuration.
+	// Verify entry is present and would block a new alert.
+	m.mu.Lock()
+	last, ok := m.cooldown["cluster-1"]
+	m.mu.Unlock()
+
+	assert.True(t, ok)
+	assert.True(t, time.Since(last) < quotaCooldownDuration, "recent cooldown entry should block repeat alert")
+}

--- a/backend/internal/cluster/secret_monitor.go
+++ b/backend/internal/cluster/secret_monitor.go
@@ -1,0 +1,207 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"backend/internal/k8s"
+	"backend/internal/models"
+)
+
+// SecretNotifier sends system-wide notifications for secret expiry warnings.
+type SecretNotifier interface {
+	NotifySystem(ctx context.Context, notifType, title, message, entityType, entityID string) error
+}
+
+// SecretMonitorConfig holds constructor dependencies.
+type SecretMonitorConfig struct {
+	ClusterRepo  models.ClusterRepository
+	InstanceRepo models.StackInstanceRepository
+	Registry     *Registry
+	Notifier     SecretNotifier
+	Interval     time.Duration
+	Threshold    time.Duration // warn this far before expiry (default 7 days)
+}
+
+// SecretMonitor periodically scans managed K8s secrets (ACR pull secrets, TLS
+// certs) and emits system notifications when they are approaching expiry.
+type SecretMonitor struct {
+	clusterRepo  models.ClusterRepository
+	instanceRepo models.StackInstanceRepository
+	registry     *Registry
+	notifier     SecretNotifier
+	interval     time.Duration
+	threshold    time.Duration
+	stopCh       chan struct{}
+	done         chan struct{}
+	stopOnce     sync.Once
+	started      atomic.Bool
+
+	mu     sync.Mutex
+	warned map[string]time.Time // key: "cluster/ns/secret" → last warned
+}
+
+const (
+	defaultSecretMonitorInterval  = 1 * time.Hour
+	defaultSecretExpiryThreshold  = 7 * 24 * time.Hour // 7 days
+	secretWarnCooldown            = 24 * time.Hour
+)
+
+// NewSecretMonitor creates a new secret expiry monitor.
+func NewSecretMonitor(cfg SecretMonitorConfig) *SecretMonitor {
+	interval := cfg.Interval
+	if interval <= 0 {
+		interval = defaultSecretMonitorInterval
+	}
+	threshold := cfg.Threshold
+	if threshold <= 0 {
+		threshold = defaultSecretExpiryThreshold
+	}
+	return &SecretMonitor{
+		clusterRepo:  cfg.ClusterRepo,
+		instanceRepo: cfg.InstanceRepo,
+		registry:     cfg.Registry,
+		notifier:     cfg.Notifier,
+		interval:     interval,
+		threshold:    threshold,
+		stopCh:       make(chan struct{}),
+		done:         make(chan struct{}),
+		warned:       make(map[string]time.Time),
+	}
+}
+
+// Start begins the background monitoring goroutine.
+func (m *SecretMonitor) Start() {
+	if !m.started.CompareAndSwap(false, true) {
+		return
+	}
+	go m.run()
+}
+
+// Stop requests a graceful shutdown and waits for the goroutine to exit.
+func (m *SecretMonitor) Stop() {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+	if m.started.Load() {
+		<-m.done
+	}
+}
+
+func (m *SecretMonitor) run() {
+	defer close(m.done)
+
+	ticker := time.NewTicker(m.interval)
+	defer ticker.Stop()
+
+	slog.Info("Secret monitor started", "interval", m.interval, "threshold", m.threshold)
+
+	m.scan()
+
+	for {
+		select {
+		case <-m.stopCh:
+			slog.Info("Secret monitor stopped")
+			return
+		case <-ticker.C:
+			m.scan()
+		}
+	}
+}
+
+func (m *SecretMonitor) scan() {
+	if m.notifier == nil {
+		return
+	}
+
+	m.pruneWarned()
+
+	clusters, err := m.clusterRepo.List()
+	if err != nil {
+		slog.Error("secret monitor: failed to list clusters", "error", err)
+		return
+	}
+
+	for i := range clusters {
+		cl := &clusters[i]
+		m.scanCluster(cl)
+	}
+}
+
+func (m *SecretMonitor) pruneWarned() {
+	cutoff := time.Now().Add(-2 * secretWarnCooldown)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for k, t := range m.warned {
+		if t.Before(cutoff) {
+			delete(m.warned, k)
+		}
+	}
+}
+
+func (m *SecretMonitor) scanCluster(cl *models.Cluster) {
+	instances, err := m.instanceRepo.FindByCluster(cl.ID)
+	if err != nil {
+		return
+	}
+
+	k8sClient, err := m.registry.GetK8sClient(cl.ID)
+	if err != nil {
+		return
+	}
+
+	now := time.Now()
+	deadline := now.Add(m.threshold)
+
+	for j := range instances {
+		inst := &instances[j]
+		if inst.Namespace == "" {
+			continue
+		}
+		if inst.Status != models.StackStatusRunning && inst.Status != models.StackStatusDeploying {
+			continue
+		}
+
+		m.scanNamespace(k8sClient, cl, inst.Namespace, now, deadline)
+	}
+}
+
+func (m *SecretMonitor) scanNamespace(k8sClient *k8s.Client, cl *models.Cluster, namespace string, now, deadline time.Time) {
+	secrets, err := k8sClient.ListManagedSecrets(context.Background(), namespace)
+	if err != nil {
+		slog.Warn("secret monitor: failed to list secrets",
+			"cluster_id", cl.ID, "namespace", namespace, "error", err)
+		return
+	}
+
+	for _, s := range secrets {
+		if s.ExpiresAt == nil || s.ExpiresAt.After(deadline) {
+			continue
+		}
+
+		key := fmt.Sprintf("%s/%s/%s", cl.ID, s.Namespace, s.Name)
+
+		m.mu.Lock()
+		lastWarned, alreadyWarned := m.warned[key]
+		if alreadyWarned && now.Sub(lastWarned) < secretWarnCooldown {
+			m.mu.Unlock()
+			continue
+		}
+		m.warned[key] = now
+		m.mu.Unlock()
+
+		remaining := time.Until(*s.ExpiresAt).Truncate(time.Hour)
+		_ = m.notifier.NotifySystem(context.Background(),
+			"secret.expiring",
+			fmt.Sprintf("%s secret expiring on %s", s.Type, cl.Name),
+			fmt.Sprintf("%s secret %q in namespace %s expires in %s",
+				s.Type, s.Name, s.Namespace, remaining),
+			"cluster", cl.ID,
+		)
+		slog.Warn("secret monitor: secret expiring soon",
+			"cluster_id", cl.ID, "namespace", s.Namespace,
+			"secret", s.Name, "type", s.Type, "expires_at", s.ExpiresAt)
+	}
+}

--- a/backend/internal/cluster/secret_monitor_test.go
+++ b/backend/internal/cluster/secret_monitor_test.go
@@ -1,0 +1,131 @@
+package cluster
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- Secret monitor test mocks ---
+
+type mockSecretNotifier struct {
+	mu    sync.Mutex
+	calls []secretNotifyCall
+}
+
+type secretNotifyCall struct {
+	notifType, title, message, entityType, entityID string
+}
+
+func (m *mockSecretNotifier) NotifySystem(_ context.Context, notifType, title, message, entityType, entityID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, secretNotifyCall{notifType, title, message, entityType, entityID})
+	return nil
+}
+
+func (m *mockSecretNotifier) getCalls() []secretNotifyCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]secretNotifyCall, len(m.calls))
+	copy(out, m.calls)
+	return out
+}
+
+// --- Tests ---
+
+func TestSecretMonitor_StartStop(t *testing.T) {
+	t.Parallel()
+
+	m := NewSecretMonitor(SecretMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	m.Start()
+	m.Start() // idempotent
+
+	m.Stop()
+	m.Stop() // safe to call twice
+}
+
+func TestSecretMonitor_SkipsWhenNilNotifier(t *testing.T) {
+	t.Parallel()
+
+	m := NewSecretMonitor(SecretMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+	})
+	// notifier is nil — scan() should return without panic.
+	m.scan()
+}
+
+func TestSecretMonitor_PruneWarned(t *testing.T) {
+	t.Parallel()
+
+	m := NewSecretMonitor(SecretMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	stale := time.Now().Add(-3 * secretWarnCooldown)   // 72h ago, well past 2*24h cutoff
+	fresh := time.Now().Add(-12 * time.Hour)            // 12h ago, within 48h cutoff
+
+	m.mu.Lock()
+	m.warned["cluster-1/ns-1/old-secret"] = stale
+	m.warned["cluster-1/ns-1/recent-secret"] = fresh
+	m.mu.Unlock()
+
+	m.pruneWarned()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, hasStale := m.warned["cluster-1/ns-1/old-secret"]
+	_, hasFresh := m.warned["cluster-1/ns-1/recent-secret"]
+
+	assert.False(t, hasStale, "stale entry should have been pruned")
+	assert.True(t, hasFresh, "fresh entry should be kept")
+}
+
+func TestSecretMonitor_DefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	m := NewSecretMonitor(SecretMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+	})
+
+	require.Equal(t, defaultSecretMonitorInterval, m.interval)
+	require.Equal(t, defaultSecretExpiryThreshold, m.threshold)
+}
+
+func TestSecretMonitor_CooldownPreventsRepeatWarning(t *testing.T) {
+	t.Parallel()
+
+	m := NewSecretMonitor(SecretMonitorConfig{
+		ClusterRepo:  newMockClusterRepo(),
+		InstanceRepo: &mockInstanceRepo{},
+		Interval:     1 * time.Hour,
+	})
+
+	// Simulate a recent warning.
+	m.mu.Lock()
+	m.warned["cluster-1/ns-1/my-secret"] = time.Now()
+	m.mu.Unlock()
+
+	// pruneWarned should NOT remove it (it's fresh).
+	m.pruneWarned()
+
+	m.mu.Lock()
+	_, exists := m.warned["cluster-1/ns-1/my-secret"]
+	m.mu.Unlock()
+
+	assert.True(t, exists, "recent warning should survive pruning")
+}

--- a/backend/internal/cluster/secret_refresher_test.go
+++ b/backend/internal/cluster/secret_refresher_test.go
@@ -47,7 +47,8 @@ func (m *mockInstanceRepo) CountByOwnerIDs(_ []string) (map[string]int, error)  
 func (m *mockInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]string, error) { return nil, nil }
 func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, error)     { return nil, nil }
 func (m *mockInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) { return false, nil }
-func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error)    { return nil, nil }
+func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error)                        { return nil, nil }
+func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) { return nil, nil }
 
 func TestSecretRefresher_RefreshesRunningInstances(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/database/stack_instance_repository.go
+++ b/backend/internal/database/stack_instance_repository.go
@@ -203,6 +203,20 @@ func (r *GORMStackInstanceRepository) ListExpired() ([]*models.StackInstance, er
 	return instances, nil
 }
 
+// ListExpiringSoon returns running instances whose ExpiresAt is within the given
+// threshold from now (i.e., will expire soon but haven't expired yet).
+func (r *GORMStackInstanceRepository) ListExpiringSoon(threshold time.Duration) ([]*models.StackInstance, error) {
+	now := time.Now().UTC()
+	deadline := now.Add(threshold)
+	var instances []*models.StackInstance
+	if err := r.db.Where("status = ? AND expires_at IS NOT NULL AND expires_at > ? AND expires_at <= ?",
+		models.StackStatusRunning, now, deadline).
+		Find(&instances).Error; err != nil {
+		return nil, dberrors.NewDatabaseError("list_expiring_soon", err)
+	}
+	return instances, nil
+}
+
 // CountByDefinitionIDs returns a map of definition ID to instance count for the
 // given definition IDs in a single GROUP BY query. IDs are processed in chunks
 // of 500 to stay within MySQL's IN clause limits.

--- a/backend/internal/database/user_repository.go
+++ b/backend/internal/database/user_repository.go
@@ -137,3 +137,15 @@ func (r *GORMUserRepository) List() ([]models.User, error) {
 	}
 	return users, nil
 }
+
+// ListByRoles returns users whose role matches any of the given roles.
+func (r *GORMUserRepository) ListByRoles(roles []string) ([]models.User, error) {
+	if len(roles) == 0 {
+		return nil, nil
+	}
+	var users []models.User
+	if err := r.db.Where("role IN ?", roles).Find(&users).Error; err != nil {
+		return nil, dberrors.NewDatabaseError("list_by_roles", err)
+	}
+	return users, nil
+}

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -3,6 +3,7 @@ package deployer
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -666,7 +667,16 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 	_ = m.fireDeployHook(hookCtx, hooks.EventDeployFinalized, instance, deployLog.ID, deployLog.StartedAt)
 
 	if deployErr != nil {
-		m.notifyUser(instance.OwnerID, instanceID, "deployment.error", "Deployment failed", fmt.Sprintf("Deployment of %s failed: %s", instance.Name, instance.ErrorMessage))
+		if isTimeoutError(deployErr) {
+			m.notifyUser(instance.OwnerID, instanceID, "deploy.timeout",
+				"Deployment timed out",
+				fmt.Sprintf("Deployment of %s exceeded the timeout threshold", instance.Name))
+			_ = m.fireDeployHook(hookCtx, hooks.EventDeployTimeout, instance, deployLog.ID, deployLog.StartedAt)
+		} else {
+			m.notifyUser(instance.OwnerID, instanceID, "deployment.error",
+				"Deployment failed",
+				fmt.Sprintf("Deployment of %s failed: %s", instance.Name, instance.ErrorMessage))
+		}
 	} else {
 		m.notifyUser(instance.OwnerID, instanceID, "deployment.success", "Deployment succeeded", fmt.Sprintf("Deployment of %s completed successfully", instance.Name))
 	}
@@ -913,6 +923,17 @@ func (m *Manager) finalizeStop(instanceID string, deployLog *models.DeploymentLo
 //
 // The function keeps only the first wrapped layer (e.g. "deploying chart
 // \"nginx\"") plus a generic suffix.
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "timed out") || strings.Contains(msg, "deadline exceeded")
+}
+
 func sanitizeDeployError(err error) string {
 	msg := err.Error()
 

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -156,6 +156,10 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
 func (m *mockInstanceRepo) setError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/deployer/timeout_test.go
+++ b/backend/internal/deployer/timeout_test.go
@@ -1,0 +1,69 @@
+package deployer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTimeoutError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error returns false",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "context.DeadlineExceeded returns true",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			name:     "wrapped context.DeadlineExceeded returns true",
+			err:      fmt.Errorf("wrapped: %w", context.DeadlineExceeded),
+			expected: true,
+		},
+		{
+			name:     "error containing timed out returns true",
+			err:      errors.New("request timed out waiting for pods"),
+			expected: true,
+		},
+		{
+			name:     "error containing deadline exceeded returns true",
+			err:      errors.New("context deadline exceeded"),
+			expected: true,
+		},
+		{
+			name:     "connection refused returns false",
+			err:      errors.New("connection refused"),
+			expected: false,
+		},
+		{
+			name:     "unrelated error returns false",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "empty error message returns false",
+			err:      errors.New(""),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := isTimeoutError(tt.err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/internal/hooks/config.go
+++ b/backend/internal/hooks/config.go
@@ -77,7 +77,10 @@ func isKnownEvent(e string) bool {
 		EventDeployFinalized,
 		EventStopCompleted, EventCleanCompleted,
 		EventRollbackCompleted, EventDeleteCompleted,
-		EventInstanceCreated:
+		EventInstanceCreated,
+		EventDeployTimeout, EventCleanupPolicyExecuted,
+		EventStackExpired, EventStackExpiring,
+		EventQuotaWarning, EventSecretExpiring:
 		return true
 	}
 	return false

--- a/backend/internal/hooks/types.go
+++ b/backend/internal/hooks/types.go
@@ -7,8 +7,9 @@ package hooks
 
 import "time"
 
-// Event names. Use these constants when calling Dispatcher.Fire and when
-// declaring Subscription.Events to avoid typos.
+// Event names use kebab-case (e.g. "deploy-timeout") for webhook payloads.
+// In-app notification types in the notifier package use dot-separated names
+// (e.g. "deploy.timeout") — keep the two conventions distinct.
 const (
 	EventPreDeploy           = "pre-deploy"
 	EventPostDeploy          = "post-deploy"
@@ -26,6 +27,14 @@ const (
 	EventRollbackCompleted   = "rollback-completed"
 	EventDeleteCompleted     = "delete-completed"
 	EventInstanceCreated     = "instance-created"
+
+	// Phase 2 notification events (#189–#193).
+	EventDeployTimeout          = "deploy-timeout"
+	EventCleanupPolicyExecuted  = "cleanup-policy-executed"
+	EventStackExpired           = "stack-expired"
+	EventStackExpiring          = "stack-expiring"
+	EventQuotaWarning           = "quota-warning"
+	EventSecretExpiring         = "secret-expiring"
 )
 
 // FailurePolicy controls how dispatch errors propagate to the caller.

--- a/backend/internal/k8s/client.go
+++ b/backend/internal/k8s/client.go
@@ -4,12 +4,15 @@ package k8s
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -178,7 +181,8 @@ func (c *Client) EnsureDockerRegistrySecret(ctx context.Context, namespace, secr
 				"k8s-stack-manager.io/image-pull-secret": "true",
 			},
 			Annotations: map[string]string{
-				"k8s-stack-manager.io/registry": server,
+				"k8s-stack-manager.io/registry":     server,
+				"k8s-stack-manager.io/refreshed-at": time.Now().UTC().Format(time.RFC3339),
 			},
 		},
 		Type: corev1.SecretTypeDockerConfigJson,
@@ -292,4 +296,87 @@ func (c *Client) CopySecret(ctx context.Context, sourceNS, sourceName, targetNS,
 	}
 	slog.Debug("Updated copied secret", "from", sourceNS+"/"+sourceName, "to", targetNS+"/"+targetName)
 	return nil
+}
+
+// ACRTokenLifetime is the assumed validity period for ACR pull-secret tokens.
+// Azure Container Registry refresh tokens default to 3 hours. Override this if
+// your registry uses a different token lifetime.
+var ACRTokenLifetime = 3 * time.Hour
+
+// ManagedSecret describes a secret managed by k8s-stack-manager with parsed
+// expiry information (when available).
+type ManagedSecret struct {
+	Name      string
+	Namespace string
+	Type      string // "pull-secret" or "tls"
+	ExpiresAt *time.Time
+}
+
+// ListManagedSecrets returns secrets in the given namespace that are managed by
+// k8s-stack-manager. For TLS secrets, it parses the certificate to extract the
+// expiry date.
+func (c *Client) ListManagedSecrets(ctx context.Context, namespace string) ([]ManagedSecret, error) {
+	secrets, err := c.clientset.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "managed-by=k8s-stack-manager",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list secrets in %q: %w", namespace, err)
+	}
+
+	var result []ManagedSecret
+	for i := range secrets.Items {
+		s := &secrets.Items[i]
+		ms := ManagedSecret{
+			Name:      s.Name,
+			Namespace: s.Namespace,
+		}
+
+		switch s.Type {
+		case corev1.SecretTypeTLS:
+			ms.Type = "tls"
+			if certPEM, ok := s.Data[corev1.TLSCertKey]; ok {
+				if exp, parseErr := parseCertExpiry(certPEM); parseErr == nil {
+					ms.ExpiresAt = &exp
+				}
+			}
+		case corev1.SecretTypeDockerConfigJson:
+			ms.Type = "pull-secret"
+			// Docker config secrets don't embed an expiry date in the payload.
+			// Use the secret's last-modified annotation if set by the refresher,
+			// otherwise treat as unknown expiry.
+			if ts, ok := s.Annotations["k8s-stack-manager.io/refreshed-at"]; ok {
+				if t, parseErr := time.Parse(time.RFC3339, ts); parseErr == nil {
+					exp := t.Add(ACRTokenLifetime)
+					ms.ExpiresAt = &exp
+				}
+			}
+		default:
+			// Copied secrets (e.g., wildcard TLS) labelled as managed.
+			if _, hasTLS := s.Data[corev1.TLSCertKey]; hasTLS {
+				ms.Type = "tls"
+				if certPEM, ok := s.Data[corev1.TLSCertKey]; ok {
+					if exp, parseErr := parseCertExpiry(certPEM); parseErr == nil {
+						ms.ExpiresAt = &exp
+					}
+				}
+			} else {
+				continue // skip unrecognized secret types
+			}
+		}
+		result = append(result, ms)
+	}
+	return result, nil
+}
+
+// parseCertExpiry reads the first PEM certificate and returns its NotAfter.
+func parseCertExpiry(certPEM []byte) (time.Time, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return time.Time{}, fmt.Errorf("no PEM block found")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return cert.NotAfter, nil
 }

--- a/backend/internal/k8s/watcher_test.go
+++ b/backend/internal/k8s/watcher_test.go
@@ -146,6 +146,10 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return nil, nil
 }
 
+func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
 func (m *mockInstanceRepo) getStatus(id string) string {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -54,4 +54,5 @@ type StackInstanceRepository interface {
 	ListIDsByOwnerIDs(ownerIDs []string) (map[string][]string, error)
 	ExistsByDefinitionAndStatus(definitionID, status string) (bool, error)
 	ListExpired() ([]*StackInstance, error)
+	ListExpiringSoon(threshold time.Duration) ([]*StackInstance, error)
 }

--- a/backend/internal/models/user.go
+++ b/backend/internal/models/user.go
@@ -26,5 +26,6 @@ type UserRepository interface {
 	Update(user *User) error
 	Delete(id string) error
 	List() ([]User, error)
+	ListByRoles(roles []string) ([]User, error)
 	Count() (int64, error)
 }

--- a/backend/internal/notifier/notifier.go
+++ b/backend/internal/notifier/notifier.go
@@ -16,16 +16,18 @@ import (
 
 // Notifier creates notification records and broadcasts them in real time.
 type Notifier struct {
-	repo models.NotificationRepository
-	hub  *websocket.Hub
+	repo     models.NotificationRepository
+	hub      *websocket.Hub
+	userRepo models.UserRepository
 }
 
-// NewNotifier creates a new Notifier. hub may be nil if real-time broadcasting
-// is not needed.
-func NewNotifier(repo models.NotificationRepository, hub *websocket.Hub) *Notifier {
+// NewNotifier creates a new Notifier. hub and userRepo may be nil if real-time
+// broadcasting or system-wide notifications are not needed.
+func NewNotifier(repo models.NotificationRepository, hub *websocket.Hub, userRepo models.UserRepository) *Notifier {
 	return &Notifier{
-		repo: repo,
-		hub:  hub,
+		repo:     repo,
+		hub:      hub,
+		userRepo: userRepo,
 	}
 }
 
@@ -63,6 +65,27 @@ func (n *Notifier) Notify(ctx context.Context, userID, notifType, title, message
 		n.hub.Broadcast(data)
 	}
 
+	return nil
+}
+
+// NotifySystem creates a notification for all admin and devops users.
+// Requires userRepo to have been provided at construction time.
+func (n *Notifier) NotifySystem(ctx context.Context, notifType, title, message, entityType, entityID string) error {
+	if n.userRepo == nil {
+		slog.Warn("NotifySystem called without userRepo configured")
+		return nil
+	}
+
+	admins, err := n.userRepo.ListByRoles([]string{"admin", "devops"})
+	if err != nil {
+		return err
+	}
+
+	for _, u := range admins {
+		if err := n.Notify(ctx, u.ID, notifType, title, message, entityType, entityID); err != nil {
+			slog.Error("failed to create system notification for user", "user_id", u.ID, "type", notifType, "error", err)
+		}
+	}
 	return nil
 }
 

--- a/backend/internal/notifier/notifier_test.go
+++ b/backend/internal/notifier/notifier_test.go
@@ -132,7 +132,7 @@ func TestNotify(t *testing.T) {
 				defer tt.hub.Shutdown()
 			}
 
-			n := NewNotifier(repo, tt.hub)
+			n := NewNotifier(repo, tt.hub, nil)
 
 			err := n.Notify(
 				context.Background(),
@@ -178,7 +178,7 @@ func TestNotifyUUIDUniqueness(t *testing.T) {
 	t.Parallel()
 
 	repo := newMockNotificationRepo()
-	n := NewNotifier(repo, nil)
+	n := NewNotifier(repo, nil, nil)
 
 	// Create multiple notifications and verify unique IDs.
 	for i := 0; i < 10; i++ {
@@ -235,7 +235,7 @@ func TestNotifyFieldsAreSetCorrectly(t *testing.T) {
 			t.Parallel()
 
 			repo := newMockNotificationRepo()
-			n := NewNotifier(repo, nil)
+			n := NewNotifier(repo, nil, nil)
 
 			before := time.Now().UTC()
 			err := n.Notify(context.Background(), tt.userID, tt.notifType, tt.title, tt.message, tt.entityType, tt.entityID)
@@ -270,7 +270,7 @@ func TestNotifyWithHubBroadcasts(t *testing.T) {
 	defer hub.Shutdown()
 
 	repo := newMockNotificationRepo()
-	n := NewNotifier(repo, hub)
+	n := NewNotifier(repo, hub, nil)
 
 	err := n.Notify(context.Background(), "user-1", "deploy", "Done", "Deployed", "instance", "i1")
 	assert.NoError(t, err)
@@ -287,7 +287,7 @@ func TestNewNotifier(t *testing.T) {
 	t.Run("creates notifier with nil hub", func(t *testing.T) {
 		t.Parallel()
 		repo := newMockNotificationRepo()
-		n := NewNotifier(repo, nil)
+		n := NewNotifier(repo, nil, nil)
 		assert.NotNil(t, n)
 	})
 
@@ -295,7 +295,7 @@ func TestNewNotifier(t *testing.T) {
 		t.Parallel()
 		repo := newMockNotificationRepo()
 		hub := websocket.NewHub()
-		n := NewNotifier(repo, hub)
+		n := NewNotifier(repo, hub, nil)
 		assert.NotNil(t, n)
 	})
 }

--- a/backend/internal/scheduler/scheduler.go
+++ b/backend/internal/scheduler/scheduler.go
@@ -30,9 +30,16 @@ type CleanupResult struct {
 	InstanceID   string `json:"instance_id"`
 	InstanceName string `json:"instance_name"`
 	Namespace    string `json:"namespace"`
+	OwnerID      string `json:"owner_id"`
 	Action       string `json:"action"`
 	Status       string `json:"status"` // "success", "error", "dry_run"
 	Error        string `json:"error,omitempty"`
+}
+
+// CleanupNotifier creates in-app notifications for cleanup events.
+type CleanupNotifier interface {
+	Notify(ctx context.Context, userID, notifType, title, message, entityType, entityID string) error
+	NotifySystem(ctx context.Context, notifType, title, message, entityType, entityID string) error
 }
 
 // Scheduler manages cron-based cleanup policy execution.
@@ -41,19 +48,21 @@ type Scheduler struct {
 	policyRepo   models.CleanupPolicyRepository
 	instanceRepo models.StackInstanceRepository
 	auditRepo    models.AuditLogRepository
-	executor     ActionExecutor // can be nil (dry-run only mode)
+	executor     ActionExecutor    // can be nil (dry-run only mode)
+	notifier     CleanupNotifier   // can be nil
 	mu           sync.Mutex
 	entryMap     map[string]cron.EntryID // policyID → cron entry
 	ctx          context.Context
 	cancel       context.CancelFunc
 }
 
-// NewScheduler creates a new cleanup scheduler.
+// NewScheduler creates a new cleanup scheduler. notifier may be nil.
 func NewScheduler(
 	policyRepo models.CleanupPolicyRepository,
 	instanceRepo models.StackInstanceRepository,
 	auditRepo models.AuditLogRepository,
 	executor ActionExecutor,
+	notifier CleanupNotifier,
 ) *Scheduler {
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Scheduler{
@@ -65,6 +74,7 @@ func NewScheduler(
 		instanceRepo: instanceRepo,
 		auditRepo:    auditRepo,
 		executor:     executor,
+		notifier:     notifier,
 		entryMap:     make(map[string]cron.EntryID),
 		ctx:          ctx,
 		cancel:       cancel,
@@ -152,6 +162,8 @@ func (s *Scheduler) executePolicy(policy models.CleanupPolicy) {
 		slog.Error("Failed to update policy LastRunAt", "policy", policy.ID, "error", updateErr)
 	}
 	slog.Info("Cleanup policy executed", "policy", policy.Name, "results", len(results))
+
+	s.notifyPolicyExecuted(&policy, results)
 }
 
 func (s *Scheduler) executePolicyWithOptions(policy *models.CleanupPolicy, dryRun bool) ([]CleanupResult, error) {
@@ -209,6 +221,7 @@ func (s *Scheduler) executePolicyWithOptions(policy *models.CleanupPolicy, dryRu
 			InstanceID:   inst.ID,
 			InstanceName: inst.Name,
 			Namespace:    inst.Namespace,
+			OwnerID:      inst.OwnerID,
 			Action:       policy.Action,
 		}
 
@@ -268,5 +281,58 @@ func (s *Scheduler) createAuditEntry(policy *models.CleanupPolicy, inst *models.
 	}
 	if err := s.auditRepo.Create(entry); err != nil {
 		slog.Error("Failed to create audit log for cleanup", "error", err)
+	}
+}
+
+func (s *Scheduler) notifyPolicyExecuted(policy *models.CleanupPolicy, results []CleanupResult) {
+	if s.notifier == nil || len(results) == 0 {
+		return
+	}
+	ctx := s.ctx
+
+	dryRunLabel := ""
+	if policy.DryRun {
+		dryRunLabel = " (dry run)"
+	}
+
+	var affected int
+	for _, r := range results {
+		if r.Status == "success" || r.Status == "dry_run" {
+			affected++
+		}
+	}
+	_ = s.notifier.NotifySystem(ctx,
+		"cleanup.policy.executed",
+		fmt.Sprintf("Cleanup policy %q ran%s", policy.Name, dryRunLabel),
+		fmt.Sprintf("Policy %q matched %d instance(s), action: %s%s", policy.Name, affected, policy.Action, dryRunLabel),
+		"cleanup_policy", policy.ID,
+	)
+
+	if policy.DryRun {
+		return
+	}
+	for _, r := range results {
+		if r.Status != "success" {
+			continue
+		}
+		notifType := "cleanup.policy." + r.Action
+		_ = s.notifier.Notify(ctx, r.OwnerID, notifType,
+			fmt.Sprintf("Stack %q %s by cleanup policy", r.InstanceName, actionPastTense(r.Action)),
+			fmt.Sprintf("Cleanup policy %q performed %s on your stack %q", policy.Name, r.Action, r.InstanceName),
+			"stack_instance", r.InstanceID,
+		)
+	}
+}
+
+func actionPastTense(action string) string {
+	switch action {
+	case "stop":
+		return "stopped"
+	case "clean":
+		return "cleaned"
+	case "delete":
+		return "deleted"
+	default:
+		return action + "ed"
 	}
 }

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -121,7 +121,8 @@ func (r *mockInstanceRepo) CountByStatus(string) (int, error) { return 0, nil }
 func (r *mockInstanceRepo) ExistsByDefinitionAndStatus(string, string) (bool, error) {
 	return false, nil
 }
-func (r *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error)           { return nil, nil }
+func (r *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error)                        { return nil, nil }
+func (r *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) { return nil, nil }
 func (r *mockInstanceRepo) CountByDefinitionIDs(_ []string) (map[string]int, error) { return nil, nil }
 func (r *mockInstanceRepo) CountByOwnerIDs(_ []string) (map[string]int, error)      { return nil, nil }
 func (r *mockInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]string, error) {
@@ -213,7 +214,7 @@ func TestSchedulerStartStop(t *testing.T) {
 	instanceRepo := &mockInstanceRepo{}
 	auditRepo := &mockAuditRepo{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 
 	err := s.Start()
 	assert.NoError(t, err)
@@ -239,7 +240,7 @@ func TestSchedulerReload(t *testing.T) {
 	instanceRepo := &mockInstanceRepo{}
 	auditRepo := &mockAuditRepo{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -284,7 +285,7 @@ func TestRunPolicyDryRun(t *testing.T) {
 	}
 	auditRepo := &mockAuditRepo{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -321,7 +322,7 @@ func TestRunPolicyWithExecutor(t *testing.T) {
 	auditRepo := &mockAuditRepo{}
 	executor := &mockExecutor{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -362,7 +363,7 @@ func TestRunPolicyCleanAction(t *testing.T) {
 	auditRepo := &mockAuditRepo{}
 	executor := &mockExecutor{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -398,7 +399,7 @@ func TestRunPolicyDeleteAction(t *testing.T) {
 	auditRepo := &mockAuditRepo{}
 	executor := &mockExecutor{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -434,7 +435,7 @@ func TestRunPolicyByCluster(t *testing.T) {
 	}
 	auditRepo := &mockAuditRepo{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -469,7 +470,7 @@ func TestRunPolicyExecutorError(t *testing.T) {
 	auditRepo := &mockAuditRepo{}
 	executor := &failingExecutor{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, executor, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()
@@ -488,7 +489,7 @@ func TestRunPolicyNotFound(t *testing.T) {
 	instanceRepo := &mockInstanceRepo{}
 	auditRepo := &mockAuditRepo{}
 
-	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil)
+	s := NewScheduler(policyRepo, instanceRepo, auditRepo, nil, nil)
 	err := s.Start()
 	assert.NoError(t, err)
 	defer s.Stop()

--- a/backend/internal/ttl/reaper_test.go
+++ b/backend/internal/ttl/reaper_test.go
@@ -103,6 +103,10 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 	return out, nil
 }
 
+func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
 func (m *mockInstanceRepo) get(id string) *models.StackInstance {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/backend/internal/ttl/warner.go
+++ b/backend/internal/ttl/warner.go
@@ -1,0 +1,131 @@
+package ttl
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"backend/internal/models"
+)
+
+// ExpiryNotifier sends in-app notifications for TTL warnings.
+type ExpiryNotifier interface {
+	Notify(ctx context.Context, userID, notifType, title, message, entityType, entityID string) error
+}
+
+// Warner periodically checks for stack instances approaching TTL expiry and
+// sends a one-time warning notification to the instance owner.
+type Warner struct {
+	instanceRepo models.StackInstanceRepository
+	notifier     ExpiryNotifier
+	threshold    time.Duration // warn this far before ExpiresAt
+	interval     time.Duration // how often to check
+	stopCh       chan struct{}
+	doneCh       chan struct{}
+	once         sync.Once
+
+	// warned tracks instances for which a warning has already been sent.
+	// Key: instanceID + "|" + ExpiresAt (so a TTL extension resets the warning).
+	// Value: the ExpiresAt time, used for pruning entries once they've passed.
+	mu     sync.Mutex
+	warned map[string]time.Time
+}
+
+// NewWarner creates a TTL expiry warner. threshold is how far before expiry to
+// warn (default 30m), interval is how often to scan (default 60s).
+func NewWarner(instanceRepo models.StackInstanceRepository, notifier ExpiryNotifier, threshold, interval time.Duration) *Warner {
+	if threshold <= 0 {
+		threshold = 30 * time.Minute
+	}
+	if interval <= 0 {
+		interval = 60 * time.Second
+	}
+	return &Warner{
+		instanceRepo: instanceRepo,
+		notifier:     notifier,
+		threshold:    threshold,
+		interval:     interval,
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+		warned:       make(map[string]time.Time),
+	}
+}
+
+// Start begins the periodic warning check loop. Blocks until Stop is called.
+func (w *Warner) Start() {
+	defer close(w.doneCh)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	slog.Info("TTL warner started", "threshold", w.threshold, "interval", w.interval)
+
+	w.check()
+
+	for {
+		select {
+		case <-w.stopCh:
+			slog.Info("TTL warner stopped")
+			return
+		case <-ticker.C:
+			w.check()
+		}
+	}
+}
+
+// Stop signals the warner to shut down and waits for it to finish.
+func (w *Warner) Stop() {
+	w.once.Do(func() { close(w.stopCh) })
+	<-w.doneCh
+}
+
+func (w *Warner) check() {
+	w.pruneWarned()
+
+	instances, err := w.instanceRepo.ListExpiringSoon(w.threshold)
+	if err != nil {
+		slog.Error("TTL warner: failed to list expiring instances", "error", err)
+		return
+	}
+
+	for _, inst := range instances {
+		key := inst.ID + "|" + inst.ExpiresAt.Format(time.RFC3339)
+
+		w.mu.Lock()
+		_, already := w.warned[key]
+		if !already {
+			w.warned[key] = *inst.ExpiresAt
+		}
+		w.mu.Unlock()
+
+		if already {
+			continue
+		}
+
+		remaining := time.Until(*inst.ExpiresAt).Truncate(time.Minute)
+		_ = w.notifier.Notify(
+			context.Background(),
+			inst.OwnerID,
+			"stack.expiring",
+			"Stack expiring soon",
+			fmt.Sprintf("Stack %q will expire in %s", inst.Name, remaining),
+			"stack_instance",
+			inst.ID,
+		)
+		slog.Info("TTL warner: sent expiry warning", "instance_id", inst.ID, "expires_at", inst.ExpiresAt)
+	}
+}
+
+// pruneWarned removes entries whose ExpiresAt has passed.
+func (w *Warner) pruneWarned() {
+	now := time.Now()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for key, expiresAt := range w.warned {
+		if expiresAt.Before(now) {
+			delete(w.warned, key)
+		}
+	}
+}

--- a/backend/internal/ttl/warner_test.go
+++ b/backend/internal/ttl/warner_test.go
@@ -1,0 +1,255 @@
+package ttl
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"backend/internal/models"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Mock notifier
+// ---------------------------------------------------------------------------
+
+type notifyCall struct {
+	userID, notifType, title, message, entityType, entityID string
+}
+
+type mockExpiryNotifier struct {
+	mu    sync.Mutex
+	calls []notifyCall
+}
+
+func (m *mockExpiryNotifier) Notify(_ context.Context, userID, notifType, title, message, entityType, entityID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls = append(m.calls, notifyCall{
+		userID:     userID,
+		notifType:  notifType,
+		title:      title,
+		message:    message,
+		entityType: entityType,
+		entityID:   entityID,
+	})
+	return nil
+}
+
+func (m *mockExpiryNotifier) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.calls)
+}
+
+func (m *mockExpiryNotifier) getCalls() []notifyCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]notifyCall, len(m.calls))
+	copy(cp, m.calls)
+	return cp
+}
+
+// ---------------------------------------------------------------------------
+// Mock instance repo for warner tests (separate from reaper's mockInstanceRepo)
+// ---------------------------------------------------------------------------
+
+type warnerMockInstanceRepo struct {
+	mu              sync.Mutex
+	expiringSoonItems []*models.StackInstance
+}
+
+func (m *warnerMockInstanceRepo) setExpiringSoon(items []*models.StackInstance) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.expiringSoonItems = items
+}
+
+func (m *warnerMockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]*models.StackInstance, len(m.expiringSoonItems))
+	copy(cp, m.expiringSoonItems)
+	return cp, nil
+}
+
+// --- no-op stubs for the rest of the interface ---
+
+func (m *warnerMockInstanceRepo) Create(_ *models.StackInstance) error   { return nil }
+func (m *warnerMockInstanceRepo) FindByID(_ string) (*models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) FindByNamespace(_ string) (*models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) Update(_ *models.StackInstance) error { return nil }
+func (m *warnerMockInstanceRepo) Delete(_ string) error                { return nil }
+func (m *warnerMockInstanceRepo) List() ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) ListPaged(_, _ int) ([]models.StackInstance, int, error) {
+	return nil, 0, nil
+}
+func (m *warnerMockInstanceRepo) ListByOwner(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) FindByCluster(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) CountByClusterAndOwner(_, _ string) (int, error) { return 0, nil }
+func (m *warnerMockInstanceRepo) CountAll() (int, error)                          { return 0, nil }
+func (m *warnerMockInstanceRepo) CountByStatus(_ string) (int, error)             { return 0, nil }
+func (m *warnerMockInstanceRepo) CountByDefinitionIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) CountByOwnerIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (m *warnerMockInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) {
+	return false, nil
+}
+func (m *warnerMockInstanceRepo) ListExpired() ([]*models.StackInstance, error) { return nil, nil }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestWarner_SendsWarningForExpiringSoon(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(10 * time.Minute)
+	repo := &warnerMockInstanceRepo{
+		expiringSoonItems: []*models.StackInstance{
+			{
+				ID:       "inst-1",
+				Name:     "my-stack",
+				OwnerID:  "user-42",
+				Status:   models.StackStatusRunning,
+				ExpiresAt: &expiresAt,
+			},
+		},
+	}
+	notifier := &mockExpiryNotifier{}
+
+	w := NewWarner(repo, notifier, 30*time.Minute, 60*time.Second)
+	w.check()
+
+	calls := notifier.getCalls()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "user-42", calls[0].userID)
+	assert.Equal(t, "stack.expiring", calls[0].notifType)
+	assert.Equal(t, "stack_instance", calls[0].entityType)
+	assert.Equal(t, "inst-1", calls[0].entityID)
+}
+
+func TestWarner_DeduplicatesWarnings(t *testing.T) {
+	t.Parallel()
+
+	expiresAt := time.Now().Add(10 * time.Minute)
+	repo := &warnerMockInstanceRepo{
+		expiringSoonItems: []*models.StackInstance{
+			{
+				ID:       "inst-1",
+				Name:     "my-stack",
+				OwnerID:  "user-42",
+				Status:   models.StackStatusRunning,
+				ExpiresAt: &expiresAt,
+			},
+		},
+	}
+	notifier := &mockExpiryNotifier{}
+
+	w := NewWarner(repo, notifier, 30*time.Minute, 60*time.Second)
+	w.check()
+	w.check()
+
+	assert.Equal(t, 1, notifier.count(), "notifier should have been called only once; second check should deduplicate")
+}
+
+func TestWarner_PrunesExpiredEntries(t *testing.T) {
+	t.Parallel()
+
+	pastExpiry := time.Now().Add(-5 * time.Minute)
+	repo := &warnerMockInstanceRepo{}
+	notifier := &mockExpiryNotifier{}
+
+	w := NewWarner(repo, notifier, 30*time.Minute, 60*time.Second)
+
+	// Pre-populate the warned map with an entry whose ExpiresAt is in the past.
+	key := "inst-old|" + pastExpiry.Format(time.RFC3339)
+	w.mu.Lock()
+	w.warned[key] = pastExpiry
+	w.mu.Unlock()
+
+	// check() calls pruneWarned() internally.
+	w.check()
+
+	w.mu.Lock()
+	remaining := len(w.warned)
+	w.mu.Unlock()
+
+	assert.Equal(t, 0, remaining, "expired entries should be pruned from the warned map")
+}
+
+func TestWarner_TTLExtensionResetsWarning(t *testing.T) {
+	t.Parallel()
+
+	expiresT1 := time.Now().Add(10 * time.Minute)
+	inst := &models.StackInstance{
+		ID:       "inst-1",
+		Name:     "my-stack",
+		OwnerID:  "user-42",
+		Status:   models.StackStatusRunning,
+		ExpiresAt: &expiresT1,
+	}
+
+	repo := &warnerMockInstanceRepo{
+		expiringSoonItems: []*models.StackInstance{inst},
+	}
+	notifier := &mockExpiryNotifier{}
+
+	w := NewWarner(repo, notifier, 30*time.Minute, 60*time.Second)
+
+	// First check: warns for expiresT1.
+	w.check()
+	require.Equal(t, 1, notifier.count())
+
+	// Simulate TTL extension: same instance, new ExpiresAt.
+	expiresT2 := time.Now().Add(20 * time.Minute)
+	extendedInst := &models.StackInstance{
+		ID:       "inst-1",
+		Name:     "my-stack",
+		OwnerID:  "user-42",
+		Status:   models.StackStatusRunning,
+		ExpiresAt: &expiresT2,
+	}
+	repo.setExpiringSoon([]*models.StackInstance{extendedInst})
+
+	// Second check: new ExpiresAt means a different key, so should warn again.
+	w.check()
+	assert.Equal(t, 2, notifier.count(), "TTL extension should trigger a new warning")
+}
+
+func TestWarner_DefaultThresholdAndInterval(t *testing.T) {
+	t.Parallel()
+
+	repo := &warnerMockInstanceRepo{}
+	notifier := &mockExpiryNotifier{}
+
+	w := NewWarner(repo, notifier, 0, 0)
+
+	assert.Equal(t, 30*time.Minute, w.threshold, "default threshold should be 30m")
+	assert.Equal(t, 60*time.Second, w.interval, "default interval should be 60s")
+}

--- a/frontend/src/utils/notificationHelpers.tsx
+++ b/frontend/src/utils/notificationHelpers.tsx
@@ -4,6 +4,10 @@ import StopCircleOutlined from '@mui/icons-material/StopCircleOutlined';
 import DeleteOutlined from '@mui/icons-material/DeleteOutlined';
 import AddCircleOutlined from '@mui/icons-material/AddCircleOutlined';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
+import TimerOffOutlined from '@mui/icons-material/TimerOffOutlined';
+import WarningAmberOutlined from '@mui/icons-material/WarningAmberOutlined';
+import CleaningServicesOutlined from '@mui/icons-material/CleaningServicesOutlined';
+import VpnKeyOutlined from '@mui/icons-material/VpnKeyOutlined';
 
 /**
  * Returns a human-readable relative time string for a given ISO date.
@@ -28,6 +32,11 @@ export function timeAgo(dateStr: string): string {
  * Returns an MUI icon element appropriate for the notification type.
  */
 export function notificationIcon(type: string) {
+  if (type === 'deploy.timeout') return <TimerOffOutlined color="error" fontSize="small" />;
+  if (type === 'stack.expiring') return <TimerOffOutlined color="warning" fontSize="small" />;
+  if (type === 'quota.warning') return <WarningAmberOutlined color="warning" fontSize="small" />;
+  if (type === 'secret.expiring') return <VpnKeyOutlined color="warning" fontSize="small" />;
+  if (type.includes('cleanup') || type === 'stack.expired') return <CleaningServicesOutlined color="action" fontSize="small" />;
   if (type.includes('error')) return <ErrorOutlined color="error" fontSize="small" />;
   if (type.includes('success') || type.includes('completed')) return <CheckCircleOutlined color="success" fontSize="small" />;
   if (type.includes('stopped')) return <StopCircleOutlined color="warning" fontSize="small" />;
@@ -47,6 +56,9 @@ export function entityRoute(entityType?: string): string {
       return '/stack-definitions';
     case 'stack_template':
       return '/templates';
+    case 'cluster':
+    case 'cleanup_policy':
+      return '/settings';
     default:
       return '';
   }


### PR DESCRIPTION
## Summary

Implements the five Phase 2 notification issues end-to-end across backend and frontend:

- **#189 Deploy timeout detection** — `isTimeoutError` in deployer detects context deadline and string-match timeouts, emits `deploy.timeout` notification + `deploy-timeout` webhook event
- **#190 Cleanup policy notifications** — Scheduler sends `cleanup.policy.executed` system notification to admins and per-user `cleanup.policy.{stop,clean,delete}` notifications to affected instance owners
- **#191 TTL expiry warnings** — New `ttl.Warner` background job checks every 60s for instances expiring within 30min, sends `stack.expiring` notification with dedup
- **#192 Cluster quota monitoring** — New `cluster.QuotaMonitor` background job checks every 5min, alerts admins via `quota.warning` when CPU/memory/pods exceed 80% threshold with 1h cooldown
- **#193 Secret expiry monitoring** — New `cluster.SecretMonitor` background job checks every 1h, alerts admins via `secret.expiring` when TLS certs or ACR tokens expire within 7 days with 24h cooldown

### Key design decisions
- All background jobs follow the existing atomic.Bool Start / sync.Once Stop / ticker loop pattern
- Hook events use kebab-case (`deploy-timeout`), in-app notifications use dot-separated (`deploy.timeout`) — documented in hooks/types.go
- Dedup/cooldown maps in all three monitors are periodically pruned to prevent unbounded growth
- `NotifySystem` fans out to admin+devops users via `UserRepository.ListByRoles`
- ACR token lifetime extracted to configurable `k8s.ACRTokenLifetime` variable (default 3h)
- Cleanup notifications use action-specific types (`cleanup.policy.stop/clean/delete`) instead of generic `stack.expired`
- N+1 query eliminated in scheduler by carrying `OwnerID` in `CleanupResult`

### Files changed (30 files, +1606/-36)
- **New files**: `warner.go`, `quota_monitor.go`, `secret_monitor.go` + test files, `timeout_test.go`
- **Modified**: deployer/manager.go, scheduler.go, notifier.go, k8s/client.go, hooks/types.go+config.go, models, database repos, api/main.go, frontend notification helpers, and test mocks across 6 packages

## Test plan

- [x] All 25 backend test packages pass (`go test ./...`)
- [x] Frontend TypeScript type-check passes
- [x] 21 new unit tests covering: warner (5), quota monitor (6), secret monitor (5), isTimeoutError (8 sub-cases)
- [ ] Manual: trigger a deploy timeout and verify notification appears
- [ ] Manual: run a cleanup policy and verify per-user + admin notifications
- [ ] Manual: create a stack with short TTL and verify expiry warning
- [ ] Manual: configure a quota and push usage above 80% threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)