### PR TITLE
feat: dashboard overview widgets (#116)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ Thumbs.db
 /frontend/playwright-report/
 /frontend/blob-report/
 /frontend/playwright/.cache/
+/frontend/test-logs/
 
 # SonarQube
 sonar-project.properties

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ test-e2e: integration-infra-start
 		sleep 1; \
 	done
 	@echo "Backend is ready, running Playwright tests..."
-	cd frontend && npx playwright test 2>&1 | tee test-logs/playwright.log || \
+	cd frontend && bash -o pipefail -c 'npx playwright test 2>&1 | tee test-logs/playwright.log' || \
 		(kill $$(lsof -ti:8081) 2>/dev/null; $(MAKE) integration-infra-stop; exit 1)
 	@echo "Stopping backend..."
 	@kill $$(lsof -ti:8081) 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ test-frontend:
 	cd frontend && npm test
 
 # Run frontend e2e tests (requires MySQL running, starts backend natively)
+# Logs are written to frontend/test-logs/ for post-mortem troubleshooting.
 test-e2e: integration-infra-start
+	@mkdir -p frontend/test-logs
 	@echo "Building and starting backend..."
 	@cd backend && go build -o tmp/main ./api/main.go
 	@cd backend && \
@@ -91,13 +93,16 @@ test-e2e: integration-infra-start
 		ADMIN_USERNAME=admin ADMIN_PASSWORD=admin SELF_REGISTRATION=true \
 		HELM_BINARY=$${HELM_BINARY:-helm} \
 		KUBECONFIG_PATH=$${KUBECONFIG_PATH:-$$HOME/.kube/config} \
-		RATE_LIMIT=10000 PORT=8081 ./tmp/main &
+		CORS_ALLOWED_ORIGINS=http://localhost:3000 \
+		RATE_LIMIT=10000 LOGIN_RATE_LIMIT=10000 PORT=8081 \
+		./tmp/main > ../frontend/test-logs/backend.log 2>&1 &
 	@echo "Waiting for backend to be healthy..."
 	@until curl -sf http://localhost:8081/health/live >/dev/null 2>&1; do \
 		sleep 1; \
 	done
 	@echo "Backend is ready, running Playwright tests..."
-	cd frontend && npx playwright test || (kill $$(lsof -ti:8081) 2>/dev/null; $(MAKE) integration-infra-stop; exit 1)
+	cd frontend && npx playwright test 2>&1 | tee test-logs/playwright.log || \
+		(kill $$(lsof -ti:8081) 2>/dev/null; $(MAKE) integration-infra-stop; exit 1)
 	@echo "Stopping backend..."
 	@kill $$(lsof -ti:8081) 2>/dev/null || true
 	$(MAKE) integration-infra-stop

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -359,6 +359,7 @@ func main() {
 	}
 
 	analyticsHandler := handlers.NewAnalyticsHandler(templateRepo, definitionRepo, instanceRepo, deployLogRepo, userRepo)
+	dashboardHandler := handlers.NewDashboardHandler(clusterRepo, instanceRepo, deployLogRepo, clusterRegistry)
 
 	// ------------------------------------------------------------------
 	// Phase 6.2: Cleanup policies
@@ -394,6 +395,7 @@ func main() {
 		FavoriteHandler:              favoriteHandler,
 		QuickDeployHandler:           quickDeployHandler,
 		AnalyticsHandler:             analyticsHandler,
+		DashboardHandler:             dashboardHandler,
 		CleanupPolicyHandler:         cleanupPolicyHandler,
 		CleanupScheduler:             cleanupScheduler,
 		ClusterHandler:               clusterHandler,

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -527,6 +527,7 @@ func main() {
 		clusterRegistry:  clusterRegistry,
 		watcherCancel:    watcherCancel,
 		oidcStateStore:   oidcStateStore,
+		dashboardHandler: dashboardHandler,
 		repo:             repo,
 	})
 }
@@ -547,6 +548,7 @@ type shutdownDeps struct {
 	clusterRegistry  *cluster.Registry
 	watcherCancel    context.CancelFunc
 	oidcStateStore   *auth.StateStore
+	dashboardHandler *handlers.DashboardHandler
 	repo             models.Repository
 }
 
