### PR TITLE
feat: reject deploy to terminating namespace + gate on pod readiness

### DIFF
--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -266,6 +266,8 @@ func main() {
 		WildcardTLSSourceNamespace: cfg.Deployment.WildcardTLSSourceNamespace,
 		WildcardTLSSourceSecret:    cfg.Deployment.WildcardTLSSourceSecret,
 		WildcardTLSTargetSecret:    cfg.Deployment.WildcardTLSTargetSecret,
+		StabilizeTimeout:           cfg.Deployment.StabilizeTimeout,
+		StabilizePollInterval:      cfg.Deployment.StabilizePollInterval,
 		Hooks:                      hookDispatcher,
 		Notifier:                   lifecycleNotifier,
 	})

--- a/backend/internal/api/handlers/stack_instances.go
+++ b/backend/internal/api/handlers/stack_instances.go
@@ -730,7 +730,7 @@ func (h *InstanceHandler) DeleteInstance(c *gin.Context) {
 	}
 
 	switch inst.Status {
-	case models.StackStatusDeploying, models.StackStatusStopping, models.StackStatusCleaning, models.StackStatusQueued:
+	case models.StackStatusDeploying, models.StackStatusStopping, models.StackStatusCleaning, models.StackStatusQueued, models.StackStatusStabilizing:
 		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Cannot delete: instance is currently %s", inst.Status)})
 		return
 
@@ -1211,7 +1211,7 @@ func (h *InstanceHandler) DeployInstance(c *gin.Context) {
 	switch inst.Status {
 	case models.StackStatusDraft, models.StackStatusStopped, models.StackStatusError, models.StackStatusRunning:
 		// OK — running triggers a helm upgrade with the latest values.
-	case models.StackStatusDeploying, models.StackStatusQueued, models.StackStatusStopping:
+	case models.StackStatusDeploying, models.StackStatusQueued, models.StackStatusStopping, models.StackStatusStabilizing:
 		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Cannot deploy: instance is currently %s", inst.Status)})
 		return
 	default:
@@ -1428,8 +1428,8 @@ func (h *InstanceHandler) StopInstance(c *gin.Context) {
 
 	// Only allow stop from running or deploying.
 	switch inst.Status {
-	case models.StackStatusRunning, models.StackStatusDeploying:
-		// OK
+	case models.StackStatusRunning, models.StackStatusDeploying, models.StackStatusStabilizing:
+		// OK — stabilizing means Helm succeeded, safe to stop
 	default:
 		c.JSON(http.StatusConflict, gin.H{"error": fmt.Sprintf("Cannot stop: instance is currently %s", inst.Status)})
 		return

--- a/backend/internal/cluster/quota_monitor.go
+++ b/backend/internal/cluster/quota_monitor.go
@@ -161,7 +161,7 @@ func (m *QuotaMonitor) checkCluster(cl *models.Cluster) {
 	var running int
 	var namespaces []string
 	for j := range instances {
-		if instances[j].Status == models.StackStatusRunning || instances[j].Status == models.StackStatusDeploying {
+		if instances[j].Status == models.StackStatusRunning || instances[j].Status == models.StackStatusDeploying || instances[j].Status == models.StackStatusStabilizing {
 			running++
 			if instances[j].Namespace != "" {
 				namespaces = append(namespaces, instances[j].Namespace)

--- a/backend/internal/cluster/secret_monitor.go
+++ b/backend/internal/cluster/secret_monitor.go
@@ -160,7 +160,7 @@ func (m *SecretMonitor) scanCluster(cl *models.Cluster) {
 		if inst.Namespace == "" {
 			continue
 		}
-		if inst.Status != models.StackStatusRunning && inst.Status != models.StackStatusDeploying {
+		if inst.Status != models.StackStatusRunning && inst.Status != models.StackStatusDeploying && inst.Status != models.StackStatusStabilizing {
 			continue
 		}
 

--- a/backend/internal/cluster/secret_refresher.go
+++ b/backend/internal/cluster/secret_refresher.go
@@ -130,7 +130,7 @@ func (r *SecretRefresher) refreshClusterSecrets(cl *models.Cluster, regCfg *mode
 	var refreshed, failed int
 	for j := range instances {
 		inst := &instances[j]
-		if inst.Status != models.StackStatusRunning && inst.Status != models.StackStatusDeploying {
+		if inst.Status != models.StackStatusRunning && inst.Status != models.StackStatusDeploying && inst.Status != models.StackStatusStabilizing {
 			continue
 		}
 		if inst.Namespace == "" {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -83,7 +83,11 @@ type DeploymentConfig struct {
 	// route returns 503. See internal/hooks/configfile.go for the schema.
 	HooksConfigFile string
 
-	MaxConcurrentDeploys int32
+	// StabilizeTimeout is how long to wait for pods to become ready after
+	// Helm charts succeed. 0 disables readiness gating (legacy behavior).
+	StabilizeTimeout      time.Duration
+	StabilizePollInterval time.Duration
+	MaxConcurrentDeploys  int32
 }
 
 // OIDCConfig holds OpenID Connect configuration for external SSO authentication.
@@ -531,6 +535,8 @@ func loadDeploymentConfig() DeploymentConfig {
 		KubeconfigEncryptionKey:   getEnv("KUBECONFIG_ENCRYPTION_KEY", ""),
 		DeploymentTimeout:         getEnvDuration("DEPLOYMENT_TIMEOUT", 10*time.Minute),
 		ClusterHealthPollInterval:  getEnvDuration("CLUSTER_HEALTH_POLL_INTERVAL", 60*time.Second),
+		StabilizeTimeout:           getEnvDuration("DEPLOY_STABILIZE_TIMEOUT", 5*time.Minute),
+		StabilizePollInterval:      getEnvDuration("DEPLOY_STABILIZE_POLL_INTERVAL", 5*time.Second),
 		MaxConcurrentDeploys:       getEnvInt32("MAX_CONCURRENT_DEPLOYS", 5),
 		WildcardTLSSourceNamespace: getEnv("WILDCARD_TLS_SOURCE_NAMESPACE", ""),
 		WildcardTLSSourceSecret:    getEnv("WILDCARD_TLS_SOURCE_SECRET", ""),

--- a/backend/internal/deployer/cleanup_executor.go
+++ b/backend/internal/deployer/cleanup_executor.go
@@ -61,7 +61,7 @@ func (e *CleanupExecutor) CleanInstance(ctx context.Context, inst *models.StackI
 // Callers should ensure the instance is stopped/cleaned before requesting deletion.
 func (e *CleanupExecutor) DeleteInstance(ctx context.Context, inst *models.StackInstance) error {
 	switch inst.Status {
-	case models.StackStatusRunning, models.StackStatusDeploying,
+	case models.StackStatusRunning, models.StackStatusDeploying, models.StackStatusStabilizing,
 		models.StackStatusStopping, models.StackStatusCleaning:
 		return fmt.Errorf("cannot delete instance %s while status is %s; stop/clean must complete first", inst.ID, inst.Status)
 	}

--- a/backend/internal/deployer/manager.go
+++ b/backend/internal/deployer/manager.go
@@ -71,6 +71,9 @@ type Manager struct {
 	wildcardTLSSourceSecret string
 	wildcardTLSTargetSecret string
 
+	stabilizeTimeout      time.Duration
+	stabilizePollInterval time.Duration
+
 	// hooks dispatches lifecycle events to user-configured webhooks.
 	// nil disables all hook dispatch.
 	hooks *hooks.Dispatcher
@@ -112,6 +115,14 @@ type ManagerConfig struct {
 	// Notifier creates in-app notifications for lifecycle events.
 	// Optional — nil disables notification creation from the deployer.
 	Notifier LifecycleNotifier
+
+	// StabilizeTimeout is how long to wait for pods to become ready after
+	// all Helm charts succeed. 0 disables readiness gating.
+	StabilizeTimeout time.Duration
+
+	// StabilizePollInterval controls how frequently pod readiness is checked
+	// during the stabilization window. Defaults to 5s if zero.
+	StabilizePollInterval time.Duration
 }
 
 // DeployRequest contains everything needed to deploy a stack instance.
@@ -143,10 +154,16 @@ func NewManager(cfg ManagerConfig) *Manager {
 		wildcardTarget = cfg.WildcardTLSSourceSecret
 	}
 
+	stabilizePoll := cfg.StabilizePollInterval
+	if stabilizePoll == 0 {
+		stabilizePoll = 5 * time.Second
+	}
+
 	slog.Info("deploy manager init",
 		"wildcard_tls_source_ns", cfg.WildcardTLSSourceNamespace,
 		"wildcard_tls_source_secret", cfg.WildcardTLSSourceSecret,
 		"wildcard_tls_target_secret", wildcardTarget,
+		"stabilize_timeout", cfg.StabilizeTimeout,
 	)
 
 	return &Manager{
@@ -163,6 +180,9 @@ func NewManager(cfg ManagerConfig) *Manager {
 		wildcardTLSSourceNS:     cfg.WildcardTLSSourceNamespace,
 		wildcardTLSSourceSecret: cfg.WildcardTLSSourceSecret,
 		wildcardTLSTargetSecret: wildcardTarget,
+
+		stabilizeTimeout:      cfg.StabilizeTimeout,
+		stabilizePollInterval: stabilizePoll,
 
 		hooks:    cfg.Hooks,
 		notifier: cfg.Notifier,
@@ -288,15 +308,21 @@ func (m *Manager) Deploy(ctx context.Context, req DeployRequest) (string, error)
 			"cluster_id", clusterID, "error", err)
 	}
 
-	// Resolve the k8s client up front when we'll need it for wildcard TLS
-	// replication or image pull secret provisioning. Avoids the executeDeploy
-	// goroutine re-fetching the instance + re-resolving the cluster on every deploy.
-	var k8sClient *k8s.Client
-	needsK8s := (m.wildcardTLSSourceSecret != "" && m.wildcardTLSSourceNS != "") || regCfg != nil
-	if needsK8s {
-		k8sClient, err = m.registry.GetK8sClient(clusterID)
-		if err != nil {
-			return "", fmt.Errorf("getting cluster k8s client: %w", err)
+	// Always resolve the k8s client: needed for namespace-terminating check
+	// (#182), readiness gating (#186), wildcard TLS, and pull secrets.
+	k8sClient, err := m.registry.GetK8sClient(clusterID)
+	if err != nil {
+		return "", fmt.Errorf("getting cluster k8s client: %w", err)
+	}
+
+	// Reject deploy when the target namespace is still terminating (#182).
+	if k8sClient != nil {
+		phase, phaseErr := k8sClient.GetNamespacePhase(ctx, req.Instance.Namespace)
+		if phaseErr != nil {
+			return "", fmt.Errorf("checking namespace phase: %w", phaseErr)
+		}
+		if phase == "Terminating" {
+			return "", fmt.Errorf("namespace %q is still terminating; wait for it to be fully removed, then retry", req.Instance.Namespace)
 		}
 	}
 
@@ -387,10 +413,9 @@ func (m *Manager) Deploy(ctx context.Context, req DeployRequest) (string, error)
 }
 
 // executeDeploy runs the helm install for each chart sequentially within
-// a concurrency-limited goroutine. k8sClient is only non-nil when wildcard
-// TLS replication or image pull secret provisioning is needed — Deploy()
-// resolves it up front so this goroutine doesn't re-hit the repo/registry
-// on every run. regCfg is nil when the cluster has no container registry configured.
+// a concurrency-limited goroutine. k8sClient may be nil when the cluster has
+// no k8s client configured; callers guard usage accordingly. regCfg is nil
+// when the cluster has no container registry configured.
 //
 // The pre-deploy hook fires here (not in Deploy) so that long-running hooks
 // (e.g. CI trigger gates waiting minutes for builds) use shutdownCtx instead
@@ -407,7 +432,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 		deployErr := fmt.Errorf("pre-deploy hook: %w", err)
 		slog.Error("pre-deploy hook denied deployment",
 			"instance_id", instanceID, "log_id", deployLog.ID, "error", err)
-		m.finalizeDeploy(instanceID, deployLog, "", deployErr, lastDeployedValues)
+		m.finalizeDeploy(instanceID, deployLog, "", deployErr, lastDeployedValues, "")
 		return
 	}
 
@@ -434,7 +459,7 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 	if err != nil {
 		deployErr = fmt.Errorf("creating temp directory: %w", err)
 		slog.Error("deployment failed", "instance_id", instanceID, "error", deployErr)
-		m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues)
+		m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues, "")
 		return
 	}
 	defer os.RemoveAll(tmpDir)
@@ -619,7 +644,17 @@ func (m *Manager) executeDeploy(helm HelmExecutor, k8sClient *k8s.Client, regCfg
 		allOutput += rollbackOutput
 	}
 
-	m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues)
+	// If all charts succeeded, wait for pods to become ready before
+	// firing deploy-finalized (#186).
+	var readinessWarning string
+	if deployErr == nil && m.stabilizeTimeout > 0 && k8sClient != nil {
+		if waitErr := m.awaitReadiness(k8sClient, instanceID, namespace, deployLog.ID); waitErr != nil {
+			readinessWarning = waitErr.Error()
+			allOutput += fmt.Sprintf("WARNING: %s\n", readinessWarning)
+		}
+	}
+
+	m.finalizeDeploy(instanceID, deployLog, allOutput, deployErr, lastDeployedValues, readinessWarning)
 }
 
 // rollbackCharts uninstalls previously-installed charts in reverse order after
@@ -665,10 +700,65 @@ func (m *Manager) rollbackCharts(helm HelmExecutor, ctx context.Context, instanc
 	return rollbackOutput
 }
 
+// awaitReadiness polls namespace status until all deployments are healthy or the
+// stabilize timeout expires. A timeout is returned as an error (treated as a
+// warning by the caller, not a hard deploy failure).
+func (m *Manager) awaitReadiness(k8sClient *k8s.Client, instanceID, namespace, logID string) error {
+	inst, err := m.instanceRepo.FindByID(instanceID)
+	if err != nil {
+		return fmt.Errorf("find instance for stabilize: %w", err)
+	}
+	inst.Status = models.StackStatusStabilizing
+	if err := m.instanceRepo.Update(inst); err != nil {
+		slog.Warn("failed to set stabilizing status", "instance_id", instanceID, "error", err)
+	}
+	m.broadcastStatus(instanceID, models.StackStatusStabilizing, logID)
+	m.broadcastLog(instanceID, logID, "Helm charts installed, waiting for pods to become ready...")
+
+	stabilizeCtx, stabilizeCancel := context.WithTimeout(m.shutdownCtx, m.stabilizeTimeout)
+	defer stabilizeCancel()
+
+	ticker := time.NewTicker(m.stabilizePollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-stabilizeCtx.Done():
+			m.broadcastLog(instanceID, logID, fmt.Sprintf("WARNING: readiness timeout after %s", m.stabilizeTimeout))
+			return fmt.Errorf("readiness timeout after %s", m.stabilizeTimeout)
+		case <-ticker.C:
+			// Abort early if the instance was stopped/cleaned while stabilizing.
+			if current, findErr := m.instanceRepo.FindByID(instanceID); findErr == nil {
+				if current.Status != models.StackStatusStabilizing {
+					m.broadcastLog(instanceID, logID, fmt.Sprintf("Stabilization aborted: instance status changed to %s", current.Status))
+					return fmt.Errorf("stabilization aborted: status changed to %s", current.Status)
+				}
+			}
+
+			checkCtx, cancel := context.WithTimeout(stabilizeCtx, 5*time.Second)
+			nsStatus, statusErr := k8sClient.GetNamespaceStatus(checkCtx, namespace, k8s.StatusOptions{})
+			cancel()
+
+			if statusErr != nil {
+				slog.Warn("readiness poll failed", "instance_id", instanceID, "error", statusErr)
+				continue
+			}
+
+			if nsStatus.Status == k8s.StatusHealthy {
+				m.broadcastLog(instanceID, logID, "All pods healthy")
+				return nil
+			}
+
+			slog.Debug("readiness poll", "instance_id", instanceID, "status", nsStatus.Status)
+		}
+	}
+}
+
 // finalizeDeploy updates the instance and deployment log with the final status.
 // The deployLog is passed directly from the goroutine closure to avoid an
-// extra FindByID call.
-func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.DeploymentLog, output string, deployErr error, lastDeployedValues string) {
+// extra FindByID call. readinessWarning is non-empty when pod readiness timed
+// out (deploy still succeeds, but the hook payload includes the warning).
+func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.DeploymentLog, output string, deployErr error, lastDeployedValues string, readinessWarning string) {
 	now := time.Now().UTC()
 
 	instance, err := m.instanceRepo.FindByID(instanceID)
@@ -680,6 +770,29 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 
 	deployLog.Output = truncateString(output, maxOutputLen)
 	deployLog.CompletedAt = &now
+
+	// If a concurrent operation (stop/clean) changed the instance status while
+	// we were deploying/stabilizing, don't overwrite it — just finalize the log.
+	concurrentOp := instance.Status != models.StackStatusDeploying &&
+		instance.Status != models.StackStatusStabilizing
+	if concurrentOp {
+		slog.Warn("finalizeDeploy: concurrent operation changed status, skipping instance update",
+			"instance_id", instanceID,
+			"current_status", instance.Status,
+		)
+		deployLog.Status = models.DeployLogSuccess
+		deployLog.ValuesSnapshot = lastDeployedValues
+		if deployErr != nil {
+			sanitized := sanitizeDeployError(deployErr)
+			deployLog.Status = models.DeployLogError
+			deployLog.ErrorMessage = truncateString(sanitized, maxLogErrorLen)
+		}
+		if err := m.logRepo.Update(m.shutdownCtx, deployLog); err != nil {
+			slog.Error("failed to update deploy log after concurrent op",
+				"instance_id", instanceID, "deploy_log_id", deployLog.ID, "error", err)
+		}
+		return
+	}
 
 	if deployErr != nil {
 		// Use a sanitized, high-level message for user-visible fields.
@@ -749,7 +862,11 @@ func (m *Manager) finalizeDeploy(instanceID string, deployLog *models.Deployment
 	if deployErr == nil {
 		_ = m.fireDeployHook(hookCtx, hooks.EventPostDeploy, instance, deployLog.ID, deployLog.StartedAt, hookOpts{})
 	}
-	_ = m.fireDeployHook(hookCtx, hooks.EventDeployFinalized, instance, deployLog.ID, deployLog.StartedAt, hookOpts{})
+	finalizeHookOpts := hookOpts{}
+	if readinessWarning != "" {
+		finalizeHookOpts.Metadata = map[string]string{"readiness": "timeout", "readiness_warning": readinessWarning}
+	}
+	_ = m.fireDeployHook(hookCtx, hooks.EventDeployFinalized, instance, deployLog.ID, deployLog.StartedAt, finalizeHookOpts)
 
 	if deployErr != nil {
 		if isTimeoutError(deployErr) {
@@ -1650,6 +1767,9 @@ func (m *Manager) applyNamespaceQuotas(ctx context.Context, instanceID, namespac
 	k8sClient, err := m.registry.GetK8sClient(clusterID)
 	if err != nil {
 		return fmt.Errorf("getting k8s client: %w", err)
+	}
+	if k8sClient == nil {
+		return fmt.Errorf("k8s client is nil for cluster %s", clusterID)
 	}
 
 	if err := k8sClient.EnsureResourceQuota(ctx, namespace, effectiveQuota); err != nil {

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -357,7 +357,7 @@ func waitForTerminalStatus(t *testing.T, repo *mockInstanceRepo, instanceID stri
 		if err == nil {
 			switch inst.Status {
 			case models.StackStatusQueued, models.StackStatusDeploying,
-				models.StackStatusStopping, models.StackStatusCleaning:
+				models.StackStatusStabilizing, models.StackStatusStopping, models.StackStatusCleaning:
 			default:
 				return
 			}
@@ -373,6 +373,7 @@ func waitForTerminalStatus(t *testing.T, repo *mockInstanceRepo, instanceID stri
 type mockClusterResolver struct {
 	helm           HelmExecutor
 	k8sClient      *k8s.Client
+	noK8sClient    bool
 	registryConfig *models.RegistryConfig
 	resolveErr     error
 	helmErr        error
@@ -400,7 +401,13 @@ func (m *mockClusterResolver) GetK8sClient(_ string) (*k8s.Client, error) {
 	if m.k8sErr != nil {
 		return nil, m.k8sErr
 	}
-	return m.k8sClient, nil
+	if m.k8sClient != nil {
+		return m.k8sClient, nil
+	}
+	if m.noK8sClient {
+		return nil, nil
+	}
+	return k8s.NewClientFromInterface(fake.NewSimpleClientset()), nil
 }
 
 func (m *mockClusterResolver) GetRegistryConfig(_ string) (*models.RegistryConfig, error) {
@@ -1105,7 +1112,7 @@ func TestManager_FinalizeDeploy_InstanceNotFound(t *testing.T) {
 
 	// Should not panic when instance is not found.
 	orphanLog := &models.DeploymentLog{ID: "some-log-id", StackInstanceID: "nonexistent-id"}
-	mgr.finalizeDeploy("nonexistent-id", orphanLog, "output", nil, "")
+	mgr.finalizeDeploy("nonexistent-id", orphanLog, "output", nil, "", "")
 }
 
 func TestManager_BroadcastStatusWithError_NilHub(t *testing.T) {
@@ -1459,7 +1466,7 @@ func TestManager_FinalizeDeploy_OutputTruncation(t *testing.T) {
 
 	// Create output larger than maxOutputLen (64KB).
 	largeOutput := strings.Repeat("x", maxOutputLen+1000)
-	mgr.finalizeDeploy(inst.ID, deployLog, largeOutput, nil, "")
+	mgr.finalizeDeploy(inst.ID, deployLog, largeOutput, nil, "", "")
 
 	finalLog, err := logRepo.FindByID(context.Background(), deployLog.ID)
 	assert.NoError(t, err)
@@ -1799,7 +1806,7 @@ func TestManager_Clean_Success_NoK8sClient(t *testing.T) {
 	helmMock := &mockHelmExecutor{}
 
 	mgr := NewManager(ManagerConfig{
-		Registry:      &mockClusterResolver{helm: helmMock},
+		Registry:      &mockClusterResolver{helm: helmMock, noK8sClient: true},
 		InstanceRepo:  instanceRepo,
 		DeployLogRepo: logRepo,
 		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
@@ -2967,7 +2974,7 @@ func TestManager_FinalizeDeploy_LastDeployedValues(t *testing.T) {
 	})
 
 	lastValues := `{"mychart":"key: value\n"}`
-	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", nil, lastValues)
+	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", nil, lastValues, "")
 
 	updated, err := instanceRepo.FindByID(inst.ID)
 	require.NoError(t, err)
@@ -3008,7 +3015,7 @@ func TestManager_FinalizeDeploy_LastDeployedValuesNotSetOnError(t *testing.T) {
 	})
 
 	lastValues := `{"mychart":"key: value\n"}`
-	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", fmt.Errorf("helm install failed"), lastValues)
+	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", fmt.Errorf("helm install failed"), lastValues, "")
 
 	updated, err := instanceRepo.FindByID(inst.ID)
 	require.NoError(t, err)
@@ -3617,6 +3624,361 @@ func TestManager_Rollback_StreamingSupport(t *testing.T) {
 		}
 	}
 	assert.Greater(t, logMsgCount, 0, "rollback with streaming executor should produce per-line log messages")
+}
+
+// ---- #182: namespace terminating rejection tests ----
+
+func TestDeploy_RejectsTerminatingNamespace(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	inst := &models.StackInstance{
+		ID:                "inst-terminating",
+		StackDefinitionID: "def-1",
+		Name:              "terminating-test",
+		Namespace:         "stack-terminating",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	fakeCS := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-terminating"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceTerminating},
+	})
+	k8sClient := k8s.NewClientFromInterface(fakeCS)
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: &mockHelmExecutor{}, k8sClient: k8sClient},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+	})
+
+	_, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "terminating")
+}
+
+func TestDeploy_AllowsActiveNamespace(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	inst := &models.StackInstance{
+		ID:                "inst-active",
+		StackDefinitionID: "def-1",
+		Name:              "active-test",
+		Namespace:         "stack-active",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	fakeCS := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-active"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	})
+	k8sClient := k8s.NewClientFromInterface(fakeCS)
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: &mockHelmExecutor{}, k8sClient: k8sClient},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+	})
+
+	logID, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+}
+
+func TestDeploy_AllowsNonExistentNamespace(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+
+	inst := &models.StackInstance{
+		ID:                "inst-new-ns",
+		StackDefinitionID: "def-1",
+		Name:              "new-ns-test",
+		Namespace:         "stack-new",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	// Empty clientset — namespace doesn't exist yet.
+	k8sClient := k8s.NewClientFromInterface(fake.NewSimpleClientset())
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: &mockHelmExecutor{}, k8sClient: k8sClient},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           &mockBroadcaster{},
+		MaxConcurrent: 2,
+	})
+
+	logID, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+}
+
+// ---- #186: readiness gating tests ----
+
+func TestAwaitReadiness_HealthyImmediately(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-ready",
+		StackDefinitionID: "def-1",
+		Name:              "ready-test",
+		Namespace:         "stack-ready",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	// Namespace exists with no pods/deployments → healthy immediately.
+	fakeCS := fake.NewSimpleClientset(&corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "stack-ready"},
+		Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+	})
+	k8sClient := k8s.NewClientFromInterface(fakeCS)
+
+	mgr := NewManager(ManagerConfig{
+		Registry:             &mockClusterResolver{helm: &mockHelmExecutor{}, k8sClient: k8sClient},
+		InstanceRepo:         instanceRepo,
+		DeployLogRepo:        logRepo,
+		TxRunner:             &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:                  hub,
+		MaxConcurrent:        2,
+		StabilizeTimeout:     10 * time.Second,
+		StabilizePollInterval: 50 * time.Millisecond,
+	})
+
+	logID, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
+
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	// Verify stabilizing status was broadcast.
+	messages := hub.getMessages()
+	var sawStabilizing bool
+	for _, msg := range messages {
+		if strings.Contains(string(msg), "stabilizing") {
+			sawStabilizing = true
+			break
+		}
+	}
+	assert.True(t, sawStabilizing, "should have broadcast stabilizing status")
+}
+
+func TestAwaitReadiness_Timeout(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-timeout",
+		StackDefinitionID: "def-1",
+		Name:              "timeout-test",
+		Namespace:         "stack-timeout",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	// Namespace with a pending pod → never becomes healthy.
+	fakeCS := fake.NewSimpleClientset(
+		&corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "stack-timeout"},
+			Status:     corev1.NamespaceStatus{Phase: corev1.NamespaceActive},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "stuck-pod", Namespace: "stack-timeout"},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodPending,
+			},
+		},
+	)
+	k8sClient := k8s.NewClientFromInterface(fakeCS)
+
+	mgr := NewManager(ManagerConfig{
+		Registry:             &mockClusterResolver{helm: &mockHelmExecutor{}, k8sClient: k8sClient},
+		InstanceRepo:         instanceRepo,
+		DeployLogRepo:        logRepo,
+		TxRunner:             &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:                  hub,
+		MaxConcurrent:        2,
+		StabilizeTimeout:     200 * time.Millisecond,
+		StabilizePollInterval: 50 * time.Millisecond,
+	})
+
+	logID, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
+
+	// Deploy still succeeds (readiness timeout is a warning, not a failure).
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	// Verify timeout warning was broadcast.
+	messages := hub.getMessages()
+	var sawTimeout bool
+	for _, msg := range messages {
+		if strings.Contains(string(msg), "readiness timeout") {
+			sawTimeout = true
+			break
+		}
+	}
+	assert.True(t, sawTimeout, "should have broadcast readiness timeout warning")
+}
+
+func TestAwaitReadiness_Disabled_WhenTimeoutZero(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-no-stabilize",
+		StackDefinitionID: "def-1",
+		Name:              "no-stabilize",
+		Namespace:         "stack-no-stabilize",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDraft,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	mgr := NewManager(ManagerConfig{
+		Registry:             &mockClusterResolver{helm: &mockHelmExecutor{}},
+		InstanceRepo:         instanceRepo,
+		DeployLogRepo:        logRepo,
+		TxRunner:             &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:                  hub,
+		MaxConcurrent:        2,
+		StabilizeTimeout:     0, // disabled
+		StabilizePollInterval: 50 * time.Millisecond,
+	})
+
+	logID, err := mgr.Deploy(context.Background(), DeployRequest{
+		Instance:   inst,
+		Definition: &models.StackDefinition{ID: "def-1", Name: "test-def"},
+		Charts:     []ChartDeployInfo{},
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, logID)
+
+	waitForTerminalStatus(t, instanceRepo, inst.ID)
+
+	final, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, final.Status)
+
+	// Should NOT see stabilizing status when timeout is 0.
+	messages := hub.getMessages()
+	for _, msg := range messages {
+		assert.NotContains(t, string(msg), "stabilizing", "should not enter stabilizing state when timeout=0")
+	}
+}
+
+func TestFinalizeDeploy_ReadinessWarning_AttachesHookMetadata(t *testing.T) {
+	t.Parallel()
+
+	instanceRepo := newMockInstanceRepo()
+	logRepo := newMockDeployLogRepo()
+	hub := &mockBroadcaster{}
+
+	inst := &models.StackInstance{
+		ID:                "inst-rw",
+		StackDefinitionID: "def-1",
+		Name:              "rw-test",
+		Namespace:         "stack-rw",
+		OwnerID:           "user-1",
+		Branch:            "main",
+		Status:            models.StackStatusDeploying,
+	}
+	require.NoError(t, instanceRepo.Create(inst))
+
+	deployLog := &models.DeploymentLog{
+		ID:              "log-rw",
+		StackInstanceID: inst.ID,
+		Action:          models.DeployActionDeploy,
+		Status:          models.DeployLogRunning,
+		StartedAt:       time.Now().UTC(),
+	}
+	require.NoError(t, logRepo.Create(context.Background(), deployLog))
+
+	mgr := NewManager(ManagerConfig{
+		Registry:      &mockClusterResolver{helm: &mockHelmExecutor{}},
+		InstanceRepo:  instanceRepo,
+		DeployLogRepo: logRepo,
+		TxRunner:      &mockTxRunner{instanceRepo: instanceRepo, logRepo: logRepo},
+		Hub:           hub,
+		MaxConcurrent: 2,
+	})
+
+	// Call finalizeDeploy with a readinessWarning — deploy succeeds but with metadata.
+	mgr.finalizeDeploy(inst.ID, deployLog, "deploy output", nil, "", "readiness timeout after 5m0s")
+
+	updated, err := instanceRepo.FindByID(inst.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.StackStatusRunning, updated.Status)
+
+	finalLog, err := logRepo.FindByID(context.Background(), deployLog.ID)
+	require.NoError(t, err)
+	assert.Equal(t, models.DeployLogSuccess, finalLog.Status)
 }
 
 // Verify that streamingMockHelmExecutor satisfies StreamingHelmExecutor at compile time.

--- a/backend/internal/k8s/client.go
+++ b/backend/internal/k8s/client.go
@@ -139,6 +139,19 @@ func (c *Client) NamespaceExists(ctx context.Context, name string) (bool, error)
 	return true, nil
 }
 
+// GetNamespacePhase returns the phase of a namespace ("Active", "Terminating")
+// or an empty string if the namespace does not exist.
+func (c *Client) GetNamespacePhase(ctx context.Context, name string) (string, error) {
+	ns, err := c.clientset.CoreV1().Namespaces().Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", fmt.Errorf("get namespace %q: %w", name, err)
+	}
+	return string(ns.Status.Phase), nil
+}
+
 // Clientset returns the underlying kubernetes.Interface for advanced operations.
 func (c *Client) Clientset() kubernetes.Interface {
 	return c.clientset

--- a/backend/internal/k8s/watcher.go
+++ b/backend/internal/k8s/watcher.go
@@ -121,7 +121,8 @@ func (w *Watcher) poll(ctx context.Context) {
 
 		// Only monitor instances that are actively deployed.
 		if inst.Status != models.StackStatusRunning &&
-			inst.Status != models.StackStatusDeploying {
+			inst.Status != models.StackStatusDeploying &&
+			inst.Status != models.StackStatusStabilizing {
 			continue
 		}
 

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -23,14 +23,15 @@ type StackInstance struct {
 
 // Valid stack instance statuses.
 const (
-	StackStatusDraft     = "draft"
-	StackStatusQueued    = "queued"
-	StackStatusDeploying = "deploying"
-	StackStatusRunning   = "running"
-	StackStatusStopping  = "stopping"
-	StackStatusStopped   = "stopped"
-	StackStatusCleaning  = "cleaning"
-	StackStatusError     = "error"
+	StackStatusDraft       = "draft"
+	StackStatusQueued      = "queued"
+	StackStatusDeploying   = "deploying"
+	StackStatusStabilizing = "stabilizing"
+	StackStatusRunning     = "running"
+	StackStatusStopping    = "stopping"
+	StackStatusStopped     = "stopped"
+	StackStatusCleaning    = "cleaning"
+	StackStatusError       = "error"
 )
 
 // StackInstanceRepository defines data access operations for stack instances.

--- a/frontend/src/components/StatusBadge/index.tsx
+++ b/frontend/src/components/StatusBadge/index.tsx
@@ -4,6 +4,7 @@ import type { StackStatus } from '../../types';
 const statusColors: Record<StackStatus, 'default' | 'info' | 'success' | 'warning' | 'error'> = {
   draft: 'default',
   deploying: 'info',
+  stabilizing: 'info',
   running: 'success',
   stopped: 'warning',
   stopping: 'warning',

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -44,7 +44,7 @@ import LoadingState from '../../components/LoadingState';
 import EmptyState from '../../components/EmptyState';
 import { useNotification } from '../../context/NotificationContext';
 
-const STATUSES = ['All', 'draft', 'deploying', 'running', 'stopped', 'error'];
+const STATUSES = ['All', 'draft', 'deploying', 'stabilizing', 'running', 'stopped', 'error'];
 
 type BulkAction = 'deploy' | 'stop' | 'clean' | 'delete';
 
@@ -143,7 +143,7 @@ const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, k8sH
         </Box>
         <Box sx={{ display: 'flex', alignItems: 'center' }}>
           <StatusBadge status={instance.status} />
-          {(instance.status === 'running' || instance.status === 'deploying') && k8sHealth && (
+          {(instance.status === 'running' || instance.status === 'deploying' || instance.status === 'stabilizing') && k8sHealth && (
             <PodHealthDot status={k8sHealth} />
           )}
         </Box>
@@ -251,7 +251,7 @@ const Dashboard = () => {
   // Phase 2: fetch status/URLs for newly running/deploying instances
   useEffect(() => {
     const running = instances.filter(
-      (i) => i.status === 'running' || i.status === 'deploying',
+      (i) => i.status === 'running' || i.status === 'deploying' || i.status === 'stabilizing',
     );
     const newRunning = running.filter(
       (i) => !fetchedStatusIdsRef.current.has(i.id) && !inFlightIdsRef.current.has(i.id),

--- a/frontend/src/pages/StackInstances/Detail.tsx
+++ b/frontend/src/pages/StackInstances/Detail.tsx
@@ -115,7 +115,7 @@ const Detail = () => {
         } catch { /* ignore — no logs yet */ }
 
         // Fetch pod health for active instances (includes container states + events).
-        if (inst.status === 'running' || inst.status === 'deploying' || inst.status === 'error' || inst.status === 'stopping' || inst.status === 'cleaning') {
+        if (inst.status === 'running' || inst.status === 'deploying' || inst.status === 'stabilizing' || inst.status === 'error' || inst.status === 'stopping' || inst.status === 'cleaning') {
           try {
             setStatusLoading(true);
             const status = await instanceService.getPods(id);
@@ -150,14 +150,14 @@ const Detail = () => {
       }
 
       // Fetch current K8s status for terminal states where resources may exist.
-      if (newStatus === 'running' || newStatus === 'error') {
+      if (newStatus === 'running' || newStatus === 'stabilizing' || newStatus === 'error') {
         instanceService.getPods(id).then(setK8sStatus).catch(() => {});
       }
 
       // On active states, insert a placeholder log entry so streaming lines
       // have an accordion to attach to before the REST refresh completes.
       const logId = (payload as { log_id?: string }).log_id;
-      if ((newStatus === 'deploying' || newStatus === 'stopping' || newStatus === 'cleaning' || newStatus === 'rolling_back') && logId) {
+      if ((newStatus === 'deploying' || newStatus === 'stabilizing' || newStatus === 'stopping' || newStatus === 'cleaning' || newStatus === 'rolling_back') && logId) {
         const actionMap: Record<string, DeploymentLog['action']> = {
           deploying: 'deploy', stopping: 'stop', cleaning: 'clean', rolling_back: 'rollback',
         };
@@ -463,7 +463,7 @@ const Detail = () => {
   };
 
   const canDeploy = instance?.status === 'draft' || instance?.status === 'stopped' || instance?.status === 'error';
-  const canStop = instance?.status === 'running' || instance?.status === 'deploying';
+  const canStop = instance?.status === 'running' || instance?.status === 'deploying' || instance?.status === 'stabilizing';
   const canClean = instance?.status === 'running' || instance?.status === 'stopped' || instance?.status === 'error';
 
   const renderStatusActions = (status: string) => (
@@ -492,7 +492,7 @@ const Detail = () => {
     </>
   );
 
-  const LIFECYCLE_STEPS = ['draft', 'deploying', 'running'];
+  const LIFECYCLE_STEPS = ['draft', 'deploying', 'stabilizing', 'running'];
 
   const renderLifecycle = (status: string) => {
     const activeStep = LIFECYCLE_STEPS.indexOf(status);
@@ -584,7 +584,7 @@ const Detail = () => {
 
         {renderLifecycle(instance.status)}
 
-        {(instance.status === 'running' || instance.status === 'deploying' || instance.status === 'error' || instance.status === 'stopping' || instance.status === 'cleaning') && (
+        {(instance.status === 'running' || instance.status === 'deploying' || instance.status === 'stabilizing' || instance.status === 'error' || instance.status === 'stopping' || instance.status === 'cleaning') && (
           <Box sx={{ mb: 2 }}>
             <Typography variant="subtitle2" gutterBottom>Cluster Resources</Typography>
             <PodStatusDisplay status={k8sStatus} loading={statusLoading} />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -260,7 +260,7 @@ export interface InstantiateTemplateRequest {
   chart_overrides?: Record<string, string>;
 }
 
-export type StackStatus = 'draft' | 'deploying' | 'running' | 'stopped' | 'error' | 'stopping' | 'cleaning';
+export type StackStatus = 'draft' | 'deploying' | 'stabilizing' | 'running' | 'stopped' | 'error' | 'stopping' | 'cleaning';
 
 export interface CreateUserRequest {
   username: string;


### PR DESCRIPTION
## Summary
- **#182** — `Deploy()` checks namespace phase via new `GetNamespacePhase()` and rejects with an actionable error when the target namespace is still terminating
- **#186** — New `stabilizing` status: after Helm charts are applied, polls pod health before firing `deploy-finalized`. Configurable via `DEPLOY_STABILIZE_TIMEOUT` (default 5m, `0` disables). Timeout is a warning, not a hard failure
- Fixes nil-pointer in `applyNamespaceQuotas` when k8s client is nil
- Fixes race in `finalizeDeploy` that could overwrite a concurrent stop/clean operation
- Adds `stabilizing` to all backend guards (cleanup_executor, secret_monitor, secret_refresher, quota_monitor, watcher, handler delete/deploy/stop checks)
- Adds `stabilizing` to all frontend status checks (Detail.tsx lifecycle steps, action buttons, WS handlers, K8s status panel; Dashboard.tsx filter, health badge, health fetch)

Closes #182, closes #186

## Test plan
- [ ] `go test ./...` passes (29 packages, 0 failures)
- [ ] 7 new tests cover: terminating rejection, active/non-existent namespace allow, readiness healthy path, readiness timeout path, timeout=0 disables stabilization, finalizeDeploy with readiness warning
- [ ] Deploy to a namespace that is terminating → returns clear error
- [ ] Deploy with `DEPLOY_STABILIZE_TIMEOUT=30s` → see stabilizing status, then running once pods healthy
- [ ] Deploy with `DEPLOY_STABILIZE_TIMEOUT=0` → skips stabilization, goes straight to running
- [ ] Stop during stabilization → stabilization aborts, stop proceeds without race
- [ ] Frontend shows stabilizing in lifecycle stepper, Stop button enabled during stabilizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)