### PR TITLE
fix: auto-login to OCI registries and patch default SA with imagePullSecrets

### DIFF
--- a/backend/internal/api/handlers/admin_test.go
+++ b/backend/internal/api/handlers/admin_test.go
@@ -65,6 +65,10 @@ func (m *mockAdminHelmExecutor) GetValues(_ context.Context, _ string, _ string,
 	return "", nil
 }
 
+func (m *mockAdminHelmExecutor) RegistryLogin(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (m *mockAdminHelmExecutor) Timeout() time.Duration {
 	return 30 * time.Second
 }

--- a/backend/internal/api/handlers/clusters_test.go
+++ b/backend/internal/api/handlers/clusters_test.go
@@ -53,6 +53,7 @@ func (m *mockClusterHelmExecutor) Rollback(_ context.Context, _ string, _ string
 func (m *mockClusterHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ int) (string, error) {
 	return "", nil
 }
+func (m *mockClusterHelmExecutor) RegistryLogin(_ context.Context, _, _, _ string) error { return nil }
 func (m *mockClusterHelmExecutor) Timeout() time.Duration { return 30 * time.Second }
 
 // setupClusterRouter creates a gin engine wired to ClusterHandler routes.

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -274,6 +274,10 @@ func (n *noopHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ in
 	return "", nil
 }
 
+func (n *noopHelmExecutor) RegistryLogin(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (n *noopHelmExecutor) Timeout() time.Duration {
 	return 30 * time.Second
 }

--- a/backend/internal/deployer/executor.go
+++ b/backend/internal/deployer/executor.go
@@ -15,6 +15,7 @@ type HelmExecutor interface {
 	History(ctx context.Context, releaseName, namespace string, max int) ([]ReleaseRevision, error)
 	Rollback(ctx context.Context, releaseName, namespace string, revision int) (string, error)
 	GetValues(ctx context.Context, releaseName, namespace string, revision int) (string, error)
+	RegistryLogin(ctx context.Context, host, username, password string) error
 	Timeout() time.Duration
 }
 

--- a/backend/internal/deployer/helm.go
+++ b/backend/internal/deployer/helm.go
@@ -289,6 +289,44 @@ func (h *HelmClient) GetValues(ctx context.Context, releaseName, namespace strin
 	return output, nil
 }
 
+// RegistryLogin runs: helm registry login <host> --username <user> --password-stdin
+// The login state persists in the helm config dir for the lifetime of the process.
+func (h *HelmClient) RegistryLogin(ctx context.Context, host, username, password string) error {
+	if host == "" || username == "" {
+		return nil
+	}
+	if err := validatePositionalArg("registry host", host); err != nil {
+		return err
+	}
+	if err := validatePositionalArg("registry username", username); err != nil {
+		return err
+	}
+
+	args := []string{
+		"registry", "login",
+		host,
+		"--username", username,
+		"--password-stdin",
+	}
+
+	slog.Info("executing helm registry login", "host", host, "username", username)
+
+	cmd := exec.CommandContext(ctx, h.binaryPath, args...) //nolint:gosec // G204: same justification as run()
+	cmd.Stdin = strings.NewReader(password)
+
+	var combined bytes.Buffer
+	cmd.Stdout = &combined
+	cmd.Stderr = &combined
+
+	if err := cmd.Run(); err != nil {
+		slog.Debug("helm registry login failed", "host", host, "output", combined.String())
+		return fmt.Errorf("helm registry login %s failed: %w", host, err)
+	}
+
+	slog.Info("helm registry login succeeded", "host", host)
+	return nil
+}
+
 // run executes a helm command with the given arguments and returns the combined output.
 func (h *HelmClient) run(ctx context.Context, args []string) (string, error) {
 	// Prepend --kubeconfig flag so helm always uses the configured kubeconfig

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -447,6 +448,32 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 			allOutput += fmt.Sprintf("WARNING: failed to provision image pull secret: %s\n", secretErr.Error())
 		} else {
 			allOutput += fmt.Sprintf("Image pull secret %q provisioned for registry %s\n", regCfg.SecretName, regCfg.URL)
+			if saErr := k8sClient.EnsureServiceAccountPullSecret(ctx, namespace, regCfg.SecretName); saErr != nil {
+				slog.Warn("failed to patch default SA with imagePullSecret",
+					"instance_id", instanceID,
+					"namespace", namespace,
+					"error", saErr,
+				)
+				allOutput += fmt.Sprintf("WARNING: failed to patch default SA with imagePullSecret: %s\n", saErr.Error())
+			}
+		}
+	}
+
+	// Ensure helm is logged in to OCI registries before installing charts.
+	if regCfg != nil {
+		host := regCfg.URL
+		if u, err := url.Parse(regCfg.URL); err == nil && u.Host != "" {
+			host = u.Host
+		}
+		if loginErr := helm.RegistryLogin(ctx, host, regCfg.Username, regCfg.Password); loginErr != nil {
+			slog.Warn("helm registry login failed",
+				"instance_id", instanceID,
+				"registry", regCfg.URL,
+				"error", loginErr,
+			)
+			allOutput += fmt.Sprintf("WARNING: helm registry login failed: %s\n", loginErr.Error())
+		} else {
+			allOutput += fmt.Sprintf("Helm registry login succeeded for %s\n", host)
 		}
 	}
 

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -1525,6 +1525,10 @@ func (m *mockHelmExecutor) GetValues(_ context.Context, _ string, _ string, _ in
 	return "", nil
 }
 
+func (m *mockHelmExecutor) RegistryLogin(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (m *mockHelmExecutor) Timeout() time.Duration {
 	if m.timeout > 0 {
 		return m.timeout
@@ -3093,6 +3097,10 @@ func (w *streamingMockWrapper) Rollback(ctx context.Context, releaseName, namesp
 
 func (w *streamingMockWrapper) GetValues(ctx context.Context, releaseName, namespace string, revision int) (string, error) {
 	return w.inner.GetValues(ctx, releaseName, namespace, revision)
+}
+
+func (w *streamingMockWrapper) RegistryLogin(_ context.Context, _, _, _ string) error {
+	return nil
 }
 
 func (w *streamingMockWrapper) Timeout() time.Duration {

--- a/backend/internal/deployer/notifications_test.go
+++ b/backend/internal/deployer/notifications_test.go
@@ -376,6 +376,10 @@ func (f *failingHelmExecutor) GetValues(_ context.Context, _, _ string, _ int) (
 	return "", fmt.Errorf("%s", f.err)
 }
 
+func (f *failingHelmExecutor) RegistryLogin(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
 func (f *failingHelmExecutor) Timeout() time.Duration {
 	return 30 * time.Second
 }

--- a/backend/internal/k8s/client.go
+++ b/backend/internal/k8s/client.go
@@ -234,6 +234,31 @@ func (c *Client) EnsureDockerRegistrySecret(ctx context.Context, namespace, secr
 	return nil
 }
 
+// EnsureServiceAccountPullSecret patches the default ServiceAccount in the given
+// namespace to include the named imagePullSecret. This ensures all pods in the
+// namespace can pull from private registries regardless of chart-level support
+// for imagePullSecrets values.
+func (c *Client) EnsureServiceAccountPullSecret(ctx context.Context, namespace, secretName string) error {
+	sa, err := c.clientset.CoreV1().ServiceAccounts(namespace).Get(ctx, "default", metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("get default SA in %s: %w", namespace, err)
+	}
+
+	for _, ref := range sa.ImagePullSecrets {
+		if ref.Name == secretName {
+			return nil
+		}
+	}
+
+	sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+	if _, err := c.clientset.CoreV1().ServiceAccounts(namespace).Update(ctx, sa, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("patch default SA in %s: %w", namespace, err)
+	}
+
+	slog.Info("Patched default SA with imagePullSecret", "namespace", namespace, "secret", secretName)
+	return nil
+}
+
 // CopySecret copies a secret from a source namespace to a target namespace.
 // Used for replicating shared TLS certificates (for example, a pre-existing
 // wildcard TLS secret stored in a shared namespace) into each stack namespace


### PR DESCRIPTION
## Summary
- Run `helm registry login` automatically before deploying OCI-based charts, using the cluster's registry credentials
- Patch the default ServiceAccount in the namespace with the image pull secret so all pods can pull from private registries
- Password passed via `--password-stdin` to avoid leaking in process lists
- Positional args validated to prevent argument injection (defense-in-depth)
- URL-to-host extraction uses `net/url.Parse` for robustness
- All failures are non-fatal (logged as warnings in deploy output)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [ ] Deploy a stack with OCI chart references to a cluster with registry credentials — verify no 401
- [ ] Verify pods can pull images without manual `imagePullSecrets` in chart values
- [ ] Verify deploy still succeeds when registry credentials are not configured

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)