@@ -589,6 +591,9 @@ func gracefulShutdown(srv *http.Server, timeout time.Duration, deps shutdownDeps
 	deps.watcherCancel()
 	if deps.oidcStateStore != nil {
 		deps.oidcStateStore.Stop()
+	}
+	if deps.dashboardHandler != nil {
+		deps.dashboardHandler.Stop()
 	}
 
 	// 5. Flush OTel spans/metrics/logs AFTER all services stop,

--- a/backend/api/main_integration_test.go
+++ b/backend/api/main_integration_test.go
@@ -23,8 +23,8 @@ func TestDatabaseInitialization(t *testing.T) {
 		Database: config.DatabaseConfig{
 			Host:            "localhost",
 			Port:            "3306",
-			User:            "appuser",
-			Password:        "apppass",
+			User:            "root",
+			Password:        "rootpassword",
 			DBName:          "app",
 			MaxOpenConns:    5,
 			MaxIdleConns:    2,

--- a/backend/api/main_test.go
+++ b/backend/api/main_test.go
@@ -483,6 +483,9 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
 	return nil, nil
 }
+func (m *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 // ---- extractAPIServerURL tests ----
 

--- a/backend/internal/api/handlers/analytics_test.go
+++ b/backend/internal/api/handlers/analytics_test.go
@@ -159,6 +159,10 @@ func (m *mockDeployLogRepo) CountByAction(_ context.Context, action string) (int
 	return count, nil
 }
 
+func (m *mockDeployLogRepo) ListRecentGlobal(_ context.Context, limit int) ([]models.DeploymentLogWithContext, error) {
+	return nil, nil
+}
+
 func (m *mockDeployLogRepo) setError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/api/handlers/cleanup_policies_test.go
+++ b/backend/internal/api/handlers/cleanup_policies_test.go
@@ -762,6 +762,9 @@ func (r *cleanupMockInstanceRepo) ListExpired() ([]*models.StackInstance, error)
 func (r *cleanupMockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
 	return nil, nil
 }
+func (r *cleanupMockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 // cleanupMockAuditRepo implements models.AuditLogRepository for handler tests.
 type cleanupMockAuditRepo struct {

--- a/backend/internal/api/handlers/dashboard.go
+++ b/backend/internal/api/handlers/dashboard.go
@@ -187,11 +187,14 @@ func (h *DashboardHandler) buildClusterData(ctx context.Context, privileged bool
 
 	result := make([]DashboardCluster, len(clusters))
 	for i, cl := range clusters {
-		result[i] = DashboardCluster{
-			ID:           cl.ID,
-			Name:         cl.Name,
-			HealthStatus: cl.HealthStatus,
+		dc := DashboardCluster{
+			ID:   cl.ID,
+			Name: cl.Name,
 		}
+		if privileged {
+			dc.HealthStatus = cl.HealthStatus
+		}
+		result[i] = dc
 	}
 
 	if !privileged || h.registry == nil {

--- a/backend/internal/api/handlers/dashboard.go
+++ b/backend/internal/api/handlers/dashboard.go
@@ -1,0 +1,294 @@
+package handlers
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"backend/internal/cache"
+	"backend/internal/cluster"
+	"backend/internal/k8s"
+	"backend/internal/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+const dashboardCacheTTL = 30 * time.Second
+
+// ---- Response types ----
+
+type DashboardResponse struct {
+	Clusters          []DashboardCluster    `json:"clusters"`
+	RecentDeployments []DashboardDeployment `json:"recent_deployments"`
+	ExpiringSoon      []DashboardExpiring   `json:"expiring_soon"`
+	FailingInstances  []DashboardFailing    `json:"failing_instances"`
+}
+
+type DashboardCluster struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	HealthStatus      string `json:"health_status"`
+	NodeCount         *int   `json:"node_count,omitempty"`
+	ReadyNodeCount    *int   `json:"ready_node_count,omitempty"`
+	TotalCPU          string `json:"total_cpu,omitempty"`
+	TotalMemory       string `json:"total_memory,omitempty"`
+	AllocatableCPU    string `json:"allocatable_cpu,omitempty"`
+	AllocatableMemory string `json:"allocatable_memory,omitempty"`
+	NamespaceCount    *int   `json:"namespace_count,omitempty"`
+}
+
+type DashboardDeployment struct {
+	ID              string     `json:"id"`
+	StackInstanceID string     `json:"stack_instance_id"`
+	InstanceName    string     `json:"instance_name"`
+	Action          string     `json:"action"`
+	Status          string     `json:"status"`
+	StartedAt       time.Time  `json:"started_at"`
+	CompletedAt     *time.Time `json:"completed_at,omitempty"`
+	Username        string     `json:"username,omitempty"`
+}
+
+type DashboardExpiring struct {
+	ID         string     `json:"id"`
+	Name       string     `json:"name"`
+	Namespace  string     `json:"namespace"`
+	Status     string     `json:"status"`
+	ExpiresAt  *time.Time `json:"expires_at"`
+	TTLMinutes int        `json:"ttl_minutes"`
+	ClusterID  string     `json:"cluster_id,omitempty"`
+}
+
+type DashboardFailing struct {
+	ID           string    `json:"id"`
+	Name         string    `json:"name"`
+	Namespace    string    `json:"namespace"`
+	Status       string    `json:"status"`
+	ErrorMessage string    `json:"error_message"`
+	ClusterID    string    `json:"cluster_id,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}
+
+// ---- Handler ----
+
+type DashboardHandler struct {
+	clusterRepo   models.ClusterRepository
+	instanceRepo  models.StackInstanceRepository
+	deployLogRepo models.DeploymentLogRepository
+	registry      *cluster.Registry
+	privCache     *cache.TTLCache[*DashboardResponse]
+	basicCache    *cache.TTLCache[*DashboardResponse]
+}
+
+func NewDashboardHandler(
+	clusterRepo models.ClusterRepository,
+	instanceRepo models.StackInstanceRepository,
+	deployLogRepo models.DeploymentLogRepository,
+	registry *cluster.Registry,
+) *DashboardHandler {
+	return &DashboardHandler{
+		clusterRepo:   clusterRepo,
+		instanceRepo:  instanceRepo,
+		deployLogRepo: deployLogRepo,
+		registry:      registry,
+		privCache:     cache.New[*DashboardResponse](dashboardCacheTTL, dashboardCacheTTL),
+		basicCache:    cache.New[*DashboardResponse](dashboardCacheTTL, dashboardCacheTTL),
+	}
+}
+
+// GetDashboard godoc
+// @Summary     Get dashboard overview
+// @Description Returns aggregated dashboard data: cluster health, recent deployments, expiring instances, and failing instances.
+// @Tags        dashboard
+// @Produce     json
+// @Security    BearerAuth
+// @Success     200 {object} DashboardResponse
+// @Failure     500 {object} map[string]string
+// @Router      /api/v1/dashboard [get]
+func (h *DashboardHandler) GetDashboard(c *gin.Context) {
+	privileged := isPrivilegedRole(c)
+
+	cacheStore := h.basicCache
+	cacheKey := "dashboard:basic"
+	if privileged {
+		cacheStore = h.privCache
+		cacheKey = "dashboard:privileged"
+	}
+
+	if cached, ok := cacheStore.Get(cacheKey); ok {
+		c.JSON(http.StatusOK, cached)
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	clusters, err := h.buildClusterData(ctx, privileged)
+	if err != nil {
+		slog.Error("dashboard: failed to build cluster data", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	recentDeploys, err := h.buildRecentDeployments(ctx)
+	if err != nil {
+		slog.Error("dashboard: failed to build recent deployments", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	expiring, err := h.buildExpiringSoon()
+	if err != nil {
+		slog.Error("dashboard: failed to build expiring instances", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	failing, err := h.buildFailingInstances()
+	if err != nil {
+		slog.Error("dashboard: failed to build failing instances", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	resp := &DashboardResponse{
+		Clusters:          clusters,
+		RecentDeployments: recentDeploys,
+		ExpiringSoon:      expiring,
+		FailingInstances:  failing,
+	}
+
+	cacheStore.Set(cacheKey, resp)
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *DashboardHandler) buildClusterData(ctx context.Context, privileged bool) ([]DashboardCluster, error) {
+	clusters, err := h.clusterRepo.List()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]DashboardCluster, len(clusters))
+	for i, cl := range clusters {
+		result[i] = DashboardCluster{
+			ID:           cl.ID,
+			Name:         cl.Name,
+			HealthStatus: cl.HealthStatus,
+		}
+	}
+
+	if !privileged || h.registry == nil {
+		return result, nil
+	}
+
+	// Fan out health summary fetches with a 3s timeout per cluster.
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i, cl := range clusters {
+		wg.Add(1)
+		go func(idx int, clusterID string) {
+			defer wg.Done()
+			fetchCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+			defer cancel()
+
+			k8sClient, err := h.registry.GetK8sClient(clusterID)
+			if err != nil {
+				slog.Warn("dashboard: failed to get k8s client", "cluster_id", clusterID, "error", err)
+				return
+			}
+
+			summary, err := k8sClient.GetClusterSummary(fetchCtx)
+			if err != nil {
+				slog.Warn("dashboard: failed to get cluster summary", "cluster_id", clusterID, "error", err)
+				return
+			}
+
+			h.enrichClusterFromSummary(&mu, &result[idx], summary)
+		}(i, cl.ID)
+	}
+	wg.Wait()
+
+	return result, nil
+}
+
+func (h *DashboardHandler) enrichClusterFromSummary(mu *sync.Mutex, dc *DashboardCluster, summary *k8s.ClusterSummary) {
+	mu.Lock()
+	defer mu.Unlock()
+	dc.NodeCount = &summary.NodeCount
+	dc.ReadyNodeCount = &summary.ReadyNodeCount
+	dc.TotalCPU = summary.TotalCPU
+	dc.TotalMemory = summary.TotalMemory
+	dc.AllocatableCPU = summary.AllocatableCPU
+	dc.AllocatableMemory = summary.AllocatableMemory
+	dc.NamespaceCount = &summary.NamespaceCount
+}
+
+func (h *DashboardHandler) buildRecentDeployments(ctx context.Context) ([]DashboardDeployment, error) {
+	logs, err := h.deployLogRepo.ListRecentGlobal(ctx, 10)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]DashboardDeployment, len(logs))
+	for i, l := range logs {
+		result[i] = DashboardDeployment{
+			ID:              l.ID,
+			StackInstanceID: l.StackInstanceID,
+			InstanceName:    l.InstanceName,
+			Action:          l.Action,
+			Status:          l.Status,
+			StartedAt:       l.StartedAt,
+			CompletedAt:     l.CompletedAt,
+			Username:        l.Username,
+		}
+	}
+	return result, nil
+}
+
+func (h *DashboardHandler) buildExpiringSoon() ([]DashboardExpiring, error) {
+	instances, err := h.instanceRepo.ListExpiringSoon(1 * time.Hour)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]DashboardExpiring, len(instances))
+	for i, inst := range instances {
+		result[i] = DashboardExpiring{
+			ID:         inst.ID,
+			Name:       inst.Name,
+			Namespace:  inst.Namespace,
+			Status:     inst.Status,
+			ExpiresAt:  inst.ExpiresAt,
+			TTLMinutes: inst.TTLMinutes,
+			ClusterID:  inst.ClusterID,
+		}
+	}
+	return result, nil
+}
+
+func (h *DashboardHandler) buildFailingInstances() ([]DashboardFailing, error) {
+	all, err := h.instanceRepo.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var result []DashboardFailing
+	for _, inst := range all {
+		if inst.Status != models.StackStatusError {
+			continue
+		}
+		result = append(result, DashboardFailing{
+			ID:           inst.ID,
+			Name:         inst.Name,
+			Namespace:    inst.Namespace,
+			Status:       inst.Status,
+			ErrorMessage: inst.ErrorMessage,
+			ClusterID:    inst.ClusterID,
+			UpdatedAt:    inst.UpdatedAt,
+		})
+	}
+	if result == nil {
+		result = []DashboardFailing{}
+	}
+	return result, nil
+}

--- a/backend/internal/api/handlers/dashboard.go
+++ b/backend/internal/api/handlers/dashboard.go
@@ -48,7 +48,7 @@ type DashboardDeployment struct {
 	Status          string     `json:"status"`
 	StartedAt       time.Time  `json:"started_at"`
 	CompletedAt     *time.Time `json:"completed_at,omitempty"`
-	Username        string     `json:"username,omitempty"`
+	OwnerUsername   string     `json:"owner_username,omitempty"`
 }
 
 type DashboardExpiring struct {
@@ -109,6 +109,7 @@ func (h *DashboardHandler) Stop() {
 // @Summary     Get dashboard overview
 // @Description Returns aggregated dashboard data: cluster health, recent deployments, expiring instances, and failing instances.
 // @Tags        dashboard
+// @Accept      json
 // @Produce     json
 // @Security    BearerAuth
 // @Success     200 {object} DashboardResponse
@@ -259,7 +260,7 @@ func (h *DashboardHandler) buildRecentDeployments(ctx context.Context) ([]Dashbo
 			Status:          l.Status,
 			StartedAt:       l.StartedAt,
 			CompletedAt:     l.CompletedAt,
-			Username:        l.Username,
+			OwnerUsername:   l.OwnerUsername,
 		}
 	}
 	return result, nil
@@ -269,6 +270,10 @@ func (h *DashboardHandler) buildExpiringSoon() ([]DashboardExpiring, error) {
 	instances, err := h.instanceRepo.ListExpiringSoon(1 * time.Hour)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(instances) > 50 {
+		instances = instances[:50]
 	}
 
 	result := make([]DashboardExpiring, len(instances))

--- a/backend/internal/api/handlers/dashboard.go
+++ b/backend/internal/api/handlers/dashboard.go
@@ -13,6 +13,7 @@ import (
 	"backend/internal/models"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/sync/singleflight"
 )
 
 const dashboardCacheTTL = 30 * time.Second
@@ -79,6 +80,7 @@ type DashboardHandler struct {
 	registry      *cluster.Registry
 	privCache     *cache.TTLCache[*DashboardResponse]
 	basicCache    *cache.TTLCache[*DashboardResponse]
+	sfGroup       singleflight.Group
 }
 
 func NewDashboardHandler(
@@ -95,6 +97,12 @@ func NewDashboardHandler(
 		privCache:     cache.New[*DashboardResponse](dashboardCacheTTL, dashboardCacheTTL),
 		basicCache:    cache.New[*DashboardResponse](dashboardCacheTTL, dashboardCacheTTL),
 	}
+}
+
+// Stop halts background cache cleanup goroutines.
+func (h *DashboardHandler) Stop() {
+	h.privCache.Stop()
+	h.basicCache.Stop()
 }
 
 // GetDashboard godoc
@@ -123,32 +131,41 @@ func (h *DashboardHandler) GetDashboard(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	clusters, err := h.buildClusterData(ctx, privileged)
+	val, err, _ := h.sfGroup.Do(cacheKey, func() (interface{}, error) {
+		// Re-check cache inside singleflight to avoid redundant work.
+		if cached, ok := cacheStore.Get(cacheKey); ok {
+			return cached, nil
+		}
+		return h.buildDashboard(ctx, privileged, cacheStore, cacheKey)
+	})
 	if err != nil {
-		slog.Error("dashboard: failed to build cluster data", "error", err)
+		slog.Error("dashboard: failed to build dashboard", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
 		return
+	}
+
+	c.JSON(http.StatusOK, val)
+}
+
+func (h *DashboardHandler) buildDashboard(ctx context.Context, privileged bool, cacheStore *cache.TTLCache[*DashboardResponse], cacheKey string) (*DashboardResponse, error) {
+	clusters, err := h.buildClusterData(ctx, privileged)
+	if err != nil {
+		return nil, err
 	}
 
 	recentDeploys, err := h.buildRecentDeployments(ctx)
 	if err != nil {
-		slog.Error("dashboard: failed to build recent deployments", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-		return
+		return nil, err
 	}
 
 	expiring, err := h.buildExpiringSoon()
 	if err != nil {
-		slog.Error("dashboard: failed to build expiring instances", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-		return
+		return nil, err
 	}
 
 	failing, err := h.buildFailingInstances()
 	if err != nil {
-		slog.Error("dashboard: failed to build failing instances", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
-		return
+		return nil, err
 	}
 
 	resp := &DashboardResponse{
@@ -159,7 +176,7 @@ func (h *DashboardHandler) GetDashboard(c *gin.Context) {
 	}
 
 	cacheStore.Set(cacheKey, resp)
-	c.JSON(http.StatusOK, resp)
+	return resp, nil
 }
 
 func (h *DashboardHandler) buildClusterData(ctx context.Context, privileged bool) ([]DashboardCluster, error) {
@@ -267,17 +284,14 @@ func (h *DashboardHandler) buildExpiringSoon() ([]DashboardExpiring, error) {
 }
 
 func (h *DashboardHandler) buildFailingInstances() ([]DashboardFailing, error) {
-	all, err := h.instanceRepo.List()
+	failing, err := h.instanceRepo.ListByStatus(models.StackStatusError, 50)
 	if err != nil {
 		return nil, err
 	}
 
-	var result []DashboardFailing
-	for _, inst := range all {
-		if inst.Status != models.StackStatusError {
-			continue
-		}
-		result = append(result, DashboardFailing{
+	result := make([]DashboardFailing, len(failing))
+	for i, inst := range failing {
+		result[i] = DashboardFailing{
 			ID:           inst.ID,
 			Name:         inst.Name,
 			Namespace:    inst.Namespace,
@@ -285,10 +299,7 @@ func (h *DashboardHandler) buildFailingInstances() ([]DashboardFailing, error) {
 			ErrorMessage: inst.ErrorMessage,
 			ClusterID:    inst.ClusterID,
 			UpdatedAt:    inst.UpdatedAt,
-		})
-	}
-	if result == nil {
-		result = []DashboardFailing{}
+		}
 	}
 	return result, nil
 }

--- a/backend/internal/api/handlers/dashboard_test.go
+++ b/backend/internal/api/handlers/dashboard_test.go
@@ -189,8 +189,8 @@ func TestDashboard_RecentDeployments(t *testing.T) {
 				Status:          models.DeployLogSuccess,
 				StartedAt:       now.Add(-5 * time.Minute),
 			},
-			InstanceName: "my-stack",
-			Username:     "alice",
+			InstanceName:  "my-stack",
+			OwnerUsername: "alice",
 		},
 	})
 
@@ -204,7 +204,7 @@ func TestDashboard_RecentDeployments(t *testing.T) {
 
 	require.Len(t, resp.RecentDeployments, 1)
 	assert.Equal(t, "my-stack", resp.RecentDeployments[0].InstanceName)
-	assert.Equal(t, "alice", resp.RecentDeployments[0].Username)
+	assert.Equal(t, "alice", resp.RecentDeployments[0].OwnerUsername)
 }
 
 func TestDashboard_ExpiringSoon(t *testing.T) {

--- a/backend/internal/api/handlers/dashboard_test.go
+++ b/backend/internal/api/handlers/dashboard_test.go
@@ -1,0 +1,326 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"backend/internal/models"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---- dashboard-specific deploy log mock ----
+
+type dashboardMockDeployLogRepo struct {
+	mu    sync.RWMutex
+	items []models.DeploymentLogWithContext
+	err   error
+}
+
+func (m *dashboardMockDeployLogRepo) Create(_ context.Context, _ *models.DeploymentLog) error {
+	return nil
+}
+func (m *dashboardMockDeployLogRepo) FindByID(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) Update(_ context.Context, _ *models.DeploymentLog) error {
+	return nil
+}
+func (m *dashboardMockDeployLogRepo) ListByInstance(_ context.Context, _ string) ([]models.DeploymentLog, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) ListByInstancePaginated(_ context.Context, _ models.DeploymentLogFilters) (*models.DeploymentLogResult, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) GetLatestByInstance(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) SummarizeByInstance(_ context.Context, _ string) (*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) SummarizeBatch(_ context.Context, _ []string) (map[string]*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (m *dashboardMockDeployLogRepo) CountByAction(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+
+func (m *dashboardMockDeployLogRepo) ListRecentGlobal(_ context.Context, limit int) ([]models.DeploymentLogWithContext, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	if limit <= 0 || limit > len(m.items) {
+		return m.items, nil
+	}
+	return m.items[:limit], nil
+}
+
+func (m *dashboardMockDeployLogRepo) setItems(items []models.DeploymentLogWithContext) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = items
+}
+
+func (m *dashboardMockDeployLogRepo) setError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+// ---- test helpers ----
+
+func setupDashboardRouter(
+	clusterRepo *MockClusterRepository,
+	instanceRepo *MockStackInstanceRepository,
+	deployLogRepo *dashboardMockDeployLogRepo,
+	role string,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectAuthContext("user-1", role))
+
+	h := NewDashboardHandler(clusterRepo, instanceRepo, deployLogRepo, nil)
+	defer h.Stop()
+
+	r.GET("/api/v1/dashboard", h.GetDashboard)
+	return r
+}
+
+func callDashboard(router *gin.Engine) *httptest.ResponseRecorder {
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// ---- tests ----
+
+func TestDashboard_EmptyState(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.Clusters)
+	assert.Empty(t, resp.RecentDeployments)
+	assert.Empty(t, resp.ExpiringSoon)
+	assert.Empty(t, resp.FailingInstances)
+}
+
+func TestDashboard_BasicUserGetsNoK8sMetrics(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	_ = clusterRepo.Create(&models.Cluster{ID: "c1", Name: "dev", HealthStatus: "healthy"})
+
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Clusters, 1)
+	assert.Equal(t, "dev", resp.Clusters[0].Name)
+	assert.Equal(t, "healthy", resp.Clusters[0].HealthStatus)
+	assert.Nil(t, resp.Clusters[0].NodeCount, "basic user should not see node metrics")
+}
+
+func TestDashboard_AdminGetsClusterData(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	_ = clusterRepo.Create(&models.Cluster{ID: "c1", Name: "prod", HealthStatus: "healthy"})
+
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	// Admin role, but no registry — so no enrichment, but still gets the cluster data
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "admin")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Clusters, 1)
+	assert.Equal(t, "prod", resp.Clusters[0].Name)
+}
+
+func TestDashboard_RecentDeployments(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	now := time.Now()
+	deployLogRepo.setItems([]models.DeploymentLogWithContext{
+		{
+			DeploymentLog: models.DeploymentLog{
+				ID:              "d1",
+				StackInstanceID: "i1",
+				Action:          "deploy",
+				Status:          "completed",
+				StartedAt:       now.Add(-5 * time.Minute),
+			},
+			InstanceName: "my-stack",
+			Username:     "alice",
+		},
+	})
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.RecentDeployments, 1)
+	assert.Equal(t, "my-stack", resp.RecentDeployments[0].InstanceName)
+	assert.Equal(t, "alice", resp.RecentDeployments[0].Username)
+}
+
+func TestDashboard_ExpiringSoon(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	expiresAt := time.Now().Add(30 * time.Minute)
+	_ = instanceRepo.Create(&models.StackInstance{
+		ID:         "i1",
+		Name:       "expiring-stack",
+		Namespace:  "ns-1",
+		Status:     models.StackStatusRunning,
+		ExpiresAt:  &expiresAt,
+		TTLMinutes: 60,
+	})
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.ExpiringSoon, 1)
+	assert.Equal(t, "expiring-stack", resp.ExpiringSoon[0].Name)
+}
+
+func TestDashboard_FailingInstances(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	_ = instanceRepo.Create(&models.StackInstance{
+		ID:           "i1",
+		Name:         "broken-stack",
+		Namespace:    "ns-1",
+		Status:       models.StackStatusError,
+		ErrorMessage: "helm install failed",
+	})
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DashboardResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.FailingInstances, 1)
+	assert.Equal(t, "broken-stack", resp.FailingInstances[0].Name)
+	assert.Equal(t, "helm install failed", resp.FailingInstances[0].ErrorMessage)
+}
+
+func TestDashboard_ClusterRepoError(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	clusterRepo.SetError(errors.New("db connection lost"))
+
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDashboard_PartialFailure_DeployLogs(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	_ = clusterRepo.Create(&models.Cluster{ID: "c1", Name: "dev", HealthStatus: "healthy"})
+
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+	deployLogRepo.setError(errors.New("deploy log query failed"))
+
+	router := setupDashboardRouter(clusterRepo, instanceRepo, deployLogRepo, "developer")
+	w := callDashboard(router)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestDashboard_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	clusterRepo := NewMockClusterRepository()
+	instanceRepo := NewMockStackInstanceRepository()
+	deployLogRepo := &dashboardMockDeployLogRepo{}
+
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.Use(injectAuthContext("user-1", "developer"))
+
+	h := NewDashboardHandler(clusterRepo, instanceRepo, deployLogRepo, nil)
+	defer h.Stop()
+	r.GET("/api/v1/dashboard", h.GetDashboard)
+
+	// First call populates cache
+	w1 := httptest.NewRecorder()
+	req1, _ := http.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	r.ServeHTTP(w1, req1)
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	// Inject error — second call should still succeed from cache
+	clusterRepo.SetError(errors.New("should not be called"))
+
+	w2 := httptest.NewRecorder()
+	req2, _ := http.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	r.ServeHTTP(w2, req2)
+	assert.Equal(t, http.StatusOK, w2.Code)
+	assert.Equal(t, w1.Body.String(), w2.Body.String())
+}

--- a/backend/internal/api/handlers/dashboard_test.go
+++ b/backend/internal/api/handlers/dashboard_test.go
@@ -145,7 +145,7 @@ func TestDashboard_BasicUserGetsNoK8sMetrics(t *testing.T) {
 
 	require.Len(t, resp.Clusters, 1)
 	assert.Equal(t, "dev", resp.Clusters[0].Name)
-	assert.Equal(t, "healthy", resp.Clusters[0].HealthStatus)
+	assert.Empty(t, resp.Clusters[0].HealthStatus, "basic user should not see health status")
 	assert.Nil(t, resp.Clusters[0].NodeCount, "basic user should not see node metrics")
 }
 
@@ -169,6 +169,7 @@ func TestDashboard_AdminGetsClusterData(t *testing.T) {
 
 	require.Len(t, resp.Clusters, 1)
 	assert.Equal(t, "prod", resp.Clusters[0].Name)
+	assert.Equal(t, "healthy", resp.Clusters[0].HealthStatus, "admin should see health status")
 }
 
 func TestDashboard_RecentDeployments(t *testing.T) {
@@ -185,7 +186,7 @@ func TestDashboard_RecentDeployments(t *testing.T) {
 				ID:              "d1",
 				StackInstanceID: "i1",
 				Action:          "deploy",
-				Status:          "completed",
+				Status:          models.DeployLogSuccess,
 				StartedAt:       now.Add(-5 * time.Minute),
 			},
 			InstanceName: "my-stack",

--- a/backend/internal/api/handlers/mock_domain_repositories_test.go
+++ b/backend/internal/api/handlers/mock_domain_repositories_test.go
@@ -1042,7 +1042,7 @@ func (m *MockStackInstanceRepository) ListIDsByOwnerIDs(ownerIDs []string) (map[
 	return result, nil
 }
 
-func (m *MockStackInstanceRepository) ListByStatus(status string, _ int) ([]*models.StackInstance, error) {
+func (m *MockStackInstanceRepository) ListByStatus(status string, limit int) ([]*models.StackInstance, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	if m.err != nil {
@@ -1053,6 +1053,12 @@ func (m *MockStackInstanceRepository) ListByStatus(status string, _ int) ([]*mod
 		if inst.Status == status {
 			result = append(result, inst)
 		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].UpdatedAt.After(result[j].UpdatedAt)
+	})
+	if limit > 0 && len(result) > limit {
+		result = result[:limit]
 	}
 	return result, nil
 }

--- a/backend/internal/api/handlers/mock_domain_repositories_test.go
+++ b/backend/internal/api/handlers/mock_domain_repositories_test.go
@@ -1042,6 +1042,21 @@ func (m *MockStackInstanceRepository) ListIDsByOwnerIDs(ownerIDs []string) (map[
 	return result, nil
 }
 
+func (m *MockStackInstanceRepository) ListByStatus(status string, _ int) ([]*models.StackInstance, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	var result []*models.StackInstance
+	for _, inst := range m.items {
+		if inst.Status == status {
+			result = append(result, inst)
+		}
+	}
+	return result, nil
+}
+
 func (m *MockStackInstanceRepository) SetError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/api/handlers/stack_instances_deploy_test.go
+++ b/backend/internal/api/handlers/stack_instances_deploy_test.go
@@ -180,6 +180,10 @@ func (m *MockDeploymentLogRepository) CountByAction(_ context.Context, _ string)
 	return 0, nil
 }
 
+func (m *MockDeploymentLogRepository) ListRecentGlobal(_ context.Context, _ int) ([]models.DeploymentLogWithContext, error) {
+	return nil, nil
+}
+
 func (m *MockDeploymentLogRepository) SetError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -68,6 +68,9 @@ type Deps struct {
 	Registry            *cluster.Registry
 	InstanceRepo        models.StackInstanceRepository
 
+	// Dashboard handler.
+	DashboardHandler *handlers.DashboardHandler
+
 	// Template version handler.
 	TemplateVersionHandler *handlers.TemplateVersionHandler
 
@@ -480,6 +483,11 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 				analytics.GET("/templates", deps.AnalyticsHandler.GetTemplateStats)
 				analytics.GET("/users", middleware.RequireAdmin(), deps.AnalyticsHandler.GetUserStats)
 			}
+		}
+
+		// Dashboard overview (all authenticated users)
+		if deps.DashboardHandler != nil {
+			authed.GET("/dashboard", deps.DashboardHandler.GetDashboard)
 		}
 
 		// Notifications

--- a/backend/internal/cluster/secret_refresher_test.go
+++ b/backend/internal/cluster/secret_refresher_test.go
@@ -49,6 +49,7 @@ func (m *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 func (m *mockInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) { return false, nil }
 func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error)                        { return nil, nil }
 func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) { return nil, nil }
+func (m *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error)     { return nil, nil }
 
 func TestSecretRefresher_RefreshesRunningInstances(t *testing.T) {
 	t.Parallel()

--- a/backend/internal/database/deployment_log_repository.go
+++ b/backend/internal/database/deployment_log_repository.go
@@ -317,14 +317,14 @@ func (r *GORMDeploymentLogRepository) ListRecentGlobal(ctx context.Context, limi
 
 	type row struct {
 		models.DeploymentLog
-		InstanceName string `gorm:"column:instance_name"`
-		Username     string `gorm:"column:username"`
+		InstanceName  string `gorm:"column:instance_name"`
+		OwnerUsername string `gorm:"column:owner_username"`
 	}
 
 	var rows []row
 	err := r.db.WithContext(ctx).
 		Table("deployment_logs dl").
-		Select("dl.id, dl.stack_instance_id, dl.action, dl.status, dl.started_at, dl.completed_at, dl.error_message, COALESCE(si.name, '(deleted)') AS instance_name, COALESCE(u.username, '(unknown)') AS username").
+		Select("dl.id, dl.stack_instance_id, dl.action, dl.status, dl.started_at, dl.completed_at, dl.error_message, COALESCE(si.name, '(deleted)') AS instance_name, COALESCE(u.username, '(unknown)') AS owner_username").
 		Joins("LEFT JOIN stack_instances si ON dl.stack_instance_id = si.id").
 		Joins("LEFT JOIN users u ON si.owner_id = u.id").
 		Order("dl.started_at DESC").
@@ -339,7 +339,7 @@ func (r *GORMDeploymentLogRepository) ListRecentGlobal(ctx context.Context, limi
 		result[i] = models.DeploymentLogWithContext{
 			DeploymentLog: r.DeploymentLog,
 			InstanceName:  r.InstanceName,
-			Username:      r.Username,
+			OwnerUsername: r.OwnerUsername,
 		}
 	}
 	return result, nil

--- a/backend/internal/database/deployment_log_repository.go
+++ b/backend/internal/database/deployment_log_repository.go
@@ -324,9 +324,9 @@ func (r *GORMDeploymentLogRepository) ListRecentGlobal(ctx context.Context, limi
 	var rows []row
 	err := r.db.WithContext(ctx).
 		Table("deployment_logs dl").
-		Select("dl.*, si.name AS instance_name, u.username AS username").
-		Joins("JOIN stack_instances si ON dl.stack_instance_id = si.id").
-		Joins("JOIN users u ON si.owner_id = u.id").
+		Select("dl.id, dl.stack_instance_id, dl.action, dl.status, dl.started_at, dl.completed_at, dl.error_message, COALESCE(si.name, '(deleted)') AS instance_name, COALESCE(u.username, '(unknown)') AS username").
+		Joins("LEFT JOIN stack_instances si ON dl.stack_instance_id = si.id").
+		Joins("LEFT JOIN users u ON si.owner_id = u.id").
 		Order("dl.started_at DESC").
 		Limit(limit).
 		Find(&rows).Error

--- a/backend/internal/database/deployment_log_repository.go
+++ b/backend/internal/database/deployment_log_repository.go
@@ -308,6 +308,43 @@ func (r *GORMDeploymentLogRepository) summarizeBatchChunk(
 	return nil
 }
 
+// ListRecentGlobal returns the most recent deployment log entries across all
+// instances, enriched with instance name and owner username via a 3-table JOIN.
+func (r *GORMDeploymentLogRepository) ListRecentGlobal(ctx context.Context, limit int) ([]models.DeploymentLogWithContext, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	type row struct {
+		models.DeploymentLog
+		InstanceName string `gorm:"column:instance_name"`
+		Username     string `gorm:"column:username"`
+	}
+
+	var rows []row
+	err := r.db.WithContext(ctx).
+		Table("deployment_logs dl").
+		Select("dl.*, si.name AS instance_name, u.username AS username").
+		Joins("JOIN stack_instances si ON dl.stack_instance_id = si.id").
+		Joins("JOIN users u ON si.owner_id = u.id").
+		Order("dl.started_at DESC").
+		Limit(limit).
+		Find(&rows).Error
+	if err != nil {
+		return nil, dberrors.NewDatabaseError("list_recent_global", err)
+	}
+
+	result := make([]models.DeploymentLogWithContext, len(rows))
+	for i, r := range rows {
+		result[i] = models.DeploymentLogWithContext{
+			DeploymentLog: r.DeploymentLog,
+			InstanceName:  r.InstanceName,
+			Username:      r.Username,
+		}
+	}
+	return result, nil
+}
+
 // CountByAction returns the total number of deployment log entries with the
 // given action within the last 90 days (matching the SummarizeByInstance cutoff).
 func (r *GORMDeploymentLogRepository) CountByAction(ctx context.Context, action string) (int, error) {

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -875,6 +875,26 @@ func (d *Database) AutoMigrate() error {
 		},
 	})
 
+	// Migration 36: Add index on deployment_logs(started_at DESC) for dashboard global query
+	migrator.AddMigration(schema.Migration{
+		Version:     "20260507000036",
+		Name:        "add_deployment_logs_started_at_index",
+		Description: "Add index on deployment_logs(started_at DESC) for ListRecentGlobal dashboard query",
+		Up: func(tx *gorm.DB) error {
+			var count int64
+			tx.Raw("SELECT COUNT(1) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?",
+				"deployment_logs", "idx_deployment_logs_started_at").Scan(&count)
+			if count > 0 {
+				return nil
+			}
+			return tx.Exec("CREATE INDEX idx_deployment_logs_started_at ON deployment_logs(started_at DESC)").Error
+		},
+		Down: func(tx *gorm.DB) error {
+			_ = tx.Exec("DROP INDEX idx_deployment_logs_started_at ON deployment_logs").Error
+			return nil
+		},
+	})
+
 	// Run migrations
 	if err := migrator.MigrateUp(); err != nil {
 		return err

--- a/backend/internal/database/stack_instance_repository.go
+++ b/backend/internal/database/stack_instance_repository.go
@@ -211,6 +211,7 @@ func (r *GORMStackInstanceRepository) ListExpiringSoon(threshold time.Duration) 
 	var instances []*models.StackInstance
 	if err := r.db.Where("status IN ? AND expires_at IS NOT NULL AND expires_at > ? AND expires_at <= ?",
 		[]string{models.StackStatusRunning, models.StackStatusPartial}, now, deadline).
+		Order("expires_at ASC").
 		Find(&instances).Error; err != nil {
 		return nil, dberrors.NewDatabaseError("list_expiring_soon", err)
 	}
@@ -221,7 +222,7 @@ func (r *GORMStackInstanceRepository) ListExpiringSoon(threshold time.Duration) 
 // A limit <= 0 returns all matching rows.
 func (r *GORMStackInstanceRepository) ListByStatus(status string, limit int) ([]*models.StackInstance, error) {
 	var instances []*models.StackInstance
-	q := r.db.Where("status = ?", status)
+	q := r.db.Where("status = ?", status).Order("updated_at DESC")
 	if limit > 0 {
 		q = q.Limit(limit)
 	}

--- a/backend/internal/database/stack_instance_repository.go
+++ b/backend/internal/database/stack_instance_repository.go
@@ -217,6 +217,20 @@ func (r *GORMStackInstanceRepository) ListExpiringSoon(threshold time.Duration) 
 	return instances, nil
 }
 
+// ListByStatus returns instances with the given status, up to limit rows.
+// A limit <= 0 returns all matching rows.
+func (r *GORMStackInstanceRepository) ListByStatus(status string, limit int) ([]*models.StackInstance, error) {
+	var instances []*models.StackInstance
+	q := r.db.Where("status = ?", status)
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if err := q.Find(&instances).Error; err != nil {
+		return nil, dberrors.NewDatabaseError("list_by_status", err)
+	}
+	return instances, nil
+}
+
 // CountByDefinitionIDs returns a map of definition ID to instance count for the
 // given definition IDs in a single GROUP BY query. IDs are processed in chunks
 // of 500 to stay within MySQL's IN clause limits.

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -294,6 +294,10 @@ func (m *mockDeployLogRepo) CountByAction(_ context.Context, _ string) (int, err
 	return 0, nil
 }
 
+func (m *mockDeployLogRepo) ListRecentGlobal(_ context.Context, _ int) ([]models.DeploymentLogWithContext, error) {
+	return nil, nil
+}
+
 // ---- txRunner mock ----
 
 // mockTxRunner implements database.TxRunner by calling fn with TxRepos

--- a/backend/internal/deployer/manager_test.go
+++ b/backend/internal/deployer/manager_test.go
@@ -159,6 +159,9 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
 	return nil, nil
 }
+func (m *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 func (m *mockInstanceRepo) setError(err error) {
 	m.mu.Lock()

--- a/backend/internal/k8s/watcher_test.go
+++ b/backend/internal/k8s/watcher_test.go
@@ -149,6 +149,9 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
 	return nil, nil
 }
+func (m *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 func (m *mockInstanceRepo) getStatus(id string) string {
 	m.mu.RLock()

--- a/backend/internal/models/deployment_log.go
+++ b/backend/internal/models/deployment_log.go
@@ -60,6 +60,14 @@ type DeployLogSummary struct {
 	ErrorCount   int
 }
 
+// DeploymentLogWithContext extends DeploymentLog with denormalized instance
+// and user fields, populated via JOIN to avoid N+1 queries.
+type DeploymentLogWithContext struct {
+	DeploymentLog
+	InstanceName string `json:"instance_name"`
+	Username     string `json:"username"`
+}
+
 // DeploymentLogRepository defines data access operations for deployment logs.
 type DeploymentLogRepository interface {
 	Create(ctx context.Context, log *DeploymentLog) error
@@ -71,4 +79,5 @@ type DeploymentLogRepository interface {
 	SummarizeByInstance(ctx context.Context, instanceID string) (*DeployLogSummary, error)
 	SummarizeBatch(ctx context.Context, instanceIDs []string) (map[string]*DeployLogSummary, error)
 	CountByAction(ctx context.Context, action string) (int, error)
+	ListRecentGlobal(ctx context.Context, limit int) ([]DeploymentLogWithContext, error)
 }

--- a/backend/internal/models/deployment_log.go
+++ b/backend/internal/models/deployment_log.go
@@ -64,8 +64,8 @@ type DeployLogSummary struct {
 // and user fields, populated via JOIN to avoid N+1 queries.
 type DeploymentLogWithContext struct {
 	DeploymentLog
-	InstanceName string `json:"instance_name"`
-	Username     string `json:"username"`
+	InstanceName  string `json:"instance_name"`
+	OwnerUsername string `json:"owner_username"`
 }
 
 // DeploymentLogRepository defines data access operations for deployment logs.

--- a/backend/internal/models/stack_instance.go
+++ b/backend/internal/models/stack_instance.go
@@ -57,4 +57,5 @@ type StackInstanceRepository interface {
 	ExistsByDefinitionAndStatus(definitionID, status string) (bool, error)
 	ListExpired() ([]*StackInstance, error)
 	ListExpiringSoon(threshold time.Duration) ([]*StackInstance, error)
+	ListByStatus(status string, limit int) ([]*StackInstance, error)
 }

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -132,6 +132,9 @@ func (r *mockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, e
 	return nil, nil
 }
 func (r *mockInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) { return nil, nil }
+func (r *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 // mockAuditRepo is a minimal in-memory mock for AuditLogRepository.
 type mockAuditRepo struct {

--- a/backend/internal/ttl/reaper_test.go
+++ b/backend/internal/ttl/reaper_test.go
@@ -106,6 +106,9 @@ func (m *mockInstanceRepo) ListExpired() ([]*models.StackInstance, error) {
 func (m *mockInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
 	return nil, nil
 }
+func (m *mockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
 
 func (m *mockInstanceRepo) get(id string) *models.StackInstance {
 	m.mu.RLock()

--- a/backend/internal/ttl/warner_test.go
+++ b/backend/internal/ttl/warner_test.go
@@ -120,7 +120,8 @@ func (m *warnerMockInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]str
 func (m *warnerMockInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) {
 	return false, nil
 }
-func (m *warnerMockInstanceRepo) ListExpired() ([]*models.StackInstance, error) { return nil, nil }
+func (m *warnerMockInstanceRepo) ListExpired() ([]*models.StackInstance, error)          { return nil, nil }
+func (m *warnerMockInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) { return nil, nil }
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,9 @@ services:
       - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-otel-collector:4317}
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-k8s-stack-manager}
       - OTEL_TRACE_SAMPLE_RATE=${OTEL_TRACE_SAMPLE_RATE:-1.0}
-      # Rate limiting (req/min per IP; override with RATE_LIMIT env var)
-      - RATE_LIMIT=${RATE_LIMIT:-100}
+      # Rate limiting (req/min per IP; override with RATE_LIMIT / LOGIN_RATE_LIMIT env vars)
+      - RATE_LIMIT=${RATE_LIMIT:-1000}
+      - LOGIN_RATE_LIMIT=${LOGIN_RATE_LIMIT:-1000}
       # Swagger UI (enabled for dev)
       - ENABLE_SWAGGER=${ENABLE_SWAGGER:-true}
       # Stack defaults

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,8 +69,8 @@ services:
       - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-k8s-stack-manager}
       - OTEL_TRACE_SAMPLE_RATE=${OTEL_TRACE_SAMPLE_RATE:-1.0}
       # Rate limiting (req/min per IP; override with RATE_LIMIT / LOGIN_RATE_LIMIT env vars)
-      - RATE_LIMIT=${RATE_LIMIT:-1000}
-      - LOGIN_RATE_LIMIT=${LOGIN_RATE_LIMIT:-1000}
+      - RATE_LIMIT=${RATE_LIMIT:-100}
+      - LOGIN_RATE_LIMIT=${LOGIN_RATE_LIMIT:-10}
       # Swagger UI (enabled for dev)
       - ENABLE_SWAGGER=${ENABLE_SWAGGER:-true}
       # Stack defaults

--- a/frontend/e2e/dashboard-widgets.spec.ts
+++ b/frontend/e2e/dashboard-widgets.spec.ts
@@ -1,0 +1,551 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginAsAdmin,
+  loginAsUser,
+  uniqueName,
+  API_BASE,
+  ADMIN_PASSWORD,
+  ensureDefaultCluster,
+  deleteCluster,
+} from './helpers';
+
+async function apiLogin(request: import('@playwright/test').APIRequestContext): Promise<string> {
+  let res;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    res = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { username: 'admin', password: ADMIN_PASSWORD },
+    });
+    if (res.status() !== 429) break;
+    await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+  }
+  expect(res!.ok(), `apiLogin failed with status ${res!.status()}`).toBe(true);
+  return (await res!.json()).token;
+}
+
+async function apiCreateDefinition(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  name: string,
+): Promise<string> {
+  const res = await request.post(`${API_BASE}/api/v1/stack-definitions`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data: { name, description: 'e2e dashboard widget test', default_branch: 'main' },
+  });
+  expect(res.ok(), `apiCreateDefinition failed: ${res.status()}`).toBe(true);
+  return (await res.json()).id;
+}
+
+async function apiCreateInstance(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  definitionId: string,
+  name: string,
+  ttlMinutes?: number,
+): Promise<string> {
+  const data: Record<string, unknown> = {
+    stack_definition_id: definitionId,
+    name,
+    branch: 'main',
+  };
+  if (ttlMinutes != null) data.ttl_minutes = ttlMinutes;
+  const res = await request.post(`${API_BASE}/api/v1/stack-instances`, {
+    headers: { Authorization: `Bearer ${token}` },
+    data,
+  });
+  const body = await res.json();
+  expect(res.ok(), `apiCreateInstance failed: ${res.status()} ${JSON.stringify(body)}`).toBe(true);
+  return body.id;
+}
+
+async function apiDeleteInstance(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  instanceId: string,
+): Promise<void> {
+  await request.delete(`${API_BASE}/api/v1/stack-instances/${instanceId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function apiDeleteDefinition(
+  request: import('@playwright/test').APIRequestContext,
+  token: string,
+  defId: string,
+): Promise<void> {
+  await request.delete(`${API_BASE}/api/v1/stack-definitions/${defId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+function accordionHeader(page: import('@playwright/test').Page, label: string) {
+  return page.locator('.MuiAccordion-root .MuiAccordionSummary-root', { hasText: label });
+}
+
+function accordion(page: import('@playwright/test').Page, label: string) {
+  return page.locator('.MuiAccordion-root', { has: page.locator('.MuiAccordionSummary-content', { hasText: label }) });
+}
+
+// Use test.describe.configure to run all describes in this file serially
+// to avoid hammering the login endpoint with parallel beforeAll calls.
+test.describe.configure({ mode: 'serial' });
+
+// ---------------------------------------------------------------------------
+// Dashboard widget structure tests
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Structure', () => {
+  let clusterId: string | null;
+
+  test.beforeAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAsAdmin(page);
+  });
+
+  test('all four widget accordions render on the dashboard', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: 'Stack Instances' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(accordionHeader(page, 'Cluster Health')).toBeVisible({ timeout: 10_000 });
+    await expect(accordionHeader(page, 'Recent Deployments')).toBeVisible();
+    await expect(accordionHeader(page, 'Expiring Soon')).toBeVisible();
+    await expect(accordionHeader(page, 'Failing Instances')).toBeVisible();
+  });
+
+  test('cluster health widget shows registered cluster', async ({ page }) => {
+    await page.goto('/');
+
+    const widget = accordion(page, 'Cluster Health');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    // Count chip should show at least 1
+    const countChip = widget.locator('.MuiAccordionSummary-content .MuiChip-root');
+    await expect(countChip).toBeVisible({ timeout: 10_000 });
+
+    // Cluster card with health chip
+    await expect(widget.locator('.MuiCard-root').first()).toBeVisible({ timeout: 10_000 });
+    await expect(widget.locator('.MuiCard-root .MuiChip-root').first()).toBeVisible();
+  });
+
+  test('recent deployments table has correct column headers or empty state', async ({ page }) => {
+    await page.goto('/');
+
+    const widget = accordion(page, 'Recent Deployments');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    const hasTable = await widget.locator('table').isVisible().catch(() => false);
+    if (hasTable) {
+      await expect(page.getByRole('columnheader', { name: 'Instance' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Action' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'User' })).toBeVisible();
+      await expect(page.getByRole('columnheader', { name: 'When' })).toBeVisible();
+    } else {
+      await expect(widget.getByText('No recent deployments.')).toBeVisible();
+    }
+  });
+
+  test('expiring soon widget shows empty state or instance list', async ({ page }) => {
+    await page.goto('/');
+
+    const widget = accordion(page, 'Expiring Soon');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    // Either empty state text or at least one Extend TTL button
+    const emptyText = widget.getByText('No instances expiring soon.');
+    const extendBtn = widget.getByRole('button', { name: 'Extend TTL' }).first();
+    await expect(emptyText.or(extendBtn)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('failing instances widget shows empty state or error list', async ({ page }) => {
+    await page.goto('/');
+
+    const widget = accordion(page, 'Failing Instances');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    // Either empty state text or at least one failing instance link
+    const emptyText = widget.getByText('No failing instances.');
+    const anyLink = widget.locator('.MuiAccordionDetails-root a').first();
+    await expect(emptyText.or(anyLink)).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('widgets render above the instance list', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1, name: 'Stack Instances' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const widgetBox = page.locator('.MuiAccordion-root').first();
+    const searchBar = page.getByPlaceholder('Search instances...');
+    await expect(widgetBox).toBeVisible({ timeout: 10_000 });
+    await expect(searchBar).toBeVisible();
+
+    const widgetY = (await widgetBox.boundingBox())!.y;
+    const searchY = (await searchBar.boundingBox())!.y;
+    expect(widgetY).toBeLessThan(searchY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Collapse persistence
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Collapse Persistence', () => {
+  let clusterId: string | null;
+
+  test.beforeAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test('collapsed state persists across page navigation', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const widget = accordion(page, 'Cluster Health');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    // Collapse the Cluster Health accordion
+    await widget.locator('.MuiAccordionSummary-root').click();
+    await expect(widget.locator('.MuiAccordionDetails-root')).toBeHidden({ timeout: 5_000 });
+
+    // Navigate away and back
+    await page.goto('/about');
+    await page.goto('/');
+    await expect(accordion(page, 'Cluster Health')).toBeVisible({ timeout: 10_000 });
+
+    // Cluster Health should still be collapsed
+    await expect(
+      accordion(page, 'Cluster Health').locator('.MuiAccordionDetails-root'),
+    ).toBeHidden();
+
+    // Recent Deployments should still be expanded
+    await expect(
+      accordion(page, 'Recent Deployments').locator('.MuiAccordionDetails-root'),
+    ).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Expiring soon widget — create an instance with short TTL
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Expiring Soon', () => {
+  let token: string;
+  let clusterId: string | null;
+  let defId: string;
+  let instanceId: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+
+    const defName = uniqueName('e2e-dash-exp-def');
+    defId = await apiCreateDefinition(request, token, defName);
+
+    const instName = uniqueName('e2e-expiring');
+    instanceId = await apiCreateInstance(request, token, defId, instName, 60);
+
+    // Deploy so it transitions to a running state with TTL active.
+    // Without deployer/charts configured this returns 503/400 and the test will skip.
+    const deployRes = await request.post(`${API_BASE}/api/v1/stack-instances/${instanceId}/deploy`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (deployRes.status() === 202) {
+      await new Promise((r) => setTimeout(r, 2000));
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    await apiDeleteInstance(request, token, instanceId);
+    await apiDeleteDefinition(request, token, defId);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test('expiring instance appears with Extend TTL button', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    // ListExpiringSoon only returns running/partial instances.
+    // Without real k8s/Helm the deploy fails and the instance stays in error/draft.
+    const instRes = await page.request.get(`${API_BASE}/api/v1/stack-instances/${instanceId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const inst = await instRes.json();
+    if (inst.status !== 'running' && inst.status !== 'partial') {
+      test.skip(true, `Instance is "${inst.status}", not running/partial — needs real k8s`);
+      return;
+    }
+
+    await page.goto('/');
+
+    const widget = accordion(page, 'Expiring Soon');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    await expect(async () => {
+      await page.reload();
+      await expect(widget.getByText(/e2e-expiring/)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 30_000 });
+
+    await expect(page.getByRole('button', { name: 'Extend TTL' }).first()).toBeVisible();
+  });
+
+  test('Extend TTL button works without error', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const instRes = await page.request.get(`${API_BASE}/api/v1/stack-instances/${instanceId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const inst = await instRes.json();
+    if (inst.status !== 'running' && inst.status !== 'partial') {
+      test.skip(true, `Instance is "${inst.status}", not running/partial — needs real k8s`);
+      return;
+    }
+
+    await page.goto('/');
+
+    const widget = accordion(page, 'Expiring Soon');
+
+    await expect(async () => {
+      await page.reload();
+      await expect(widget.getByText(/e2e-expiring/)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 30_000 });
+
+    await page.getByRole('button', { name: 'Extend TTL' }).first().click();
+
+    // No error toast should appear
+    await expect(page.getByText(/Failed to extend TTL/)).not.toBeVisible({ timeout: 5_000 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failing instances widget — deploy to trigger an error state
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Failing Instances', () => {
+  let token: string;
+  let clusterId: string | null;
+  let defId: string;
+  let instanceId: string;
+
+  test.beforeAll(async ({ request }) => {
+    token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+
+    const defName = uniqueName('e2e-dash-fail-def');
+    defId = await apiCreateDefinition(request, token, defName);
+
+    const instName = uniqueName('e2e-failing');
+    instanceId = await apiCreateInstance(request, token, defId, instName);
+
+    // Deploy — without real k8s/Helm this should fail and put instance in error state.
+    // If deployer isn't configured (503/400), no state change occurs and the test will skip.
+    const deployRes = await request.post(`${API_BASE}/api/v1/stack-instances/${instanceId}/deploy`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (deployRes.status() === 202) {
+      await new Promise((r) => setTimeout(r, 5000));
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    await apiDeleteInstance(request, token, instanceId);
+    await apiDeleteDefinition(request, token, defId);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test('failing instance appears in widget with error badge', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    // Check if instance actually ended up in error state
+    const instRes = await page.request.get(`${API_BASE}/api/v1/stack-instances/${instanceId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const inst = await instRes.json();
+    if (inst.status !== 'error') {
+      test.skip(true, 'Instance did not reach error state');
+      return;
+    }
+
+    await page.goto('/');
+    const widget = accordion(page, 'Failing Instances');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    await expect(async () => {
+      await page.reload();
+      await expect(widget.getByText(/e2e-failing/)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 30_000 });
+
+    // Link to instance detail
+    const link = widget.getByRole('link', { name: /e2e-failing/ });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', `/stack-instances/${instanceId}`);
+
+    // Error-colored count badge
+    const badge = widget
+      .locator('.MuiAccordionSummary-content')
+      .locator('.MuiChip-colorError');
+    await expect(badge).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recent deployments widget — trigger a deploy and verify it appears
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Recent Deployments', () => {
+  let token: string;
+  let clusterId: string | null;
+  let defId: string;
+  let instanceId: string;
+  let deployAccepted = false;
+
+  test.beforeAll(async ({ request }) => {
+    token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+
+    const defName = uniqueName('e2e-dash-deploy-def');
+    defId = await apiCreateDefinition(request, token, defName);
+
+    const instName = uniqueName('e2e-deployed');
+    instanceId = await apiCreateInstance(request, token, defId, instName);
+
+    // Trigger a deploy so a deployment log entry exists.
+    // Returns 503 if deployer not configured, 400 if no charts — in those cases
+    // no log entry is created and the tests should skip.
+    const deployRes = await request.post(`${API_BASE}/api/v1/stack-instances/${instanceId}/deploy`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    deployAccepted = deployRes.status() === 202;
+    if (deployAccepted) {
+      await new Promise((r) => setTimeout(r, 3000));
+    }
+  });
+
+  test.afterAll(async ({ request }) => {
+    await apiDeleteInstance(request, token, instanceId);
+    await apiDeleteDefinition(request, token, defId);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test('deployment entry appears with correct columns', async ({ page }) => {
+    if (!deployAccepted) {
+      test.skip(true, 'Deploy returned non-202 — no deployment log created');
+      return;
+    }
+
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const widget = accordion(page, 'Recent Deployments');
+    await expect(widget).toBeVisible({ timeout: 10_000 });
+
+    await expect(async () => {
+      await page.reload();
+      await expect(widget.locator('table')).toBeVisible({ timeout: 5_000 });
+      await expect(widget.getByText(/e2e-deployed/)).toBeVisible({ timeout: 3_000 });
+    }).toPass({ timeout: 30_000 });
+
+    // Table headers
+    await expect(page.getByRole('columnheader', { name: 'Instance' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Action' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'User' })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: 'When' })).toBeVisible();
+
+    // Instance link
+    const instLink = widget.getByRole('link', { name: /e2e-deployed/ });
+    await expect(instLink).toBeVisible();
+    await expect(instLink).toHaveAttribute('href', `/stack-instances/${instanceId}`);
+
+    // Action chip
+    await expect(widget.locator('.MuiChip-outlined', { hasText: 'deploy' })).toBeVisible();
+
+    // Status chip (success or error depending on env)
+    const row = widget.locator('table tbody tr', { hasText: /e2e-deployed/ });
+    await expect(row.locator('.MuiChip-filled')).toBeVisible();
+  });
+
+  test('deployment instance link navigates to detail page', async ({ page }) => {
+    if (!deployAccepted) {
+      test.skip(true, 'Deploy returned non-202 — no deployment log created');
+      return;
+    }
+
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const widget = accordion(page, 'Recent Deployments');
+    await expect(async () => {
+      await page.reload();
+      await expect(widget.getByText(/e2e-deployed/)).toBeVisible({ timeout: 5_000 });
+    }).toPass({ timeout: 30_000 });
+
+    await widget.getByRole('link', { name: /e2e-deployed/ }).click();
+    await page.waitForURL(`/stack-instances/${instanceId}`, { timeout: 10_000 });
+    await expect(page.getByRole('heading', { level: 1, name: /e2e-deployed/ })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Role-based visibility
+// ---------------------------------------------------------------------------
+test.describe('Dashboard Widgets - Role-Based Visibility', () => {
+  let clusterId: string | null;
+
+  test.beforeAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    clusterId = await ensureDefaultCluster(request, token);
+  });
+
+  test.afterAll(async ({ request }) => {
+    const token = await apiLogin(request);
+    await deleteCluster(request, token, clusterId);
+  });
+
+  test('admin sees cluster card with health chip', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.goto('/');
+
+    const widget = accordion(page, 'Cluster Health');
+    const card = widget.locator('.MuiCard-root').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Admin should see health chip (healthy/degraded/unreachable/unknown)
+    await expect(card.locator('.MuiChip-root')).toBeVisible();
+
+    // Node metrics are only populated when the cluster is reachable.
+    // Verify they're present if the cluster is reachable, skip assertion otherwise.
+    const nodesText = card.getByText(/Nodes:/);
+    const nodesVisible = await nodesText.isVisible().catch(() => false);
+    if (nodesVisible) {
+      await expect(card.getByText(/CPU:/)).toBeVisible();
+      await expect(card.getByText(/Memory:/)).toBeVisible();
+    }
+  });
+
+  test('regular user sees cluster card without node metrics', async ({ page }) => {
+    await loginAsUser(page);
+    await page.goto('/');
+
+    const widget = accordion(page, 'Cluster Health');
+    const card = widget.locator('.MuiCard-root').first();
+    await expect(card).toBeVisible({ timeout: 10_000 });
+
+    // Regular user should see the health chip showing "unknown" (backend strips health_status)
+    await expect(card.locator('.MuiChip-root')).toBeVisible();
+
+    // Regular user should NOT see node metrics (backend strips them for non-privileged)
+    await expect(card.getByText(/Nodes:/)).toBeHidden();
+  });
+});

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -147,19 +147,18 @@ describe('templateService', () => {
 
   it('get merges template with charts from response', async () => {
     const api = mockApi;
-    const template = { id: '1', name: 'tmpl-1' };
     const charts = [{ id: 'c1', chart_name: 'nginx' }];
-    api.get.mockResolvedValueOnce(mockResponse({ template, charts }));
+    api.get.mockResolvedValueOnce(mockResponse({ id: '1', name: 'tmpl-1', charts }));
 
     const result = await templateService.get('1');
 
     expect(api.get).toHaveBeenCalledWith('/api/v1/templates/1');
-    expect(result).toEqual({ ...template, charts });
+    expect(result).toEqual({ id: '1', name: 'tmpl-1', charts });
   });
 
   it('get defaults charts to empty array when null', async () => {
     const api = mockApi;
-    api.get.mockResolvedValueOnce(mockResponse({ template: { id: '1' }, charts: null }));
+    api.get.mockResolvedValueOnce(mockResponse({ id: '1', charts: null }));
 
     const result = await templateService.get('1');
 
@@ -770,7 +769,7 @@ describe('clusterService', () => {
 describe('gitService', () => {
   it('branches sends GET with repo param', async () => {
     const api = mockApi;
-    const branches = ['main', 'develop', 'feature/x'];
+    const branches = [{ name: 'main' }, { name: 'develop' }, { name: 'feature/x' }];
     api.get.mockResolvedValueOnce(mockResponse(branches));
 
     const result = await gitService.branches('https://dev.azure.com/org/proj/_git/repo');
@@ -778,7 +777,7 @@ describe('gitService', () => {
     expect(api.get).toHaveBeenCalledWith('/api/v1/git/branches', {
       params: { repo: 'https://dev.azure.com/org/proj/_git/repo' },
     });
-    expect(result).toEqual(branches);
+    expect(result).toEqual(['main', 'develop', 'feature/x']);
   });
 
   it('branches throws on error', async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2072,8 +2072,13 @@ export const dashboardService = {
    * @see GET /api/v1/dashboard
    */
   getOverview: async (): Promise<DashboardResponse> => {
-    const response = await api.get('/api/v1/dashboard');
-    return response.data;
+    try {
+      const response = await api.get('/api/v1/dashboard');
+      return response.data;
+    } catch (error) {
+      console.error('Failed to fetch dashboard overview:', error);
+      throw error;
+    }
   },
 };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -54,6 +54,7 @@ import type {
   UpgradeCheckResponse,
   InstanceQuotaOverride,
   DeployPreviewResponse,
+  DashboardResponse,
 } from '../types';
 
 // Extend Axios config to include our retry flag (avoids `any` cast).
@@ -1217,7 +1218,7 @@ export const gitService = {
   branches: async (repoUrl: string): Promise<string[]> => {
     try {
       const response = await api.get('/api/v1/git/branches', { params: { repo: repoUrl } });
-      return response.data;
+      return response.data.map((b: { name: string }) => b.name);
     } catch (error) {
       console.error('Failed to fetch branches:', error);
       throw error;
@@ -2060,6 +2061,13 @@ export const notificationService = {
       console.error('Failed to update notification preferences:', error);
       throw error;
     }
+  },
+};
+
+export const dashboardService = {
+  getOverview: async (): Promise<DashboardResponse> => {
+    const response = await api.get('/api/v1/dashboard');
+    return response.data;
   },
 };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -307,7 +307,7 @@ export const templateService = {
   get: async (id: string): Promise<StackTemplate> => {
     try {
       const response = await api.get(`/api/v1/templates/${id}`);
-      const { template, charts } = response.data;
+      const { charts, ...template } = response.data;
       return { ...template, charts: charts || [] };
     } catch (error) {
       console.error('Failed to fetch template:', error);
@@ -2064,7 +2064,13 @@ export const notificationService = {
   },
 };
 
+/** Dashboard overview service. Maps to `/api/v1/dashboard`. */
 export const dashboardService = {
+  /**
+   * Fetch aggregated dashboard overview data (cluster health, recent deploys, expiring/failing instances).
+   * @returns Dashboard overview with all widget data
+   * @see GET /api/v1/dashboard
+   */
   getOverview: async (): Promise<DashboardResponse> => {
     const response = await api.get('/api/v1/dashboard');
     return response.data;

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -38,6 +38,7 @@ import CompareArrowsIcon from '@mui/icons-material/CompareArrows';
 import StatusBadge from '../../components/StatusBadge';
 import FavoriteButton from '../../components/FavoriteButton';
 import ExpiryChip from './ExpiryChip';
+import DashboardWidgets from './widgets/DashboardWidgets';
 import { instanceService, clusterService, favoriteService } from '../../api/client';
 import type { StackInstance, Cluster, NamespaceStatus, UserFavorite, BulkOperationResponse } from '../../types';
 import LoadingState from '../../components/LoadingState';
@@ -502,6 +503,8 @@ const Dashboard = () => {
         </Box>
       </Box>
 
+      <DashboardWidgets />
+
       <Box sx={{ display: 'flex', gap: 2, mb: 3, alignItems: 'center', flexWrap: 'wrap' }}>
         <TextField
           size="small"
@@ -676,28 +679,6 @@ const Dashboard = () => {
             ))}
           </Box>
         </Box>
-      )}
-
-      {clusters.length > 0 && (
-        <Paper variant="outlined" sx={{ p: 1.5, mb: 3, display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap' }}>
-          <Typography variant="body2" color="text.secondary">
-            {clusters.length} cluster{clusters.length === 1 ? '' : 's'}:
-          </Typography>
-          {(['healthy', 'degraded', 'unreachable'] as const).map((status) => {
-            const count = clusters.filter((c) => c.health_status === status).length;
-            if (count === 0) return null;
-            const clusterStatusColor = status === 'healthy' ? 'success' : status === 'degraded' ? 'warning' : 'error';
-            return (
-              <Chip
-                key={status}
-                label={`${count} ${status}`}
-                size="small"
-                color={clusterStatusColor}
-                variant="outlined"
-              />
-            );
-          })}
-        </Paper>
       )}
 
       {filtered.length === 0 ? (

--- a/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
@@ -7,11 +7,15 @@ import { NotificationProvider } from '../../../context/NotificationContext';
 import type { WsMessage } from '../../../hooks/useWebSocket';
 
 type MessageHandler = (msg: WsMessage) => void;
-let capturedWsHandler: MessageHandler | null = null;
+const capturedWsHandlers: MessageHandler[] = [];
+
+function broadcastWs(msg: WsMessage) {
+  capturedWsHandlers.forEach((h) => h(msg));
+}
 
 vi.mock('../../../hooks/useWebSocket', () => ({
   useWebSocket: (handler: MessageHandler) => {
-    capturedWsHandler = handler;
+    capturedWsHandlers.push(handler);
     return { send: vi.fn() };
   },
 }));
@@ -39,6 +43,14 @@ vi.mock('../../../api/client', () => ({
     check: vi.fn().mockResolvedValue(false),
     add: vi.fn(),
     remove: vi.fn(),
+  },
+  dashboardService: {
+    getOverview: vi.fn().mockResolvedValue({
+      clusters: [],
+      recent_deployments: [],
+      expiring_soon: [],
+      failing_instances: [],
+    }),
   },
 }));
 
@@ -71,7 +83,7 @@ const mockInstance = (overrides: Record<string, unknown> = {}) => ({
 describe('Dashboard', () => {
   afterEach(() => {
     vi.clearAllMocks();
-    capturedWsHandler = null;
+    capturedWsHandlers.length = 0;
   });
 
   // Reset default mocks that survive clearAllMocks
@@ -158,7 +170,7 @@ describe('Dashboard', () => {
 
     // Simulate a WebSocket deployment.status message.
     act(() => {
-      capturedWsHandler?.({
+      broadcastWs({
         type: 'deployment.status',
         payload: { instance_id: 'inst-1', status: 'deploying', log_id: 'log-1' },
       });
@@ -192,7 +204,7 @@ describe('Dashboard', () => {
 
     // Send a message for a different instance.
     act(() => {
-      capturedWsHandler?.({
+      broadcastWs({
         type: 'deployment.status',
         payload: { instance_id: 'unknown-id', status: 'error', log_id: 'log-2' },
       });
@@ -669,15 +681,21 @@ describe('Dashboard', () => {
     });
   });
 
-  describe('Cluster Health Bar', () => {
-    it('renders cluster health summary when clusters are loaded', async () => {
+  describe('Dashboard Widgets', () => {
+    it('renders cluster health widget from dashboard API', async () => {
+      const { dashboardService } = await import('../../../api/client');
+      (dashboardService.getOverview as ReturnType<typeof vi.fn>).mockResolvedValue({
+        clusters: [
+          { id: 'c1', name: 'prod', health_status: 'healthy' },
+          { id: 'c2', name: 'staging', health_status: 'degraded' },
+          { id: 'c3', name: 'dev', health_status: 'unreachable' },
+        ],
+        recent_deployments: [],
+        expiring_soon: [],
+        failing_instances: [],
+      });
       (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([
         mockInstance(),
-      ]);
-      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([
-        { id: 'c1', name: 'prod', health_status: 'healthy', is_default: true },
-        { id: 'c2', name: 'staging', health_status: 'degraded', is_default: false },
-        { id: 'c3', name: 'dev', health_status: 'unreachable', is_default: false },
       ]);
       render(
         <MemoryRouter>
@@ -687,18 +705,24 @@ describe('Dashboard', () => {
         </MemoryRouter>
       );
       await waitFor(() => {
-        expect(screen.getByText('3 clusters:')).toBeInTheDocument();
+        expect(screen.getByText('Cluster Health')).toBeInTheDocument();
       });
-      expect(screen.getByText('1 healthy')).toBeInTheDocument();
-      expect(screen.getByText('1 degraded')).toBeInTheDocument();
-      expect(screen.getByText('1 unreachable')).toBeInTheDocument();
+      expect(screen.getByText('prod')).toBeInTheDocument();
+      expect(screen.getByText('staging')).toBeInTheDocument();
+      expect(screen.getByText('dev')).toBeInTheDocument();
     });
 
-    it('does not render cluster bar when no clusters', async () => {
+    it('renders empty state when no clusters', async () => {
+      const { dashboardService } = await import('../../../api/client');
+      (dashboardService.getOverview as ReturnType<typeof vi.fn>).mockResolvedValue({
+        clusters: [],
+        recent_deployments: [],
+        expiring_soon: [],
+        failing_instances: [],
+      });
       (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([
         mockInstance(),
       ]);
-      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       render(
         <MemoryRouter>
           <NotificationProvider>
@@ -707,9 +731,11 @@ describe('Dashboard', () => {
         </MemoryRouter>
       );
       await waitFor(() => {
-        expect(screen.getByText('Stack Instances')).toBeInTheDocument();
+        expect(screen.getByText('Cluster Health')).toBeInTheDocument();
       });
-      expect(screen.queryByText(/cluster/)).not.toBeInTheDocument();
+      await waitFor(() => {
+        expect(screen.getByText('No clusters registered.')).toBeInTheDocument();
+      });
     });
   });
 

--- a/frontend/src/pages/StackInstances/__tests__/Form.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Form.test.tsx
@@ -24,6 +24,9 @@ vi.mock('../../../api/client', () => ({
   clusterService: {
     list: vi.fn().mockResolvedValue([]),
   },
+  gitService: {
+    branches: vi.fn().mockResolvedValue([]),
+  },
 }));
 
 import { instanceService, definitionService, clusterService } from '../../../api/client';
@@ -339,7 +342,7 @@ describe('StackInstances Form', () => {
     await user.click(screen.getByText(/API Stack/));
 
     // Branch field should update to the definition's default branch
-    const branchInput = screen.getByRole('textbox', { name: /branch/i });
+    const branchInput = screen.getByRole('combobox', { name: /branch/i });
     expect(branchInput).toHaveValue('develop');
   });
 

--- a/frontend/src/pages/StackInstances/widgets/ClusterHealthWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/ClusterHealthWidget.tsx
@@ -1,0 +1,61 @@
+import { Box, Card, CardContent, Chip, Typography } from '@mui/material';
+import type { DashboardCluster } from '../../../types';
+
+const healthColor: Record<string, 'success' | 'warning' | 'error' | 'default'> = {
+  healthy: 'success',
+  degraded: 'warning',
+  unreachable: 'error',
+};
+
+interface Props {
+  clusters: DashboardCluster[];
+}
+
+const ClusterHealthWidget = ({ clusters }: Props) => {
+  if (clusters.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No clusters registered.
+      </Typography>
+    );
+  }
+
+  return (
+    <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap' }}>
+      {clusters.map((cl) => (
+        <Card key={cl.id} variant="outlined" sx={{ minWidth: 200, flex: '1 1 200px', maxWidth: 320 }}>
+          <CardContent sx={{ pb: '12px !important' }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              <Typography variant="subtitle2" noWrap>{cl.name}</Typography>
+              <Chip
+                label={cl.health_status || 'unknown'}
+                color={healthColor[cl.health_status] ?? 'default'}
+                size="small"
+              />
+            </Box>
+            {cl.node_count != null && (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.25 }}>
+                <Typography variant="caption" color="text.secondary">
+                  Nodes: {cl.ready_node_count ?? '?'}/{cl.node_count}
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  CPU: {cl.allocatable_cpu ?? '?'} allocatable / {cl.total_cpu ?? '?'} total
+                </Typography>
+                <Typography variant="caption" color="text.secondary">
+                  Memory: {cl.allocatable_memory ?? '?'} / {cl.total_memory ?? '?'}
+                </Typography>
+                {cl.namespace_count != null && (
+                  <Typography variant="caption" color="text.secondary">
+                    Namespaces: {cl.namespace_count}
+                  </Typography>
+                )}
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </Box>
+  );
+};
+
+export default ClusterHealthWidget;

--- a/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
+++ b/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, type ReactNode } from 'react';
 import {
   Accordion,
   AccordionSummary,
@@ -40,7 +40,9 @@ function loadCollapsed(): Record<WidgetKey, boolean> {
 }
 
 function saveCollapsed(state: Record<WidgetKey, boolean>) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch { /* ignore */ }
 }
 
 const DashboardWidgets = () => {
@@ -134,7 +136,7 @@ const DashboardWidgets = () => {
 
   if (!data) return null;
 
-  const widgets: { key: WidgetKey; label: string; icon: React.ReactNode; count?: number; content: React.ReactNode }[] = [
+  const widgets: { key: WidgetKey; label: string; icon: ReactNode; count?: number; content: ReactNode }[] = [
     {
       key: 'clusters',
       label: 'Cluster Health',

--- a/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
+++ b/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useState, useCallback, useRef } from 'react';
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Typography,
+  Box,
+  CircularProgress,
+  Chip,
+} from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import DnsIcon from '@mui/icons-material/Dns';
+import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
+import TimerIcon from '@mui/icons-material/Timer';
+import ErrorOutlinedIcon from '@mui/icons-material/ErrorOutlined';
+import { dashboardService } from '../../../api/client';
+import { useWebSocket } from '../../../hooks/useWebSocket';
+import type { DashboardResponse } from '../../../types';
+import ClusterHealthWidget from './ClusterHealthWidget';
+import RecentDeploymentsWidget from './RecentDeploymentsWidget';
+import ExpiringSoonWidget from './ExpiringSoonWidget';
+import FailingInstancesWidget from './FailingInstancesWidget';
+
+const STORAGE_KEY = 'dashboard_widget_collapsed';
+
+type WidgetKey = 'clusters' | 'deployments' | 'expiring' | 'failing';
+
+function loadCollapsed(): Record<WidgetKey, boolean> {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored);
+  } catch { /* ignore */ }
+  return { clusters: false, deployments: false, expiring: false, failing: false };
+}
+
+function saveCollapsed(state: Record<WidgetKey, boolean>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+}
+
+const DashboardWidgets = () => {
+  const [data, setData] = useState<DashboardResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [collapsed, setCollapsed] = useState<Record<WidgetKey, boolean>>(loadCollapsed);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const resp = await dashboardService.getOverview();
+      setData(resp);
+    } catch {
+      // silently ignore — dashboard widgets are supplementary
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const debouncedRefetch = useCallback(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchData();
+    }, 2000);
+  }, [fetchData]);
+
+  useWebSocket(
+    useCallback(
+      (msg) => {
+        if (
+          msg.type === 'deployment.status' ||
+          msg.type === 'instance.status' ||
+          msg.type === 'cluster.health_changed'
+        ) {
+          debouncedRefetch();
+        }
+      },
+      [debouncedRefetch],
+    ),
+  );
+
+  const toggle = (key: WidgetKey) => {
+    setCollapsed((prev) => {
+      const next = { ...prev, [key]: !prev[key] };
+      saveCollapsed(next);
+      return next;
+    });
+  };
+
+  const handleTtlExtended = (id: string, newExpiresAt: string) => {
+    setData((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        expiring_soon: prev.expiring_soon
+          .map((i) => (i.id === id ? { ...i, expires_at: newExpiresAt } : i))
+          .filter((i) => {
+            const ms = new Date(i.expires_at).getTime() - Date.now();
+            return ms > 0 && ms <= 60 * 60 * 1000;
+          }),
+      };
+    });
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (!data) return null;
+
+  const widgets: { key: WidgetKey; label: string; icon: React.ReactNode; count?: number; content: React.ReactNode }[] = [
+    {
+      key: 'clusters',
+      label: 'Cluster Health',
+      icon: <DnsIcon fontSize="small" />,
+      count: data.clusters.length,
+      content: <ClusterHealthWidget clusters={data.clusters} />,
+    },
+    {
+      key: 'deployments',
+      label: 'Recent Deployments',
+      icon: <RocketLaunchIcon fontSize="small" />,
+      count: data.recent_deployments.length,
+      content: <RecentDeploymentsWidget deployments={data.recent_deployments} />,
+    },
+    {
+      key: 'expiring',
+      label: 'Expiring Soon',
+      icon: <TimerIcon fontSize="small" />,
+      count: data.expiring_soon.length,
+      content: <ExpiringSoonWidget instances={data.expiring_soon} onExtended={handleTtlExtended} />,
+    },
+    {
+      key: 'failing',
+      label: 'Failing Instances',
+      icon: <ErrorOutlinedIcon fontSize="small" />,
+      count: data.failing_instances.length,
+      content: <FailingInstancesWidget instances={data.failing_instances} />,
+    },
+  ];
+
+  return (
+    <Box sx={{ mb: 3 }}>
+      {widgets.map(({ key, label, icon, count, content }) => (
+        <Accordion
+          key={key}
+          expanded={!collapsed[key]}
+          onChange={() => toggle(key)}
+          disableGutters
+          variant="outlined"
+          sx={{ '&:before': { display: 'none' }, mb: 1 }}
+        >
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              {icon}
+              <Typography variant="subtitle2">{label}</Typography>
+              {count != null && count > 0 && (
+                <Chip
+                  label={count}
+                  size="small"
+                  color={key === 'failing' && count > 0 ? 'error' : 'default'}
+                  sx={{ height: 20, fontSize: '0.7rem' }}
+                />
+              )}
+            </Box>
+          </AccordionSummary>
+          <AccordionDetails sx={{ pt: 0 }}>
+            {content}
+          </AccordionDetails>
+        </Accordion>
+      ))}
+    </Box>
+  );
+};
+
+export default DashboardWidgets;

--- a/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
+++ b/frontend/src/pages/StackInstances/widgets/DashboardWidgets.tsx
@@ -7,6 +7,7 @@ import {
   Box,
   CircularProgress,
   Chip,
+  Alert,
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import DnsIcon from '@mui/icons-material/Dns';
@@ -23,14 +24,19 @@ import FailingInstancesWidget from './FailingInstancesWidget';
 
 const STORAGE_KEY = 'dashboard_widget_collapsed';
 
+// Must match backend's buildExpiringSoon threshold (1 * time.Hour).
+const EXPIRING_THRESHOLD_MS = 60 * 60 * 1000;
+
 type WidgetKey = 'clusters' | 'deployments' | 'expiring' | 'failing';
+
+const defaultCollapsed: Record<WidgetKey, boolean> = { clusters: false, deployments: false, expiring: false, failing: false };
 
 function loadCollapsed(): Record<WidgetKey, boolean> {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) return JSON.parse(stored);
+    if (stored) return { ...defaultCollapsed, ...JSON.parse(stored) };
   } catch { /* ignore */ }
-  return { clusters: false, deployments: false, expiring: false, failing: false };
+  return { ...defaultCollapsed };
 }
 
 function saveCollapsed(state: Record<WidgetKey, boolean>) {
@@ -40,6 +46,7 @@ function saveCollapsed(state: Record<WidgetKey, boolean>) {
 const DashboardWidgets = () => {
   const [data, setData] = useState<DashboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
   const [collapsed, setCollapsed] = useState<Record<WidgetKey, boolean>>(loadCollapsed);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -47,8 +54,9 @@ const DashboardWidgets = () => {
     try {
       const resp = await dashboardService.getOverview();
       setData(resp);
+      setError(false);
     } catch {
-      // silently ignore — dashboard widgets are supplementary
+      setError(true);
     } finally {
       setLoading(false);
     }
@@ -56,6 +64,9 @@ const DashboardWidgets = () => {
 
   useEffect(() => {
     fetchData();
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
   }, [fetchData]);
 
   const debouncedRefetch = useCallback(() => {
@@ -97,7 +108,7 @@ const DashboardWidgets = () => {
           .map((i) => (i.id === id ? { ...i, expires_at: newExpiresAt } : i))
           .filter((i) => {
             const ms = new Date(i.expires_at).getTime() - Date.now();
-            return ms > 0 && ms <= 60 * 60 * 1000;
+            return ms > 0 && ms <= EXPIRING_THRESHOLD_MS;
           }),
       };
     });
@@ -107,6 +118,16 @@ const DashboardWidgets = () => {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', py: 3 }}>
         <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Box sx={{ mb: 3 }}>
+        <Alert severity="warning" variant="outlined">
+          Failed to load dashboard data.
+        </Alert>
       </Box>
     );
   }

--- a/frontend/src/pages/StackInstances/widgets/ExpiringSoonWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/ExpiringSoonWidget.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import {
+  Box,
+  Button,
+  Chip,
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  Link as MuiLink,
+  CircularProgress,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+import useCountdown from '../../../hooks/useCountdown';
+import { instanceService } from '../../../api/client';
+import type { DashboardExpiring } from '../../../types';
+
+interface ExpiringRowProps {
+  item: DashboardExpiring;
+  onExtended: (id: string, newExpiresAt: string) => void;
+}
+
+const ExpiringRow = ({ item, onExtended }: ExpiringRowProps) => {
+  const [extending, setExtending] = useState(false);
+  const countdown = useCountdown(item.expires_at);
+
+  const handleExtend = async () => {
+    setExtending(true);
+    try {
+      const updated = await instanceService.extend(item.id);
+      onExtended(item.id, updated.expires_at ?? '');
+    } catch {
+      // notification handled by caller
+    } finally {
+      setExtending(false);
+    }
+  };
+
+  return (
+    <ListItem
+      disablePadding
+      sx={{ py: 0.5, display: 'flex', justifyContent: 'space-between' }}
+    >
+      <ListItemText
+        primary={
+          <MuiLink component={Link} to={`/stack-instances/${item.id}`} underline="hover">
+            {item.name}
+          </MuiLink>
+        }
+        secondary={item.namespace}
+        slotProps={{ primary: { variant: 'body2' }, secondary: { variant: 'caption' } }}
+      />
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexShrink: 0 }}>
+        {countdown && !countdown.isExpired && (
+          <Chip
+            label={countdown.remaining}
+            size="small"
+            color={countdown.isCritical ? 'error' : countdown.isWarning ? 'warning' : 'success'}
+          />
+        )}
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={handleExtend}
+          disabled={extending}
+          sx={{ minWidth: 'auto', whiteSpace: 'nowrap' }}
+        >
+          {extending ? <CircularProgress size={16} /> : 'Extend TTL'}
+        </Button>
+      </Box>
+    </ListItem>
+  );
+};
+
+interface Props {
+  instances: DashboardExpiring[];
+  onExtended: (id: string, newExpiresAt: string) => void;
+}
+
+const ExpiringSoonWidget = ({ instances, onExtended }: Props) => {
+  if (instances.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No instances expiring soon.
+      </Typography>
+    );
+  }
+
+  return (
+    <List dense disablePadding>
+      {instances.map((item) => (
+        <ExpiringRow key={item.id} item={item} onExtended={onExtended} />
+      ))}
+    </List>
+  );
+};
+
+export default ExpiringSoonWidget;

--- a/frontend/src/pages/StackInstances/widgets/ExpiringSoonWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/ExpiringSoonWidget.tsx
@@ -13,6 +13,7 @@ import {
 import { Link } from 'react-router-dom';
 import useCountdown from '../../../hooks/useCountdown';
 import { instanceService } from '../../../api/client';
+import { useNotification } from '../../../context/NotificationContext';
 import type { DashboardExpiring } from '../../../types';
 
 interface ExpiringRowProps {
@@ -23,6 +24,7 @@ interface ExpiringRowProps {
 const ExpiringRow = ({ item, onExtended }: ExpiringRowProps) => {
   const [extending, setExtending] = useState(false);
   const countdown = useCountdown(item.expires_at);
+  const { showError } = useNotification();
 
   const handleExtend = async () => {
     setExtending(true);
@@ -30,7 +32,7 @@ const ExpiringRow = ({ item, onExtended }: ExpiringRowProps) => {
       const updated = await instanceService.extend(item.id);
       onExtended(item.id, updated.expires_at ?? '');
     } catch {
-      // notification handled by caller
+      showError(`Failed to extend TTL for ${item.name}`);
     } finally {
       setExtending(false);
     }

--- a/frontend/src/pages/StackInstances/widgets/FailingInstancesWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/FailingInstancesWidget.tsx
@@ -1,0 +1,57 @@
+import {
+  List,
+  ListItem,
+  ListItemText,
+  Typography,
+  Link as MuiLink,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+import { timeAgo } from '../../../utils/timeAgo';
+import type { DashboardFailing } from '../../../types';
+
+interface Props {
+  instances: DashboardFailing[];
+}
+
+const FailingInstancesWidget = ({ instances }: Props) => {
+  if (instances.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No failing instances.
+      </Typography>
+    );
+  }
+
+  return (
+    <List dense disablePadding>
+      {instances.map((inst) => (
+        <ListItem key={inst.id} disablePadding sx={{ py: 0.5 }}>
+          <ListItemText
+            primary={
+              <MuiLink component={Link} to={`/stack-instances/${inst.id}`} underline="hover">
+                {inst.name}
+              </MuiLink>
+            }
+            secondary={
+              <>
+                {inst.error_message
+                  ? inst.error_message.length > 120
+                    ? inst.error_message.slice(0, 120) + '...'
+                    : inst.error_message
+                  : 'Unknown error'}
+                {' — '}
+                {timeAgo(inst.updated_at)}
+              </>
+            }
+            slotProps={{
+              primary: { variant: 'body2' },
+              secondary: { variant: 'caption', color: 'error' },
+            }}
+          />
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+
+export default FailingInstancesWidget;

--- a/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
@@ -40,7 +40,7 @@ const RecentDeploymentsWidget = ({ deployments }: Props) => {
             <TableCell>Instance</TableCell>
             <TableCell>Action</TableCell>
             <TableCell>Status</TableCell>
-            <TableCell>User</TableCell>
+            <TableCell>Owner</TableCell>
             <TableCell>When</TableCell>
           </TableRow>
         </TableHead>
@@ -59,7 +59,7 @@ const RecentDeploymentsWidget = ({ deployments }: Props) => {
                 <Chip label={d.status} size="small" color={deployStatusColor[d.status] || 'default'} />
               </TableCell>
               <TableCell>
-                <Typography variant="body2" noWrap>{d.username || '-'}</Typography>
+                <Typography variant="body2" noWrap>{d.owner_username || '-'}</Typography>
               </TableCell>
               <TableCell>
                 <Typography variant="body2" color="text.secondary" noWrap>

--- a/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
@@ -1,0 +1,71 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+  Link as MuiLink,
+} from '@mui/material';
+import { Link } from 'react-router-dom';
+import { timeAgo } from '../../../utils/timeAgo';
+import StatusBadge from '../../../components/StatusBadge';
+import type { DashboardDeployment } from '../../../types';
+
+interface Props {
+  deployments: DashboardDeployment[];
+}
+
+const RecentDeploymentsWidget = ({ deployments }: Props) => {
+  if (deployments.length === 0) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No recent deployments.
+      </Typography>
+    );
+  }
+
+  return (
+    <TableContainer>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Instance</TableCell>
+            <TableCell>Action</TableCell>
+            <TableCell>Status</TableCell>
+            <TableCell>User</TableCell>
+            <TableCell>When</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {deployments.map((d) => (
+            <TableRow key={d.id} hover>
+              <TableCell>
+                <MuiLink component={Link} to={`/stack-instances/${d.stack_instance_id}`} underline="hover">
+                  {d.instance_name}
+                </MuiLink>
+              </TableCell>
+              <TableCell>
+                <StatusBadge status={d.action} />
+              </TableCell>
+              <TableCell>
+                <StatusBadge status={d.status} />
+              </TableCell>
+              <TableCell>
+                <Typography variant="body2" noWrap>{d.username || '-'}</Typography>
+              </TableCell>
+              <TableCell>
+                <Typography variant="body2" color="text.secondary" noWrap>
+                  {timeAgo(d.started_at)}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+};
+
+export default RecentDeploymentsWidget;

--- a/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
+++ b/frontend/src/pages/StackInstances/widgets/RecentDeploymentsWidget.tsx
@@ -6,12 +6,18 @@ import {
   TableHead,
   TableRow,
   Typography,
+  Chip,
   Link as MuiLink,
 } from '@mui/material';
 import { Link } from 'react-router-dom';
 import { timeAgo } from '../../../utils/timeAgo';
-import StatusBadge from '../../../components/StatusBadge';
 import type { DashboardDeployment } from '../../../types';
+
+const deployStatusColor: Record<string, 'default' | 'info' | 'success' | 'error'> = {
+  running: 'info',
+  success: 'success',
+  error: 'error',
+};
 
 interface Props {
   deployments: DashboardDeployment[];
@@ -47,10 +53,10 @@ const RecentDeploymentsWidget = ({ deployments }: Props) => {
                 </MuiLink>
               </TableCell>
               <TableCell>
-                <StatusBadge status={d.action} />
+                <Chip label={d.action} size="small" variant="outlined" />
               </TableCell>
               <TableCell>
-                <StatusBadge status={d.status} />
+                <Chip label={d.status} size="small" color={deployStatusColor[d.status] || 'default'} />
               </TableCell>
               <TableCell>
                 <Typography variant="body2" noWrap>{d.username || '-'}</Typography>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -708,7 +708,7 @@ export interface DashboardDeployment {
   status: string;
   started_at: string;
   completed_at?: string;
-  username?: string;
+  owner_username?: string;
 }
 
 export interface DashboardExpiring {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -686,3 +686,54 @@ export interface DeployPreviewResponse {
   instance_name: string;
   charts: ChartDeployPreview[];
 }
+
+export interface DashboardCluster {
+  id: string;
+  name: string;
+  health_status: string;
+  node_count?: number;
+  ready_node_count?: number;
+  total_cpu?: string;
+  total_memory?: string;
+  allocatable_cpu?: string;
+  allocatable_memory?: string;
+  namespace_count?: number;
+}
+
+export interface DashboardDeployment {
+  id: string;
+  stack_instance_id: string;
+  instance_name: string;
+  action: string;
+  status: string;
+  started_at: string;
+  completed_at?: string;
+  username?: string;
+}
+
+export interface DashboardExpiring {
+  id: string;
+  name: string;
+  namespace: string;
+  status: string;
+  expires_at: string;
+  ttl_minutes: number;
+  cluster_id?: string;
+}
+
+export interface DashboardFailing {
+  id: string;
+  name: string;
+  namespace: string;
+  status: string;
+  error_message: string;
+  cluster_id?: string;
+  updated_at: string;
+}
+
+export interface DashboardResponse {
+  clusters: DashboardCluster[];
+  recent_deployments: DashboardDeployment[];
+  expiring_soon: DashboardExpiring[];
+  failing_instances: DashboardFailing[];
+}


### PR DESCRIPTION
## Summary
- New `GET /api/v1/dashboard` endpoint returning aggregated cluster health, recent deployments, expiring TTLs, and failing instances
- 4 collapsible MUI widget components above the instance table with real-time WebSocket updates
- Role-aware caching (separate cache instances for privileged vs basic), singleflight to prevent thundering herd, LEFT JOIN for deleted instances, bounded queries

## Changes

### Backend
- `DashboardHandler` with singleflight-wrapped cache, `Stop()` for graceful shutdown
- `ListRecentGlobal` — 3-table LEFT JOIN (deployment_logs + stack_instances + users) with COALESCE for deleted entities
- `ListByStatus(status, limit)` — bounded query (50 rows for dashboard)
- Migration 36: `idx_deployment_logs_started_at` index for global ORDER BY
- 9 handler unit tests (empty state, role filtering, cache hit, error propagation, data correctness)

### Frontend
- `DashboardWidgets` orchestrator with debounced WS refetch, localStorage collapse state, error alert
- `ClusterHealthWidget`, `RecentDeploymentsWidget`, `ExpiringSoonWidget` (with extend TTL + error toast), `FailingInstancesWidget`
- Dashboard types + `dashboardService` with try/catch pattern

## Test plan
- [x] `go test ./...` — all backend tests pass
- [x] `npx vitest run` — all 920 frontend tests pass
- [ ] Manual: verify widgets render above instance table
- [ ] Manual: collapse/expand persists across refresh
- [ ] Manual: trigger deploy and verify WS-driven widget update
- [ ] Manual: extend TTL button works, error toast on failure

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)