### PR TITLE
refactor: extract main() into testable bootstrap functions

### DIFF
--- a/backend/api/bootstrap.go
+++ b/backend/api/bootstrap.go
@@ -1,0 +1,575 @@
+package main
+
+import (
+	"backend/internal/api/handlers"
+	"backend/internal/api/routes"
+	"backend/internal/auth"
+	"backend/internal/cluster"
+	"backend/internal/config"
+	"backend/internal/database"
+	"backend/internal/deployer"
+	"backend/internal/gitprovider"
+	"backend/internal/health"
+	"backend/internal/helm"
+	"backend/internal/hooks"
+	"backend/internal/k8s"
+	"backend/internal/models"
+	"backend/internal/notifier"
+	"backend/internal/scheduler"
+	"backend/internal/sessionstore"
+	"backend/internal/ttl"
+	"backend/internal/websocket"
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/pprof"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+// domainServices holds all domain-layer services wired during bootstrap.
+type domainServices struct {
+	GitRegistry       *gitprovider.Registry
+	ClusterRegistry   *cluster.Registry
+	HealthPoller      *cluster.HealthPoller
+	SecretRefresher   *cluster.SecretRefresher
+	K8sWatcher        *k8s.Watcher
+	DeployManager     *deployer.Manager
+	HookDispatcher    *hooks.Dispatcher
+	ActionRegistry    *hooks.ActionRegistry
+	LifecycleNotifier *notifier.Notifier
+	CleanupExecutor   *deployer.CleanupExecutor
+	CleanupScheduler  *scheduler.Scheduler
+	ValuesGen         *helm.ValuesGenerator
+	WatcherCancel     context.CancelFunc
+}
+
+// handlerSet holds all HTTP handlers wired during bootstrap.
+type handlerSet struct {
+	Auth                  *handlers.AuthHandler
+	OIDC                  *handlers.OIDCHandler
+	Template              *handlers.TemplateHandler
+	Definition            *handlers.DefinitionHandler
+	TemplateVersion       *handlers.TemplateVersionHandler
+	Instance              *handlers.InstanceHandler
+	Git                   *handlers.GitHandler
+	AuditLog              *handlers.AuditLogHandler
+	User                  *handlers.UserHandler
+	APIKey                *handlers.APIKeyHandler
+	Admin                 *handlers.AdminHandler
+	Cluster               *handlers.ClusterHandler
+	BranchOverride        *handlers.BranchOverrideHandler
+	InstanceQuotaOverride *handlers.InstanceQuotaOverrideHandler
+	SharedValues          *handlers.SharedValuesHandler
+	Notification          *handlers.NotificationHandler
+	Favorite              *handlers.FavoriteHandler
+	QuickDeploy           *handlers.QuickDeployHandler
+	Analytics             *handlers.AnalyticsHandler
+	Dashboard             *handlers.DashboardHandler
+	CleanupPolicy         *handlers.CleanupPolicyHandler
+}
+
+// routerDeps holds non-handler dependencies required to wire the router.
+type routerDeps struct {
+	Repo          models.Repository
+	HealthChecker *health.HealthChecker
+	Hub           *websocket.Hub
+	SessionStore  sessionstore.SessionStore
+	Repos         *database.RepositorySet
+	Svc           *domainServices
+}
+
+// backgroundServices holds services started after the router is ready.
+type backgroundServices struct {
+	Reaper                    *ttl.Reaper
+	ExpiryWarner              *ttl.Warner
+	QuotaMonitor              *cluster.QuotaMonitor
+	SecretMonitor             *cluster.SecretMonitor
+	RefreshTokenCleanupCancel context.CancelFunc
+}
+
+// initDatabase opens the GORM database connection and returns the generic
+// repository plus the underlying *gorm.DB for domain-repo construction.
+func initDatabase(cfg *config.Config) (models.Repository, *gorm.DB, error) {
+	repo, db, err := database.NewRepositoryWithGormDB(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("initialize repository: %w", err)
+	}
+	return repo, db, nil
+}
+
+// initRepositories creates all domain-specific repositories.
+func initRepositories(cfg *config.Config, db *gorm.DB) (*database.RepositorySet, error) {
+	repos, err := database.NewRepositorySet(cfg, db)
+	if err != nil {
+		return nil, fmt.Errorf("create domain repositories: %w", err)
+	}
+	return repos, nil
+}
+
+// buildSessionStore creates the session store based on the configured backend.
+func buildSessionStore(backend string, db *gorm.DB) sessionstore.SessionStore {
+	switch backend {
+	case "memory":
+		return sessionstore.NewMemoryStore()
+	default:
+		return sessionstore.NewMySQLStore(db)
+	}
+}
+
+// buildDomainServices creates all domain-layer services: git providers,
+// cluster registry, health poller, deployer, hooks, etc.
+func buildDomainServices(
+	cfg *config.Config,
+	repos *database.RepositorySet,
+	hub *websocket.Hub,
+	healthChecker *health.HealthChecker,
+) (*domainServices, error) {
+	// Git provider registry.
+	gitRegistry := gitprovider.NewRegistry(gitprovider.Config{
+		AzureDevOps: gitprovider.AzureDevOpsConfig{
+			PAT:        cfg.GitProvider.AzureDevOpsPAT,
+			DefaultOrg: cfg.GitProvider.AzureDevOpsDefaultOrg,
+		},
+		GitLab: gitprovider.GitLabConfig{
+			Token:   cfg.GitProvider.GitLabToken,
+			BaseURL: cfg.GitProvider.GitLabBaseURL,
+		},
+	})
+
+	valuesGen := helm.NewValuesGenerator()
+
+	// Auto-create default cluster from KUBECONFIG_PATH for single-cluster migration.
+	ensureDefaultCluster(repos.Cluster, repos.StackInstance, cfg)
+
+	// Cluster registry for multi-cluster client management.
+	clusterRegistry := cluster.NewRegistry(cluster.RegistryOptions{
+		ClusterRepo: repos.Cluster,
+		HelmBinary:  cfg.Deployment.HelmBinary,
+		HelmTimeout: cfg.Deployment.DeploymentTimeout,
+	})
+
+	// Extended health checks.
+	healthChecker.AddCheck("cluster_registry", func(ctx context.Context) error {
+		return clusterRegistry.HealthCheck(ctx)
+	})
+	healthChecker.AddCheck("git_provider", func(ctx context.Context) error {
+		return gitRegistry.HealthCheck(ctx)
+	})
+	healthChecker.AddCheck("helm", deployer.HelmHealthCheck(cfg.Deployment.HelmBinary))
+
+	// Cluster health poller.
+	healthPoller := cluster.NewHealthPoller(cluster.HealthPollerConfig{
+		ClusterRepo: repos.Cluster,
+		Registry:    clusterRegistry,
+		Interval:    cfg.Deployment.ClusterHealthPollInterval,
+		Hub:         hub,
+	})
+	healthPoller.Start()
+
+	// Image pull secret refresher.
+	secretRefresher := cluster.NewSecretRefresher(cluster.SecretRefresherConfig{
+		ClusterRepo:  repos.Cluster,
+		InstanceRepo: repos.StackInstance,
+		Registry:     clusterRegistry,
+	})
+	secretRefresher.Start()
+
+	// Webhook / action hooks — load before starting the watcher so errors
+	// don't leak the watcher's cancel context.
+	hookCfg, actionSpecs, hookErr := hooks.LoadConfigFile(cfg.Deployment.HooksConfigFile)
+	if hookErr != nil {
+		return nil, fmt.Errorf("load hooks config: %w", hookErr)
+	}
+
+	var hookDispatcher *hooks.Dispatcher
+	if len(hookCfg.Subscriptions) > 0 {
+		hookDispatcher, hookErr = hooks.NewDispatcher(hookCfg, http.DefaultClient)
+		if hookErr != nil {
+			return nil, fmt.Errorf("build hooks dispatcher: %w", hookErr)
+		}
+	}
+
+	var actionRegistry *hooks.ActionRegistry
+	if len(actionSpecs) > 0 {
+		actionRegistry, hookErr = hooks.NewActionRegistry(actionSpecs, http.DefaultClient)
+		if hookErr != nil {
+			return nil, fmt.Errorf("build action registry: %w", hookErr)
+		}
+	}
+
+	// K8s watcher for multi-cluster monitoring.
+	k8sWatcher := k8s.NewWatcher(clusterRegistry, repos.StackInstance, hub, 30*time.Second)
+	watcherCtx, watcherCancel := context.WithCancel(context.Background())
+	k8sWatcher.Start(watcherCtx)
+
+	var subscribedEvents []string
+	if hookDispatcher != nil {
+		subscribedEvents = hookDispatcher.EventNames()
+	}
+	var actionNames []string
+	if actionRegistry != nil {
+		actionNames = actionRegistry.Names()
+	}
+	slog.Info("hooks configured",
+		"config_file", cfg.Deployment.HooksConfigFile,
+		"subscribed_events", subscribedEvents,
+		"actions", actionNames,
+	)
+
+	// Lifecycle notifier — in-app notifications for stack events.
+	lifecycleNotifier := notifier.NewNotifier(repos.Notification, hub, repos.User)
+
+	// Deployment manager — multi-cluster deploys.
+	deployManager := deployer.NewManager(deployer.ManagerConfig{
+		Registry:                   clusterRegistry,
+		InstanceRepo:               repos.StackInstance,
+		DeployLogRepo:              repos.DeploymentLog,
+		Hub:                        hub,
+		TxRunner:                   repos.TxRunner,
+		MaxConcurrent:              int(cfg.Deployment.MaxConcurrentDeploys),
+		QuotaRepo:                  repos.ResourceQuota,
+		QuotaOverrideRepo:          repos.InstanceQuotaOverride,
+		WildcardTLSSourceNamespace: cfg.Deployment.WildcardTLSSourceNamespace,
+		WildcardTLSSourceSecret:    cfg.Deployment.WildcardTLSSourceSecret,
+		WildcardTLSTargetSecret:    cfg.Deployment.WildcardTLSTargetSecret,
+		StabilizeTimeout:           cfg.Deployment.StabilizeTimeout,
+		StabilizePollInterval:      cfg.Deployment.StabilizePollInterval,
+		Hooks:                      hookDispatcher,
+		Notifier:                   lifecycleNotifier,
+	})
+
+	// Cleanup executor + scheduler.
+	cleanupExecutor := deployer.NewCleanupExecutor(deployManager, repos.StackDefinition, repos.ChartConfig, repos.StackInstance)
+	cleanupScheduler := scheduler.NewScheduler(repos.CleanupPolicy, repos.StackInstance, repos.AuditLog, cleanupExecutor, lifecycleNotifier)
+
+	return &domainServices{
+		GitRegistry:       gitRegistry,
+		ClusterRegistry:   clusterRegistry,
+		HealthPoller:      healthPoller,
+		SecretRefresher:   secretRefresher,
+		K8sWatcher:        k8sWatcher,
+		DeployManager:     deployManager,
+		HookDispatcher:    hookDispatcher,
+		ActionRegistry:    actionRegistry,
+		LifecycleNotifier: lifecycleNotifier,
+		CleanupExecutor:   cleanupExecutor,
+		CleanupScheduler:  cleanupScheduler,
+		ValuesGen:         valuesGen,
+		WatcherCancel:     watcherCancel,
+	}, nil
+}
+
+// buildHandlers creates all HTTP handlers.
+func buildHandlers(
+	cfg *config.Config,
+	repos *database.RepositorySet,
+	svc *domainServices,
+	sessStore sessionstore.SessionStore,
+	hub *websocket.Hub,
+) (*handlerSet, error) {
+	// Auth handler.
+	authHandler := handlers.NewAuthHandler(repos.User, &cfg.Auth, &cfg.OIDC)
+	authHandler.SetSessionStore(sessStore)
+	if repos.RefreshToken != nil {
+		authHandler.SetRefreshTokenRepo(repos.RefreshToken)
+	}
+
+	// OIDC handler — conditionally initialize when enabled.
+	var oidcHandler *handlers.OIDCHandler
+	if cfg.OIDC.Enabled {
+		oidcProvider, oidcErr := auth.NewProvider(context.Background(), &cfg.OIDC)
+		if oidcErr != nil {
+			return nil, fmt.Errorf("initialize OIDC provider: %w", oidcErr)
+		}
+		oidcHandler = handlers.NewOIDCHandler(oidcProvider, sessStore, repos.User, &cfg.OIDC, &cfg.Auth)
+		if repos.RefreshToken != nil {
+			oidcHandler.SetRefreshTokenRepo(repos.RefreshToken)
+		}
+		slog.Info("OIDC authentication enabled", "provider_url", cfg.OIDC.ProviderURL)
+	}
+
+	// Template handler.
+	templateHandler, err := handlers.NewTemplateHandlerWithVersions(
+		repos.StackTemplate, repos.TemplateChartConfig, repos.StackDefinition,
+		repos.ChartConfig, repos.TemplateVersion, repos.TxRunner,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create template handler: %w", err)
+	}
+
+	// Definition handler.
+	definitionHandler, err := handlers.NewDefinitionHandlerWithVersions(
+		repos.StackDefinition, repos.ChartConfig, repos.StackInstance,
+		repos.StackTemplate, repos.TemplateChartConfig, repos.TemplateVersion, repos.TxRunner,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create definition handler: %w", err)
+	}
+
+	// Template version handler.
+	templateVersionHandler := handlers.NewTemplateVersionHandler(repos.TemplateVersion, repos.StackTemplate)
+
+	// Instance handler.
+	instanceHandler, err := handlers.NewInstanceHandlerWithDeployer(
+		repos.StackInstance, repos.ValueOverride, repos.ChartBranchOverride,
+		repos.StackDefinition, repos.ChartConfig,
+		repos.StackTemplate, repos.TemplateChartConfig, svc.ValuesGen, repos.User,
+		svc.DeployManager, svc.K8sWatcher, svc.ClusterRegistry, repos.DeploymentLog, repos.Cluster,
+		cfg.App.DefaultInstanceTTLMinutes,
+		repos.TxRunner,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create instance handler: %w", err)
+	}
+	instanceHandler.WithHooks(svc.HookDispatcher).WithActions(svc.ActionRegistry).WithNotifier(svc.LifecycleNotifier)
+
+	// Git handler.
+	gitHandler := handlers.NewGitHandler(svc.GitRegistry)
+
+	// Audit log handler.
+	auditLogHandler := handlers.NewAuditLogHandler(repos.AuditLog)
+
+	// User handler.
+	userHandler := handlers.NewUserHandler(repos.User)
+	userHandler.SetSessionStore(sessStore)
+	if repos.RefreshToken != nil {
+		userHandler.SetRefreshTokenRepo(repos.RefreshToken)
+	}
+	userHandler.SetAccessTokenExpiration(cfg.Auth.AccessTokenExpiration)
+	userHandler.SetJWTExpiration(cfg.Auth.JWTExpiration)
+
+	// API key handler.
+	apiKeyHandler := handlers.NewAPIKeyHandler(repos.APIKey, repos.User, &cfg.Auth)
+
+	// Admin handler.
+	adminHandler := handlers.NewAdminHandler(svc.ClusterRegistry, repos.StackInstance)
+
+	// Cluster handler.
+	clusterHandler := handlers.NewClusterHandlerWithQuotas(repos.Cluster, svc.ClusterRegistry, repos.StackInstance, repos.ResourceQuota)
+
+	// Branch override handler.
+	branchOverrideHandler := handlers.NewBranchOverrideHandler(repos.ChartBranchOverride, repos.StackInstance)
+
+	// Instance quota override handler.
+	instanceQuotaOverrideHandler := handlers.NewInstanceQuotaOverrideHandler(repos.InstanceQuotaOverride, repos.StackInstance)
+
+	// Shared values handler.
+	sharedValuesHandler := handlers.NewSharedValuesHandler(repos.SharedValues, repos.Cluster)
+
+	// Notification handler.
+	notificationHandler := handlers.NewNotificationHandler(repos.Notification)
+
+	// Favorite handler.
+	favoriteHandler := handlers.NewFavoriteHandler(repos.UserFavorite)
+
+	// Quick deploy handler.
+	quickDeployHandler, err := handlers.NewQuickDeployHandler(
+		repos.StackTemplate, repos.TemplateChartConfig, repos.StackDefinition, repos.ChartConfig,
+		repos.StackInstance, repos.ChartBranchOverride, repos.ValueOverride, svc.ValuesGen,
+		svc.DeployManager, repos.User, repos.DeploymentLog, repos.AuditLog,
+		hub, svc.ClusterRegistry, svc.K8sWatcher,
+		cfg.App.DefaultInstanceTTLMinutes,
+		repos.TxRunner,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create quick deploy handler: %w", err)
+	}
+
+	// Analytics handler.
+	analyticsHandler := handlers.NewAnalyticsHandler(repos.StackTemplate, repos.StackDefinition, repos.StackInstance, repos.DeploymentLog, repos.User)
+
+	// Dashboard handler.
+	dashboardHandler := handlers.NewDashboardHandler(repos.Cluster, repos.StackInstance, repos.DeploymentLog, svc.ClusterRegistry)
+
+	// Cleanup policy handler.
+	cleanupPolicyHandler := handlers.NewCleanupPolicyHandler(repos.CleanupPolicy, svc.CleanupScheduler)
+
+	// Auto-create admin user on startup.
+	authHandler.EnsureAdminUser()
+
+	return &handlerSet{
+		Auth:                  authHandler,
+		OIDC:                  oidcHandler,
+		Template:              templateHandler,
+		Definition:            definitionHandler,
+		TemplateVersion:       templateVersionHandler,
+		Instance:              instanceHandler,
+		Git:                   gitHandler,
+		AuditLog:              auditLogHandler,
+		User:                  userHandler,
+		APIKey:                apiKeyHandler,
+		Admin:                 adminHandler,
+		Cluster:               clusterHandler,
+		BranchOverride:        branchOverrideHandler,
+		InstanceQuotaOverride: instanceQuotaOverrideHandler,
+		SharedValues:          sharedValuesHandler,
+		Notification:          notificationHandler,
+		Favorite:              favoriteHandler,
+		QuickDeploy:           quickDeployHandler,
+		Analytics:             analyticsHandler,
+		Dashboard:             dashboardHandler,
+		CleanupPolicy:         cleanupPolicyHandler,
+	}, nil
+}
+
+// buildRouter creates the Gin engine, wires all routes, and returns the
+// router plus the rate limiters (caller must stop them on shutdown).
+func buildRouter(cfg *config.Config, hs *handlerSet, deps routerDeps) (*gin.Engine, *routes.RateLimiters) {
+	router := gin.New()
+	rateLimiters := routes.SetupRoutes(router, routes.Deps{
+		Repository:                   deps.Repo,
+		HealthChecker:                deps.HealthChecker,
+		Config:                       cfg,
+		Hub:                          deps.Hub,
+		AuthHandler:                  hs.Auth,
+		TemplateHandler:              hs.Template,
+		DefinitionHandler:            hs.Definition,
+		InstanceHandler:              hs.Instance,
+		GitHandler:                   hs.Git,
+		AuditLogHandler:              hs.AuditLog,
+		AuditLogger:                  deps.Repos.AuditLog,
+		UserHandler:                  hs.User,
+		APIKeyHandler:                hs.APIKey,
+		AdminHandler:                 hs.Admin,
+		BranchOverrideHandler:        hs.BranchOverride,
+		InstanceQuotaOverrideHandler: hs.InstanceQuotaOverride,
+		TemplateVersionHandler:       hs.TemplateVersion,
+		NotificationHandler:          hs.Notification,
+		FavoriteHandler:              hs.Favorite,
+		QuickDeployHandler:           hs.QuickDeploy,
+		AnalyticsHandler:             hs.Analytics,
+		DashboardHandler:             hs.Dashboard,
+		CleanupPolicyHandler:         hs.CleanupPolicy,
+		CleanupScheduler:             deps.Svc.CleanupScheduler,
+		ClusterHandler:               hs.Cluster,
+		SharedValuesHandler:          hs.SharedValues,
+		UserRepo:                     deps.Repos.User,
+		APIKeyRepo:                   deps.Repos.APIKey,
+		OIDCHandler:                  hs.OIDC,
+		SessionStore:                 deps.SessionStore,
+		HealthVerbose:                cfg.Server.HealthVerbose,
+	})
+	return router, rateLimiters
+}
+
+// startBackgroundServices starts all background goroutines (TTL reaper, expiry
+// warner, quota monitor, secret monitor, refresh token cleanup, cleanup scheduler)
+// and returns a struct the caller can use to stop them.
+func startBackgroundServices(
+	svc *domainServices,
+	hs *handlerSet,
+	repos *database.RepositorySet,
+	cfg *config.Config,
+	hub *websocket.Hub,
+) (*backgroundServices, error) {
+	// TTL reaper for auto-expiring stack instances.
+	expiryStopper := deployer.NewExpiryStopper(svc.DeployManager, repos.StackDefinition, repos.ChartConfig)
+	reaper := ttl.NewReaper(repos.StackInstance, repos.AuditLog, hub, expiryStopper, 60*time.Second)
+	go reaper.Start()
+
+	// TTL expiry warner — warns users before their stack expires.
+	expiryWarner := ttl.NewWarner(repos.StackInstance, svc.LifecycleNotifier, 30*time.Minute, 60*time.Second)
+	go expiryWarner.Start()
+
+	// Quota monitor — alerts admins when cluster resource usage is high.
+	quotaMonitor := cluster.NewQuotaMonitor(cluster.QuotaMonitorConfig{
+		ClusterRepo:  repos.Cluster,
+		InstanceRepo: repos.StackInstance,
+		QuotaRepo:    repos.ResourceQuota,
+		Registry:     svc.ClusterRegistry,
+		Notifier:     svc.LifecycleNotifier,
+	})
+	quotaMonitor.Start()
+
+	// Secret expiry monitor — alerts admins before secrets expire.
+	secretMonitor := cluster.NewSecretMonitor(cluster.SecretMonitorConfig{
+		ClusterRepo:  repos.Cluster,
+		InstanceRepo: repos.StackInstance,
+		Registry:     svc.ClusterRegistry,
+		Notifier:     svc.LifecycleNotifier,
+	})
+	secretMonitor.Start()
+
+	// Periodically clean up expired refresh tokens (every hour).
+	refreshTokenCleanupCtx, refreshTokenCleanupCancel := context.WithCancel(context.Background())
+	go func(ctx context.Context) {
+		ticker := time.NewTicker(time.Hour)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				hs.Auth.CleanupExpiredTokens()
+			}
+		}
+	}(refreshTokenCleanupCtx)
+
+	// Start cleanup scheduler.
+	if err := svc.CleanupScheduler.Start(); err != nil {
+		refreshTokenCleanupCancel()
+		reaper.Stop()
+		expiryWarner.Stop()
+		quotaMonitor.Stop()
+		secretMonitor.Stop()
+		return nil, fmt.Errorf("start cleanup scheduler: %w", err)
+	}
+
+	return &backgroundServices{
+		Reaper:                    reaper,
+		ExpiryWarner:              expiryWarner,
+		QuotaMonitor:              quotaMonitor,
+		SecretMonitor:             secretMonitor,
+		RefreshTokenCleanupCancel: refreshTokenCleanupCancel,
+	}, nil
+}
+
+// startHTTPServer creates, configures, and starts the HTTP server (and
+// optionally a pprof server) in background goroutines.
+func startHTTPServer(router *gin.Engine, cfg *config.Config) *http.Server {
+	// Start pprof server on a separate port when PPROF_ENABLED=true.
+	if cfg.Server.PprofEnabled {
+		pprofMux := http.NewServeMux()
+		pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
+		pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+		pprofSrv := &http.Server{
+			Addr:         cfg.Server.PprofAddr,
+			Handler:      pprofMux,
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		}
+		go func() {
+			slog.Info("pprof server starting", "addr", cfg.Server.PprofAddr)
+			if err := pprofSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+				slog.Error("pprof server failed", "error", err)
+			}
+		}()
+	}
+
+	srv := &http.Server{
+		Addr:         fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port),
+		Handler:      router,
+		ReadTimeout:  cfg.Server.ReadTimeout,
+		WriteTimeout: cfg.Server.WriteTimeout,
+		IdleTimeout:  cfg.Server.IdleTimeout,
+	}
+
+	go func() {
+		slog.Info("Server starting", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Error("Failed to start server", "error", err)
+			os.Exit(1)
+		}
+	}()
+
+	return srv
+}

--- a/backend/api/bootstrap.go
+++ b/backend/api/bootstrap.go
@@ -463,7 +463,6 @@ func startBackgroundServices(
 	svc *domainServices,
 	hs *handlerSet,
 	repos *database.RepositorySet,
-	cfg *config.Config,
 	hub *websocket.Hub,
 ) (*backgroundServices, error) {
 	// TTL reaper for auto-expiring stack instances.

--- a/backend/api/bootstrap.go
+++ b/backend/api/bootstrap.go
@@ -162,25 +162,7 @@ func buildDomainServices(
 	})
 	healthChecker.AddCheck("helm", deployer.HelmHealthCheck(cfg.Deployment.HelmBinary))
 
-	// Cluster health poller.
-	healthPoller := cluster.NewHealthPoller(cluster.HealthPollerConfig{
-		ClusterRepo: repos.Cluster,
-		Registry:    clusterRegistry,
-		Interval:    cfg.Deployment.ClusterHealthPollInterval,
-		Hub:         hub,
-	})
-	healthPoller.Start()
-
-	// Image pull secret refresher.
-	secretRefresher := cluster.NewSecretRefresher(cluster.SecretRefresherConfig{
-		ClusterRepo:  repos.Cluster,
-		InstanceRepo: repos.StackInstance,
-		Registry:     clusterRegistry,
-	})
-	secretRefresher.Start()
-
-	// Webhook / action hooks — load before starting the watcher so errors
-	// don't leak the watcher's cancel context.
+	// Load hooks config before starting goroutines so errors don't leak them.
 	hookCfg, actionSpecs, hookErr := hooks.LoadConfigFile(cfg.Deployment.HooksConfigFile)
 	if hookErr != nil {
 		return nil, fmt.Errorf("load hooks config: %w", hookErr)
@@ -201,6 +183,23 @@ func buildDomainServices(
 			return nil, fmt.Errorf("build action registry: %w", hookErr)
 		}
 	}
+
+	// Cluster health poller.
+	healthPoller := cluster.NewHealthPoller(cluster.HealthPollerConfig{
+		ClusterRepo: repos.Cluster,
+		Registry:    clusterRegistry,
+		Interval:    cfg.Deployment.ClusterHealthPollInterval,
+		Hub:         hub,
+	})
+	healthPoller.Start()
+
+	// Image pull secret refresher.
+	secretRefresher := cluster.NewSecretRefresher(cluster.SecretRefresherConfig{
+		ClusterRepo:  repos.Cluster,
+		InstanceRepo: repos.StackInstance,
+		Registry:     clusterRegistry,
+	})
+	secretRefresher.Start()
 
 	// K8s watcher for multi-cluster monitoring.
 	k8sWatcher := k8s.NewWatcher(clusterRegistry, repos.StackInstance, hub, 30*time.Second)
@@ -529,9 +528,17 @@ func startBackgroundServices(
 	}, nil
 }
 
+// servers holds the HTTP servers started during bootstrap.
+type servers struct {
+	Main  *http.Server
+	Pprof *http.Server // nil when pprof is disabled
+}
+
 // startHTTPServer creates, configures, and starts the HTTP server (and
 // optionally a pprof server) in background goroutines.
-func startHTTPServer(router *gin.Engine, cfg *config.Config) *http.Server {
+func startHTTPServer(router *gin.Engine, cfg *config.Config) *servers {
+	s := &servers{}
+
 	// Start pprof server on a separate port when PPROF_ENABLED=true.
 	if cfg.Server.PprofEnabled {
 		pprofMux := http.NewServeMux()
@@ -540,7 +547,7 @@ func startHTTPServer(router *gin.Engine, cfg *config.Config) *http.Server {
 		pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 		pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 		pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		pprofSrv := &http.Server{
+		s.Pprof = &http.Server{
 			Addr:         cfg.Server.PprofAddr,
 			Handler:      pprofMux,
 			ReadTimeout:  30 * time.Second,
@@ -548,14 +555,14 @@ func startHTTPServer(router *gin.Engine, cfg *config.Config) *http.Server {
 			IdleTimeout:  60 * time.Second,
 		}
 		go func() {
-			slog.Info("pprof server starting", "addr", cfg.Server.PprofAddr)
-			if err := pprofSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slog.Info("pprof server starting", "addr", s.Pprof.Addr)
+			if err := s.Pprof.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				slog.Error("pprof server failed", "error", err)
 			}
 		}()
 	}
 
-	srv := &http.Server{
+	s.Main = &http.Server{
 		Addr:         fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port),
 		Handler:      router,
 		ReadTimeout:  cfg.Server.ReadTimeout,
@@ -564,12 +571,12 @@ func startHTTPServer(router *gin.Engine, cfg *config.Config) *http.Server {
 	}
 
 	go func() {
-		slog.Info("Server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		slog.Info("Server starting", "addr", s.Main.Addr)
+		if err := s.Main.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slog.Error("Failed to start server", "error", err)
 			os.Exit(1)
 		}
 	}()
 
-	return srv
+	return s
 }

--- a/backend/api/bootstrap_test.go
+++ b/backend/api/bootstrap_test.go
@@ -264,7 +264,8 @@ func TestStartHTTPServer_ListensOnConfiguredAddress(t *testing.T) {
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	waitForServer(t, addr)
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/ping", addr))
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/ping", addr))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
@@ -297,7 +298,8 @@ func TestStartHTTPServer_PprofEnabled(t *testing.T) {
 	pprofAddr := fmt.Sprintf("127.0.0.1:%d", pprofPort)
 	waitForServer(t, pprofAddr)
 
-	resp, err := http.Get(fmt.Sprintf("http://%s/debug/pprof/", pprofAddr))
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/debug/pprof/", pprofAddr))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)

--- a/backend/api/bootstrap_test.go
+++ b/backend/api/bootstrap_test.go
@@ -1093,7 +1093,7 @@ func TestStartBackgroundServices_ReturnsAllFields(t *testing.T) {
 	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
 	require.NoError(t, err)
 
-	bg, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	bg, err := startBackgroundServices(svc, hs, repos, hub)
 	require.NoError(t, err)
 	require.NotNil(t, bg)
 
@@ -1158,7 +1158,7 @@ func TestBootstrapFullPipeline(t *testing.T) {
 	t.Cleanup(func() { rateLimiters.Stop() })
 
 	// Step 4: Background services.
-	bg, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	bg, err := startBackgroundServices(svc, hs, repos, hub)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		bg.RefreshTokenCleanupCancel()

--- a/backend/api/bootstrap_test.go
+++ b/backend/api/bootstrap_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -393,4 +394,811 @@ func TestInitRepositories_RequiresMySQL(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping: initRepositories requires a real MySQL connection")
 	}
+}
+
+// ============================================================================
+// Stub repository implementations for bootstrap wiring tests.
+// Each stub satisfies its respective interface with no-op methods returning
+// zero values. These are only used to satisfy constructors — no handler logic
+// is exercised.
+// ============================================================================
+
+// ---- stubClusterRepo ----
+
+type stubClusterRepo struct{}
+
+func (s *stubClusterRepo) Create(_ *models.Cluster) error             { return nil }
+func (s *stubClusterRepo) FindByID(_ string) (*models.Cluster, error) { return nil, nil }
+func (s *stubClusterRepo) Update(_ *models.Cluster) error             { return nil }
+func (s *stubClusterRepo) Delete(_ string) error                      { return nil }
+func (s *stubClusterRepo) List() ([]models.Cluster, error)            { return nil, nil }
+func (s *stubClusterRepo) FindDefault() (*models.Cluster, error)      { return nil, nil }
+func (s *stubClusterRepo) SetDefault(_ string) error                  { return nil }
+
+// ---- stubStackInstanceRepo ----
+
+type stubStackInstanceRepo struct{}
+
+func (s *stubStackInstanceRepo) Create(_ *models.StackInstance) error              { return nil }
+func (s *stubStackInstanceRepo) FindByID(_ string) (*models.StackInstance, error)  { return nil, nil }
+func (s *stubStackInstanceRepo) FindByNamespace(_ string) (*models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) Update(_ *models.StackInstance) error               { return nil }
+func (s *stubStackInstanceRepo) Delete(_ string) error                              { return nil }
+func (s *stubStackInstanceRepo) List() ([]models.StackInstance, error)              { return nil, nil }
+func (s *stubStackInstanceRepo) ListPaged(_, _ int) ([]models.StackInstance, int, error) {
+	return nil, 0, nil
+}
+func (s *stubStackInstanceRepo) ListByOwner(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) FindByCluster(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) CountByClusterAndOwner(_, _ string) (int, error) { return 0, nil }
+func (s *stubStackInstanceRepo) CountAll() (int, error)                          { return 0, nil }
+func (s *stubStackInstanceRepo) CountByStatus(_ string) (int, error)             { return 0, nil }
+func (s *stubStackInstanceRepo) CountByDefinitionIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) CountByOwnerIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubStackInstanceRepo) ListExpired() ([]*models.StackInstance, error)   { return nil, nil }
+func (s *stubStackInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
+// ---- stubStackDefinitionRepo ----
+
+type stubStackDefinitionRepo struct{}
+
+func (s *stubStackDefinitionRepo) Create(_ *models.StackDefinition) error             { return nil }
+func (s *stubStackDefinitionRepo) FindByID(_ string) (*models.StackDefinition, error) { return nil, nil }
+func (s *stubStackDefinitionRepo) FindByName(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) Update(_ *models.StackDefinition) error               { return nil }
+func (s *stubStackDefinitionRepo) Delete(_ string) error                                { return nil }
+func (s *stubStackDefinitionRepo) List() ([]models.StackDefinition, error)              { return nil, nil }
+func (s *stubStackDefinitionRepo) ListPaged(_, _ int) ([]models.StackDefinition, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubStackDefinitionRepo) ListByOwner(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) ListByTemplate(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) CountByTemplateIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) ListIDsByTemplateIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) Count() (int64, error) { return 0, nil }
+
+// ---- stubChartConfigRepo ----
+
+type stubChartConfigRepo struct{}
+
+func (s *stubChartConfigRepo) Create(_ *models.ChartConfig) error             { return nil }
+func (s *stubChartConfigRepo) FindByID(_ string) (*models.ChartConfig, error) { return nil, nil }
+func (s *stubChartConfigRepo) Update(_ *models.ChartConfig) error             { return nil }
+func (s *stubChartConfigRepo) Delete(_ string) error                          { return nil }
+func (s *stubChartConfigRepo) ListByDefinition(_ string) ([]models.ChartConfig, error) {
+	return nil, nil
+}
+
+// ---- stubDeploymentLogRepo ----
+
+type stubDeploymentLogRepo struct{}
+
+func (s *stubDeploymentLogRepo) Create(_ context.Context, _ *models.DeploymentLog) error { return nil }
+func (s *stubDeploymentLogRepo) FindByID(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) Update(_ context.Context, _ *models.DeploymentLog) error { return nil }
+func (s *stubDeploymentLogRepo) ListByInstance(_ context.Context, _ string) ([]models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) ListByInstancePaginated(_ context.Context, _ models.DeploymentLogFilters) (*models.DeploymentLogResult, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) GetLatestByInstance(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) SummarizeByInstance(_ context.Context, _ string) (*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) SummarizeBatch(_ context.Context, _ []string) (map[string]*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) CountByAction(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (s *stubDeploymentLogRepo) ListRecentGlobal(_ context.Context, _ int) ([]models.DeploymentLogWithContext, error) {
+	return nil, nil
+}
+
+// ---- stubAuditLogRepo ----
+
+type stubAuditLogRepo struct{}
+
+func (s *stubAuditLogRepo) Create(_ *models.AuditLog) error                          { return nil }
+func (s *stubAuditLogRepo) List(_ models.AuditLogFilters) (*models.AuditLogResult, error) { return nil, nil }
+
+// ---- stubResourceQuotaRepo ----
+
+type stubResourceQuotaRepo struct{}
+
+func (s *stubResourceQuotaRepo) GetByClusterID(_ context.Context, _ string) (*models.ResourceQuotaConfig, error) {
+	return nil, nil
+}
+func (s *stubResourceQuotaRepo) Upsert(_ context.Context, _ *models.ResourceQuotaConfig) error {
+	return nil
+}
+func (s *stubResourceQuotaRepo) Delete(_ context.Context, _ string) error { return nil }
+
+// ---- stubInstanceQuotaOverrideRepo ----
+
+type stubInstanceQuotaOverrideRepo struct{}
+
+func (s *stubInstanceQuotaOverrideRepo) GetByInstanceID(_ context.Context, _ string) (*models.InstanceQuotaOverride, error) {
+	return nil, nil
+}
+func (s *stubInstanceQuotaOverrideRepo) Upsert(_ context.Context, _ *models.InstanceQuotaOverride) error {
+	return nil
+}
+func (s *stubInstanceQuotaOverrideRepo) Delete(_ context.Context, _ string) error { return nil }
+
+// ---- stubCleanupPolicyRepo ----
+
+type stubCleanupPolicyRepo struct{}
+
+func (s *stubCleanupPolicyRepo) Create(_ *models.CleanupPolicy) error             { return nil }
+func (s *stubCleanupPolicyRepo) FindByID(_ string) (*models.CleanupPolicy, error) { return nil, nil }
+func (s *stubCleanupPolicyRepo) Update(_ *models.CleanupPolicy) error             { return nil }
+func (s *stubCleanupPolicyRepo) Delete(_ string) error                            { return nil }
+func (s *stubCleanupPolicyRepo) List() ([]models.CleanupPolicy, error)            { return nil, nil }
+func (s *stubCleanupPolicyRepo) ListEnabled() ([]models.CleanupPolicy, error)     { return nil, nil }
+
+// ---- stubNotificationRepo ----
+
+type stubNotificationRepo struct{}
+
+func (s *stubNotificationRepo) Create(_ context.Context, _ *models.Notification) error { return nil }
+func (s *stubNotificationRepo) ListByUser(_ context.Context, _ string, _ bool, _, _ int) ([]models.Notification, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubNotificationRepo) CountUnread(_ context.Context, _ string) (int64, error) { return 0, nil }
+func (s *stubNotificationRepo) MarkAsRead(_ context.Context, _, _ string) error        { return nil }
+func (s *stubNotificationRepo) MarkAllAsRead(_ context.Context, _ string) error        { return nil }
+func (s *stubNotificationRepo) GetPreferences(_ context.Context, _ string) ([]models.NotificationPreference, error) {
+	return nil, nil
+}
+func (s *stubNotificationRepo) UpdatePreference(_ context.Context, _ *models.NotificationPreference) error {
+	return nil
+}
+
+// ---- stubUserRepo ----
+
+type stubUserRepo struct{}
+
+func (s *stubUserRepo) Create(_ *models.User) error                           { return nil }
+func (s *stubUserRepo) FindByID(_ string) (*models.User, error)               { return nil, nil }
+func (s *stubUserRepo) FindByIDs(_ []string) (map[string]*models.User, error) { return nil, nil }
+func (s *stubUserRepo) FindByUsername(_ string) (*models.User, error)         { return nil, nil }
+func (s *stubUserRepo) FindByExternalID(_, _ string) (*models.User, error)    { return nil, nil }
+func (s *stubUserRepo) Update(_ *models.User) error                           { return nil }
+func (s *stubUserRepo) Delete(_ string) error                                 { return nil }
+func (s *stubUserRepo) List() ([]models.User, error)                          { return nil, nil }
+func (s *stubUserRepo) Count() (int64, error)                                 { return 0, nil }
+func (s *stubUserRepo) ListByRoles(_ []string) ([]models.User, error)         { return nil, nil }
+
+// ---- stubStackTemplateRepo ----
+
+type stubStackTemplateRepo struct{}
+
+func (s *stubStackTemplateRepo) Create(_ *models.StackTemplate) error                       { return nil }
+func (s *stubStackTemplateRepo) FindByID(_ string) (*models.StackTemplate, error)           { return nil, nil }
+func (s *stubStackTemplateRepo) Update(_ *models.StackTemplate) error                       { return nil }
+func (s *stubStackTemplateRepo) Delete(_ string) error                                      { return nil }
+func (s *stubStackTemplateRepo) List() ([]models.StackTemplate, error)                      { return nil, nil }
+func (s *stubStackTemplateRepo) ListPaged(_, _ int) ([]models.StackTemplate, int64, error)  { return nil, 0, nil }
+func (s *stubStackTemplateRepo) ListPublished() ([]models.StackTemplate, error)             { return nil, nil }
+func (s *stubStackTemplateRepo) ListPublishedPaged(_, _ int) ([]models.StackTemplate, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubStackTemplateRepo) ListByOwner(_ string) ([]models.StackTemplate, error) { return nil, nil }
+func (s *stubStackTemplateRepo) Count() (int64, error)                                { return 0, nil }
+
+// ---- stubTemplateChartConfigRepo ----
+
+type stubTemplateChartConfigRepo struct{}
+
+func (s *stubTemplateChartConfigRepo) Create(_ *models.TemplateChartConfig) error { return nil }
+func (s *stubTemplateChartConfigRepo) FindByID(_ string) (*models.TemplateChartConfig, error) {
+	return nil, nil
+}
+func (s *stubTemplateChartConfigRepo) Update(_ *models.TemplateChartConfig) error { return nil }
+func (s *stubTemplateChartConfigRepo) Delete(_ string) error                      { return nil }
+func (s *stubTemplateChartConfigRepo) ListByTemplate(_ string) ([]models.TemplateChartConfig, error) {
+	return nil, nil
+}
+
+// ---- stubValueOverrideRepo ----
+
+type stubValueOverrideRepo struct{}
+
+func (s *stubValueOverrideRepo) Create(_ *models.ValueOverride) error             { return nil }
+func (s *stubValueOverrideRepo) FindByID(_ string) (*models.ValueOverride, error) { return nil, nil }
+func (s *stubValueOverrideRepo) FindByInstanceAndChart(_, _ string) (*models.ValueOverride, error) {
+	return nil, nil
+}
+func (s *stubValueOverrideRepo) Update(_ *models.ValueOverride) error { return nil }
+func (s *stubValueOverrideRepo) Delete(_ string) error                { return nil }
+func (s *stubValueOverrideRepo) ListByInstance(_ string) ([]models.ValueOverride, error) {
+	return nil, nil
+}
+
+// ---- stubChartBranchOverrideRepo ----
+
+type stubChartBranchOverrideRepo struct{}
+
+func (s *stubChartBranchOverrideRepo) List(_ string) ([]*models.ChartBranchOverride, error) {
+	return nil, nil
+}
+func (s *stubChartBranchOverrideRepo) Get(_, _ string) (*models.ChartBranchOverride, error) {
+	return nil, nil
+}
+func (s *stubChartBranchOverrideRepo) Set(_ *models.ChartBranchOverride) error { return nil }
+func (s *stubChartBranchOverrideRepo) Delete(_, _ string) error                { return nil }
+func (s *stubChartBranchOverrideRepo) DeleteByInstance(_ string) error         { return nil }
+
+// ---- stubAPIKeyRepo ----
+
+type stubAPIKeyRepo struct{}
+
+func (s *stubAPIKeyRepo) Create(_ *models.APIKey) error                   { return nil }
+func (s *stubAPIKeyRepo) FindByID(_, _ string) (*models.APIKey, error)    { return nil, nil }
+func (s *stubAPIKeyRepo) FindByPrefix(_ string) ([]*models.APIKey, error) { return nil, nil }
+func (s *stubAPIKeyRepo) ListByUser(_ string) ([]*models.APIKey, error)   { return nil, nil }
+func (s *stubAPIKeyRepo) UpdateLastUsed(_, _ string, _ time.Time) error   { return nil }
+func (s *stubAPIKeyRepo) Delete(_, _ string) error                        { return nil }
+
+// ---- stubSharedValuesRepo ----
+
+type stubSharedValuesRepo struct{}
+
+func (s *stubSharedValuesRepo) Create(_ *models.SharedValues) error             { return nil }
+func (s *stubSharedValuesRepo) FindByID(_ string) (*models.SharedValues, error) { return nil, nil }
+func (s *stubSharedValuesRepo) FindByClusterAndID(_, _ string) (*models.SharedValues, error) {
+	return nil, nil
+}
+func (s *stubSharedValuesRepo) Update(_ *models.SharedValues) error                   { return nil }
+func (s *stubSharedValuesRepo) Delete(_ string) error                                 { return nil }
+func (s *stubSharedValuesRepo) ListByCluster(_ string) ([]models.SharedValues, error) { return nil, nil }
+
+// ---- stubTemplateVersionRepo ----
+
+type stubTemplateVersionRepo struct{}
+
+func (s *stubTemplateVersionRepo) Create(_ context.Context, _ *models.TemplateVersion) error {
+	return nil
+}
+func (s *stubTemplateVersionRepo) ListByTemplate(_ context.Context, _ string) ([]models.TemplateVersion, error) {
+	return nil, nil
+}
+func (s *stubTemplateVersionRepo) GetByID(_ context.Context, _, _ string) (*models.TemplateVersion, error) {
+	return nil, nil
+}
+func (s *stubTemplateVersionRepo) GetLatestByTemplate(_ context.Context, _ string) (*models.TemplateVersion, error) {
+	return nil, nil
+}
+
+// ---- stubUserFavoriteRepo ----
+
+type stubUserFavoriteRepo struct{}
+
+func (s *stubUserFavoriteRepo) List(_ string) ([]*models.UserFavorite, error) { return nil, nil }
+func (s *stubUserFavoriteRepo) Add(_ *models.UserFavorite) error              { return nil }
+func (s *stubUserFavoriteRepo) Remove(_, _, _ string) error                   { return nil }
+func (s *stubUserFavoriteRepo) IsFavorite(_, _, _ string) (bool, error)       { return false, nil }
+
+// ---- stubRefreshTokenRepo ----
+
+type stubRefreshTokenRepo struct{}
+
+func (s *stubRefreshTokenRepo) Create(_ *models.RefreshToken) error                      { return nil }
+func (s *stubRefreshTokenRepo) FindByTokenHash(_ string) (*models.RefreshToken, error)   { return nil, nil }
+func (s *stubRefreshTokenRepo) RevokeByID(_ string) error                                { return nil }
+func (s *stubRefreshTokenRepo) RevokeByIDIfActive(_ string) (int64, error)               { return 0, nil }
+func (s *stubRefreshTokenRepo) RevokeAllForUser(_ string) error                          { return nil }
+func (s *stubRefreshTokenRepo) RevokeAllForUserExcept(_, _ string) error                 { return nil }
+func (s *stubRefreshTokenRepo) DeleteExpired() (int64, error)                            { return 0, nil }
+func (s *stubRefreshTokenRepo) CountActiveForUser(_ string) (int64, error)               { return 0, nil }
+func (s *stubRefreshTokenRepo) WithTx(fn func(txRepo models.RefreshTokenRepository) error) error {
+	return fn(s)
+}
+
+// ---- stubTxRunner ----
+
+type stubTxRunner struct{}
+
+func (s *stubTxRunner) RunInTx(fn func(repos database.TxRepos) error) error {
+	return fn(database.TxRepos{})
+}
+
+// ---- stubGenericRepo (models.Repository) ----
+
+type stubGenericRepo struct{}
+
+func (s *stubGenericRepo) Create(_ context.Context, _ interface{}) error              { return nil }
+func (s *stubGenericRepo) FindByID(_ context.Context, _ uint, _ interface{}) error    { return nil }
+func (s *stubGenericRepo) Update(_ context.Context, _ interface{}) error              { return nil }
+func (s *stubGenericRepo) Delete(_ context.Context, _ interface{}) error              { return nil }
+func (s *stubGenericRepo) List(_ context.Context, _ interface{}, _ ...interface{}) error { return nil }
+func (s *stubGenericRepo) Ping(_ context.Context) error                               { return nil }
+func (s *stubGenericRepo) Close() error                                               { return nil }
+
+// ============================================================================
+// Test helpers
+// ============================================================================
+
+// buildTestConfig returns a minimal *config.Config suitable for bootstrap tests.
+// Fields are set to their minimum valid values needed for the bootstrap functions.
+func buildTestConfig() *config.Config {
+	return &config.Config{
+		CORS: config.CORSConfig{AllowedOrigins: "*"},
+		Server: config.ServerConfig{
+			Host:           "127.0.0.1",
+			Port:           "0",
+			RateLimit:      100,
+			LoginRateLimit: 10,
+			ReadTimeout:    5 * time.Second,
+			WriteTimeout:   5 * time.Second,
+			IdleTimeout:    30 * time.Second,
+		},
+		Auth: config.AuthConfig{
+			JWTSecret:              "test-secret-key-for-bootstrap-tests-minimum-length",
+			JWTExpiration:          time.Hour,
+			AccessTokenExpiration:  15 * time.Minute,
+			RefreshTokenExpiration: 24 * time.Hour,
+			AdminUsername:          "admin",
+			AdminPassword:          "admin-password-for-test",
+		},
+		Deployment: config.DeploymentConfig{
+			HelmBinary:                "helm",
+			HooksConfigFile:           "",
+			ClusterHealthPollInterval: 60 * time.Second,
+			DeploymentTimeout:         5 * time.Minute,
+			MaxConcurrentDeploys:      2,
+		},
+	}
+}
+
+// buildTestRepositorySet returns a *database.RepositorySet with all fields
+// populated by no-op stub implementations. No database connection is needed.
+func buildTestRepositorySet() *database.RepositorySet {
+	return &database.RepositorySet{
+		Cluster:               &stubClusterRepo{},
+		StackInstance:         &stubStackInstanceRepo{},
+		StackDefinition:       &stubStackDefinitionRepo{},
+		ChartConfig:           &stubChartConfigRepo{},
+		DeploymentLog:         &stubDeploymentLogRepo{},
+		AuditLog:              &stubAuditLogRepo{},
+		ResourceQuota:         &stubResourceQuotaRepo{},
+		InstanceQuotaOverride: &stubInstanceQuotaOverrideRepo{},
+		CleanupPolicy:         &stubCleanupPolicyRepo{},
+		Notification:          &stubNotificationRepo{},
+		User:                  &stubUserRepo{},
+		TxRunner:              &stubTxRunner{},
+		StackTemplate:         &stubStackTemplateRepo{},
+		TemplateChartConfig:   &stubTemplateChartConfigRepo{},
+		ValueOverride:         &stubValueOverrideRepo{},
+		ChartBranchOverride:   &stubChartBranchOverrideRepo{},
+		APIKey:                &stubAPIKeyRepo{},
+		SharedValues:          &stubSharedValuesRepo{},
+		TemplateVersion:       &stubTemplateVersionRepo{},
+		UserFavorite:          &stubUserFavoriteRepo{},
+		RefreshToken:          &stubRefreshTokenRepo{},
+	}
+}
+
+// buildTestHub creates a websocket.Hub for testing, starts it, and registers
+// cleanup to shut it down.
+func buildTestHub(t *testing.T) *websocket.Hub {
+	t.Helper()
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+	return hub
+}
+
+// ============================================================================
+// buildDomainServices tests
+// ============================================================================
+
+func TestBuildDomainServices_ReturnsAllFields(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	require.NotNil(t, svc)
+
+	// Clean up background goroutines started by buildDomainServices.
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	// Every non-optional field must be populated.
+	assert.NotNil(t, svc.GitRegistry, "GitRegistry")
+	assert.NotNil(t, svc.ClusterRegistry, "ClusterRegistry")
+	assert.NotNil(t, svc.HealthPoller, "HealthPoller")
+	assert.NotNil(t, svc.SecretRefresher, "SecretRefresher")
+	assert.NotNil(t, svc.K8sWatcher, "K8sWatcher")
+	assert.NotNil(t, svc.DeployManager, "DeployManager")
+	assert.NotNil(t, svc.LifecycleNotifier, "LifecycleNotifier")
+	assert.NotNil(t, svc.CleanupExecutor, "CleanupExecutor")
+	assert.NotNil(t, svc.CleanupScheduler, "CleanupScheduler")
+	assert.NotNil(t, svc.ValuesGen, "ValuesGen")
+	assert.NotNil(t, svc.WatcherCancel, "WatcherCancel")
+
+	// HookDispatcher and ActionRegistry are nil when HooksConfigFile is empty.
+	assert.Nil(t, svc.HookDispatcher, "HookDispatcher should be nil when no hooks config")
+	assert.Nil(t, svc.ActionRegistry, "ActionRegistry should be nil when no hooks config")
+}
+
+func TestBuildDomainServices_InvalidHooksConfigFile(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	cfg.Deployment.HooksConfigFile = "/nonexistent/hooks.json"
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	assert.Error(t, err, "should fail when hooks config file cannot be read")
+	assert.Nil(t, svc)
+	assert.Contains(t, err.Error(), "load hooks config")
+}
+
+func TestBuildDomainServices_AddsHealthChecks(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	// HealthChecker should have at least the three checks added by buildDomainServices:
+	// "cluster_registry", "git_provider", "helm". We verify by running readiness
+	// and checking for those keys in the result.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	status := healthChecker.CheckReadiness(ctx)
+	assert.Contains(t, status.Checks, "cluster_registry")
+	assert.Contains(t, status.Checks, "git_provider")
+	assert.Contains(t, status.Checks, "helm")
+}
+
+// ============================================================================
+// buildHandlers tests
+// ============================================================================
+
+func TestBuildHandlers_ReturnsAllFields(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+	require.NotNil(t, hs)
+
+	// All handler fields must be non-nil (except OIDC which is nil when disabled).
+	assert.NotNil(t, hs.Auth, "Auth")
+	assert.NotNil(t, hs.Template, "Template")
+	assert.NotNil(t, hs.Definition, "Definition")
+	assert.NotNil(t, hs.TemplateVersion, "TemplateVersion")
+	assert.NotNil(t, hs.Instance, "Instance")
+	assert.NotNil(t, hs.Git, "Git")
+	assert.NotNil(t, hs.AuditLog, "AuditLog")
+	assert.NotNil(t, hs.User, "User")
+	assert.NotNil(t, hs.APIKey, "APIKey")
+	assert.NotNil(t, hs.Admin, "Admin")
+	assert.NotNil(t, hs.Cluster, "Cluster")
+	assert.NotNil(t, hs.BranchOverride, "BranchOverride")
+	assert.NotNil(t, hs.InstanceQuotaOverride, "InstanceQuotaOverride")
+	assert.NotNil(t, hs.SharedValues, "SharedValues")
+	assert.NotNil(t, hs.Notification, "Notification")
+	assert.NotNil(t, hs.Favorite, "Favorite")
+	assert.NotNil(t, hs.QuickDeploy, "QuickDeploy")
+	assert.NotNil(t, hs.Analytics, "Analytics")
+	assert.NotNil(t, hs.Dashboard, "Dashboard")
+	assert.NotNil(t, hs.CleanupPolicy, "CleanupPolicy")
+
+	// OIDC handler should be nil when OIDC is not enabled.
+	assert.Nil(t, hs.OIDC, "OIDC should be nil when cfg.OIDC.Enabled=false")
+}
+
+func TestBuildHandlers_OIDCDisabled(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	cfg.OIDC.Enabled = false
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+	assert.Nil(t, hs.OIDC, "OIDC handler should be nil when disabled")
+}
+
+// ============================================================================
+// buildRouter tests
+// ============================================================================
+
+func TestBuildRouter_ReturnsEngineAndRateLimiters(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+
+	router, rateLimiters := buildRouter(cfg, hs, routerDeps{
+		Repo:          &stubGenericRepo{},
+		HealthChecker: healthChecker,
+		Hub:           hub,
+		SessionStore:  sessStore,
+		Repos:         repos,
+		Svc:           svc,
+	})
+
+	require.NotNil(t, router, "router should not be nil")
+	require.NotNil(t, rateLimiters, "rate limiters should not be nil")
+	t.Cleanup(func() { rateLimiters.Stop() })
+
+	// The router should have registered routes.
+	routeList := router.Routes()
+	assert.Greater(t, len(routeList), 0, "router should have registered routes")
+}
+
+func TestBuildRouter_HealthEndpointResponds(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+
+	router, rateLimiters := buildRouter(cfg, hs, routerDeps{
+		Repo:          &stubGenericRepo{},
+		HealthChecker: healthChecker,
+		Hub:           hub,
+		SessionStore:  sessStore,
+		Repos:         repos,
+		Svc:           svc,
+	})
+	t.Cleanup(func() { rateLimiters.Stop() })
+
+	// Smoke-test: the health endpoint should respond 200.
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/health/live", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "health/live should return 200")
+}
+
+// ============================================================================
+// startBackgroundServices tests
+// ============================================================================
+
+func TestStartBackgroundServices_ReturnsAllFields(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+
+	bg, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	require.NoError(t, err)
+	require.NotNil(t, bg)
+
+	// Clean up all background services.
+	t.Cleanup(func() {
+		bg.RefreshTokenCleanupCancel()
+		bg.Reaper.Stop()
+		bg.ExpiryWarner.Stop()
+		bg.QuotaMonitor.Stop()
+		bg.SecretMonitor.Stop()
+		svc.CleanupScheduler.Stop()
+	})
+
+	assert.NotNil(t, bg.Reaper, "Reaper")
+	assert.NotNil(t, bg.ExpiryWarner, "ExpiryWarner")
+	assert.NotNil(t, bg.QuotaMonitor, "QuotaMonitor")
+	assert.NotNil(t, bg.SecretMonitor, "SecretMonitor")
+	assert.NotNil(t, bg.RefreshTokenCleanupCancel, "RefreshTokenCleanupCancel")
+}
+
+// ============================================================================
+// Full integration: buildDomainServices -> buildHandlers -> buildRouter -> startBackgroundServices
+// ============================================================================
+
+func TestBootstrapFullPipeline(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	cfg := buildTestConfig()
+	repos := buildTestRepositorySet()
+	hub := buildTestHub(t)
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	// Step 1: Domain services.
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		svc.WatcherCancel()
+		svc.K8sWatcher.Stop()
+		svc.HealthPoller.Stop()
+		svc.SecretRefresher.Stop()
+	})
+
+	// Step 2: Handlers.
+	sessStore := sessionstore.NewMemoryStore()
+	t.Cleanup(func() { sessStore.Stop() })
+
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	require.NoError(t, err)
+
+	// Step 3: Router.
+	router, rateLimiters := buildRouter(cfg, hs, routerDeps{
+		Repo:          &stubGenericRepo{},
+		HealthChecker: healthChecker,
+		Hub:           hub,
+		SessionStore:  sessStore,
+		Repos:         repos,
+		Svc:           svc,
+	})
+	require.NotNil(t, router)
+	t.Cleanup(func() { rateLimiters.Stop() })
+
+	// Step 4: Background services.
+	bg, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		bg.RefreshTokenCleanupCancel()
+		bg.Reaper.Stop()
+		bg.ExpiryWarner.Stop()
+		bg.QuotaMonitor.Stop()
+		bg.SecretMonitor.Stop()
+		svc.CleanupScheduler.Stop()
+	})
+
+	// Verify full pipeline produced working endpoints.
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/health/live", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/backend/api/bootstrap_test.go
+++ b/backend/api/bootstrap_test.go
@@ -47,33 +47,28 @@ func TestBuildSessionStore(t *testing.T) {
 	require.NoError(t, db.AutoMigrate(&sessionstore.SessionEntry{}))
 
 	tests := []struct {
-		name        string
-		backend     string
-		wantType    string
-		wantMemory  bool // true → expect *MemoryStore; false → expect *MySQLStore
+		name       string
+		backend    string
+		wantMemory bool // true → expect *MemoryStore; false → expect *MySQLStore
 	}{
 		{
 			name:       "memory backend returns MemoryStore",
 			backend:    "memory",
-			wantType:   "*sessionstore.MemoryStore",
 			wantMemory: true,
 		},
 		{
 			name:       "mysql backend returns MySQLStore",
 			backend:    "mysql",
-			wantType:   "*sessionstore.MySQLStore",
 			wantMemory: false,
 		},
 		{
 			name:       "empty string (default) returns MySQLStore",
 			backend:    "",
-			wantType:   "*sessionstore.MySQLStore",
 			wantMemory: false,
 		},
 		{
 			name:       "unrecognised backend falls through to MySQLStore",
 			backend:    "redis",
-			wantType:   "*sessionstore.MySQLStore",
 			wantMemory: false,
 		},
 	}
@@ -210,22 +205,49 @@ func TestBackgroundServicesFieldTypes(t *testing.T) {
 }
 
 // ---- startHTTPServer tests ----
+//
+// These tests are NOT parallel because startHTTPServer calls os.Exit(1) on
+// bind failure. Running them sequentially eliminates port-race risk.
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+func waitForServer(t *testing.T, addr string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "server at %s did not become ready", addr)
+}
+
+func shutdownServers(t *testing.T, s *servers) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	_ = s.Main.Shutdown(ctx)
+	if s.Pprof != nil {
+		_ = s.Pprof.Shutdown(ctx)
+	}
+}
 
 func TestStartHTTPServer_ListensOnConfiguredAddress(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.GET("/ping", func(c *gin.Context) {
 		c.String(http.StatusOK, "pong")
 	})
 
-	// Pick a free port.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener.Close())
-
+	port := freePort(t)
 	cfg := &config.Config{
 		Server: config.ServerConfig{
 			Host:         "127.0.0.1",
@@ -236,39 +258,24 @@ func TestStartHTTPServer_ListensOnConfiguredAddress(t *testing.T) {
 		},
 	}
 
-	srv := startHTTPServer(router, cfg)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-	})
+	s := startHTTPServer(router, cfg)
+	t.Cleanup(func() { shutdownServers(t, s) })
 
-	// Give the server a moment to start listening.
-	time.Sleep(50 * time.Millisecond)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	waitForServer(t, addr)
 
-	// Verify the server is reachable and serves the expected response.
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/ping", port))
+	resp, err := http.Get(fmt.Sprintf("http://%s/ping", addr))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestStartHTTPServer_PprofEnabled(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Pick two free ports.
-	listener1, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	mainPort := listener1.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener1.Close())
-
-	listener2, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	pprofPort := listener2.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener2.Close())
+	mainPort := freePort(t)
+	pprofPort := freePort(t)
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -282,38 +289,25 @@ func TestStartHTTPServer_PprofEnabled(t *testing.T) {
 		},
 	}
 
-	srv := startHTTPServer(router, cfg)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-	})
+	s := startHTTPServer(router, cfg)
+	t.Cleanup(func() { shutdownServers(t, s) })
 
-	time.Sleep(100 * time.Millisecond)
+	require.NotNil(t, s.Pprof, "pprof server should be set when enabled")
 
-	// Verify the pprof endpoint is reachable.
-	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", pprofPort))
+	pprofAddr := fmt.Sprintf("127.0.0.1:%d", pprofPort)
+	waitForServer(t, pprofAddr)
+
+	resp, err := http.Get(fmt.Sprintf("http://%s/debug/pprof/", pprofAddr))
 	require.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
 func TestStartHTTPServer_PprofDisabled(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	// Pick two free ports — one for main server, one for pprof.
-	listener1, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	mainPort := listener1.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener1.Close())
-
-	listener2, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	pprofPort := listener2.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener2.Close())
+	mainPort := freePort(t)
 
 	cfg := &config.Config{
 		Server: config.ServerConfig{
@@ -323,36 +317,20 @@ func TestStartHTTPServer_PprofDisabled(t *testing.T) {
 			WriteTimeout: 5 * time.Second,
 			IdleTimeout:  30 * time.Second,
 			PprofEnabled: false,
-			PprofAddr:    fmt.Sprintf("127.0.0.1:%d", pprofPort),
 		},
 	}
 
-	srv := startHTTPServer(router, cfg)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-	})
+	s := startHTTPServer(router, cfg)
+	t.Cleanup(func() { shutdownServers(t, s) })
 
-	time.Sleep(100 * time.Millisecond)
-
-	// The pprof endpoint should NOT be listening when disabled.
-	client := &http.Client{Timeout: 500 * time.Millisecond}
-	_, err = client.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", pprofPort))
-	assert.Error(t, err, "pprof server should not be running when PprofEnabled=false")
+	assert.Nil(t, s.Pprof, "pprof server should be nil when disabled")
 }
 
 func TestStartHTTPServer_ReturnsValidServer(t *testing.T) {
-	t.Parallel()
-
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	port := listener.Addr().(*net.TCPAddr).Port
-	require.NoError(t, listener.Close())
-
+	port := freePort(t)
 	cfg := &config.Config{
 		Server: config.ServerConfig{
 			Host:         "127.0.0.1",
@@ -363,19 +341,14 @@ func TestStartHTTPServer_ReturnsValidServer(t *testing.T) {
 		},
 	}
 
-	srv := startHTTPServer(router, cfg)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		defer cancel()
-		_ = srv.Shutdown(ctx)
-	})
+	s := startHTTPServer(router, cfg)
+	t.Cleanup(func() { shutdownServers(t, s) })
 
-	// Verify the returned *http.Server has correct configuration.
-	assert.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), srv.Addr)
-	assert.Equal(t, 15*time.Second, srv.ReadTimeout)
-	assert.Equal(t, 30*time.Second, srv.WriteTimeout)
-	assert.Equal(t, 60*time.Second, srv.IdleTimeout)
-	assert.Equal(t, router, srv.Handler)
+	assert.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), s.Main.Addr)
+	assert.Equal(t, 15*time.Second, s.Main.ReadTimeout)
+	assert.Equal(t, 30*time.Second, s.Main.WriteTimeout)
+	assert.Equal(t, 60*time.Second, s.Main.IdleTimeout)
+	assert.Equal(t, router, s.Main.Handler)
 }
 
 // ---- initDatabase / initRepositories ----

--- a/backend/api/bootstrap_test.go
+++ b/backend/api/bootstrap_test.go
@@ -1,0 +1,396 @@
+package main
+
+import (
+	"backend/internal/api/handlers"
+	"backend/internal/cluster"
+	"backend/internal/config"
+	"backend/internal/database"
+	"backend/internal/deployer"
+	"backend/internal/gitprovider"
+	"backend/internal/health"
+	"backend/internal/helm"
+	"backend/internal/hooks"
+	"backend/internal/k8s"
+	"backend/internal/models"
+	"backend/internal/notifier"
+	"backend/internal/scheduler"
+	"backend/internal/sessionstore"
+	"backend/internal/ttl"
+	"backend/internal/websocket"
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ---- buildSessionStore tests ----
+
+func TestBuildSessionStore(t *testing.T) {
+	t.Parallel()
+
+	// Open an in-memory SQLite DB so NewMySQLStore gets a valid *gorm.DB
+	// (it starts a cleanup goroutine that references db).
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// Auto-migrate the session_entries table so the cleanup goroutine
+	// won't error when it tries to delete expired rows.
+	require.NoError(t, db.AutoMigrate(&sessionstore.SessionEntry{}))
+
+	tests := []struct {
+		name        string
+		backend     string
+		wantType    string
+		wantMemory  bool // true → expect *MemoryStore; false → expect *MySQLStore
+	}{
+		{
+			name:       "memory backend returns MemoryStore",
+			backend:    "memory",
+			wantType:   "*sessionstore.MemoryStore",
+			wantMemory: true,
+		},
+		{
+			name:       "mysql backend returns MySQLStore",
+			backend:    "mysql",
+			wantType:   "*sessionstore.MySQLStore",
+			wantMemory: false,
+		},
+		{
+			name:       "empty string (default) returns MySQLStore",
+			backend:    "",
+			wantType:   "*sessionstore.MySQLStore",
+			wantMemory: false,
+		},
+		{
+			name:       "unrecognised backend falls through to MySQLStore",
+			backend:    "redis",
+			wantType:   "*sessionstore.MySQLStore",
+			wantMemory: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var store sessionstore.SessionStore
+			if tt.wantMemory {
+				store = buildSessionStore(tt.backend, nil) // db not needed for MemoryStore
+			} else {
+				store = buildSessionStore(tt.backend, db)
+			}
+			t.Cleanup(func() { store.Stop() })
+
+			require.NotNil(t, store)
+
+			if tt.wantMemory {
+				_, ok := store.(*sessionstore.MemoryStore)
+				assert.True(t, ok, "expected *sessionstore.MemoryStore, got %T", store)
+			} else {
+				_, ok := store.(*sessionstore.MySQLStore)
+				assert.True(t, ok, "expected *sessionstore.MySQLStore, got %T", store)
+			}
+
+			// Verify the returned value satisfies the SessionStore interface.
+			var _ sessionstore.SessionStore = store
+		})
+	}
+}
+
+func TestBuildSessionStore_MemoryNilDB(t *testing.T) {
+	t.Parallel()
+
+	// Memory backend should work fine even when db is nil.
+	store := buildSessionStore("memory", nil)
+	t.Cleanup(func() { store.Stop() })
+
+	require.NotNil(t, store)
+	_, ok := store.(*sessionstore.MemoryStore)
+	assert.True(t, ok)
+
+	// Smoke-test: basic operations should succeed.
+	ctx := context.Background()
+	err := store.BlockToken(ctx, "test-jti", time.Now().Add(time.Hour))
+	assert.NoError(t, err)
+
+	blocked, err := store.IsTokenBlocked(ctx, "test-jti")
+	assert.NoError(t, err)
+	assert.True(t, blocked)
+}
+
+// ---- struct field compile-time type assertions ----
+//
+// These tests verify that the bootstrap structs expose the expected fields
+// with the expected types. A compilation failure here means a field was
+// renamed, removed, or had its type changed.
+
+func TestDomainServicesFieldTypes(t *testing.T) {
+	t.Parallel()
+
+	var ds domainServices
+
+	// Each assignment is a compile-time check that the field exists and
+	// has the expected type. We use pointers so the zero value works.
+	var _ *gitprovider.Registry = ds.GitRegistry
+	var _ *cluster.Registry = ds.ClusterRegistry
+	var _ *cluster.HealthPoller = ds.HealthPoller
+	var _ *cluster.SecretRefresher = ds.SecretRefresher
+	var _ *k8s.Watcher = ds.K8sWatcher
+	var _ *deployer.Manager = ds.DeployManager
+	var _ *hooks.Dispatcher = ds.HookDispatcher
+	var _ *hooks.ActionRegistry = ds.ActionRegistry
+	var _ *notifier.Notifier = ds.LifecycleNotifier
+	var _ *deployer.CleanupExecutor = ds.CleanupExecutor
+	var _ *scheduler.Scheduler = ds.CleanupScheduler
+	var _ *helm.ValuesGenerator = ds.ValuesGen
+	var _ context.CancelFunc = ds.WatcherCancel
+}
+
+func TestHandlerSetFieldTypes(t *testing.T) {
+	t.Parallel()
+
+	var hs handlerSet
+
+	var _ *handlers.AuthHandler = hs.Auth
+	var _ *handlers.OIDCHandler = hs.OIDC
+	var _ *handlers.TemplateHandler = hs.Template
+	var _ *handlers.DefinitionHandler = hs.Definition
+	var _ *handlers.TemplateVersionHandler = hs.TemplateVersion
+	var _ *handlers.InstanceHandler = hs.Instance
+	var _ *handlers.GitHandler = hs.Git
+	var _ *handlers.AuditLogHandler = hs.AuditLog
+	var _ *handlers.UserHandler = hs.User
+	var _ *handlers.APIKeyHandler = hs.APIKey
+	var _ *handlers.AdminHandler = hs.Admin
+	var _ *handlers.ClusterHandler = hs.Cluster
+	var _ *handlers.BranchOverrideHandler = hs.BranchOverride
+	var _ *handlers.InstanceQuotaOverrideHandler = hs.InstanceQuotaOverride
+	var _ *handlers.SharedValuesHandler = hs.SharedValues
+	var _ *handlers.NotificationHandler = hs.Notification
+	var _ *handlers.FavoriteHandler = hs.Favorite
+	var _ *handlers.QuickDeployHandler = hs.QuickDeploy
+	var _ *handlers.AnalyticsHandler = hs.Analytics
+	var _ *handlers.DashboardHandler = hs.Dashboard
+	var _ *handlers.CleanupPolicyHandler = hs.CleanupPolicy
+}
+
+func TestRouterDepsFieldTypes(t *testing.T) {
+	t.Parallel()
+
+	var rd routerDeps
+
+	var _ models.Repository = rd.Repo
+	var _ *health.HealthChecker = rd.HealthChecker
+	var _ *websocket.Hub = rd.Hub
+	var _ sessionstore.SessionStore = rd.SessionStore
+	var _ *database.RepositorySet = rd.Repos
+	var _ *domainServices = rd.Svc
+}
+
+func TestBackgroundServicesFieldTypes(t *testing.T) {
+	t.Parallel()
+
+	var bg backgroundServices
+
+	var _ *ttl.Reaper = bg.Reaper
+	var _ *ttl.Warner = bg.ExpiryWarner
+	var _ *cluster.QuotaMonitor = bg.QuotaMonitor
+	var _ *cluster.SecretMonitor = bg.SecretMonitor
+	var _ context.CancelFunc = bg.RefreshTokenCleanupCancel
+}
+
+// ---- startHTTPServer tests ----
+
+func TestStartHTTPServer_ListensOnConfiguredAddress(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/ping", func(c *gin.Context) {
+		c.String(http.StatusOK, "pong")
+	})
+
+	// Pick a free port.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:         "127.0.0.1",
+			Port:         fmt.Sprintf("%d", port),
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+			IdleTimeout:  30 * time.Second,
+		},
+	}
+
+	srv := startHTTPServer(router, cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	// Give the server a moment to start listening.
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify the server is reachable and serves the expected response.
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/ping", port))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestStartHTTPServer_PprofEnabled(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Pick two free ports.
+	listener1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	mainPort := listener1.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener1.Close())
+
+	listener2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	pprofPort := listener2.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener2.Close())
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:         "127.0.0.1",
+			Port:         fmt.Sprintf("%d", mainPort),
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+			IdleTimeout:  30 * time.Second,
+			PprofEnabled: true,
+			PprofAddr:    fmt.Sprintf("127.0.0.1:%d", pprofPort),
+		},
+	}
+
+	srv := startHTTPServer(router, cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify the pprof endpoint is reachable.
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", pprofPort))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestStartHTTPServer_PprofDisabled(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	// Pick two free ports — one for main server, one for pprof.
+	listener1, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	mainPort := listener1.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener1.Close())
+
+	listener2, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	pprofPort := listener2.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener2.Close())
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:         "127.0.0.1",
+			Port:         fmt.Sprintf("%d", mainPort),
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+			IdleTimeout:  30 * time.Second,
+			PprofEnabled: false,
+			PprofAddr:    fmt.Sprintf("127.0.0.1:%d", pprofPort),
+		},
+	}
+
+	srv := startHTTPServer(router, cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// The pprof endpoint should NOT be listening when disabled.
+	client := &http.Client{Timeout: 500 * time.Millisecond}
+	_, err = client.Get(fmt.Sprintf("http://127.0.0.1:%d/debug/pprof/", pprofPort))
+	assert.Error(t, err, "pprof server should not be running when PprofEnabled=false")
+}
+
+func TestStartHTTPServer_ReturnsValidServer(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	cfg := &config.Config{
+		Server: config.ServerConfig{
+			Host:         "127.0.0.1",
+			Port:         fmt.Sprintf("%d", port),
+			ReadTimeout:  15 * time.Second,
+			WriteTimeout: 30 * time.Second,
+			IdleTimeout:  60 * time.Second,
+		},
+	}
+
+	srv := startHTTPServer(router, cfg)
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(ctx)
+	})
+
+	// Verify the returned *http.Server has correct configuration.
+	assert.Equal(t, fmt.Sprintf("127.0.0.1:%d", port), srv.Addr)
+	assert.Equal(t, 15*time.Second, srv.ReadTimeout)
+	assert.Equal(t, 30*time.Second, srv.WriteTimeout)
+	assert.Equal(t, 60*time.Second, srv.IdleTimeout)
+	assert.Equal(t, router, srv.Handler)
+}
+
+// ---- initDatabase / initRepositories ----
+//
+// These functions require a real MySQL connection, so we skip them in short
+// mode. The tests are intentionally present to document the expected signatures
+// and serve as a reminder that integration tests exist elsewhere.
+
+func TestInitDatabase_RequiresMySQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: initDatabase requires a real MySQL connection")
+	}
+}
+
+func TestInitRepositories_RequiresMySQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: initRepositories requires a real MySQL connection")
+	}
+}

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -13,7 +13,6 @@ import (
 	"backend/internal/websocket"
 	"context"
 	"log/slog"
-	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -135,7 +134,7 @@ func main() {
 	defer bgSvc.RefreshTokenCleanupCancel()
 
 	// HTTP server.
-	srv := startHTTPServer(router, cfg)
+	srvs := startHTTPServer(router, cfg)
 
 	// Wait for interrupt signal.
 	quit := make(chan os.Signal, 1)
@@ -148,7 +147,7 @@ func main() {
 		shutdownTimeout = defaultShutdownTimeout
 	}
 
-	gracefulShutdown(srv, shutdownTimeout, shutdownDeps{
+	gracefulShutdown(srvs, shutdownTimeout, shutdownDeps{
 		telemetry:        tel,
 		reaper:           bgSvc.Reaper,
 		expiryWarner:     bgSvc.ExpiryWarner,
@@ -189,13 +188,18 @@ type shutdownDeps struct {
 }
 
 // gracefulShutdown stops all services in the correct order.
-func gracefulShutdown(srv *http.Server, timeout time.Duration, deps shutdownDeps) {
+func gracefulShutdown(srvs *servers, timeout time.Duration, deps shutdownDeps) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	// 1. Stop HTTP server — no new requests.
-	if err := srv.Shutdown(ctx); err != nil {
+	// 1. Stop HTTP servers — no new requests.
+	if err := srvs.Main.Shutdown(ctx); err != nil {
 		slog.Error("Server forced to shutdown", "error", err)
+	}
+	if srvs.Pprof != nil {
+		if err := srvs.Pprof.Shutdown(ctx); err != nil {
+			slog.Error("Pprof server forced to shutdown", "error", err)
+		}
 	}
 
 	// 2. Stop producers of deploy work.

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -129,7 +129,7 @@ func main() {
 	defer rateLimiters.Stop()
 
 	// Background services (TTL reaper, expiry warner, monitors, cleanup scheduler).
-	bgSvc, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	bgSvc, err := startBackgroundServices(svc, hs, repos, hub)
 	must("background services", err)
 	defer bgSvc.RefreshTokenCleanupCancel()
 

--- a/backend/api/main.go
+++ b/backend/api/main.go
@@ -3,36 +3,27 @@
 package main
 
 import (
-	"backend/internal/api/handlers"
-	"backend/internal/api/routes"
-	"backend/internal/auth"
-	"backend/internal/cluster"
 	"backend/internal/config"
-	"backend/internal/database"
 	"backend/internal/deployer"
-	"backend/internal/gitprovider"
 	"backend/internal/health"
-	"backend/internal/helm"
-	"backend/internal/hooks"
-	"backend/internal/k8s"
 	"backend/internal/models"
-	"backend/internal/notifier"
 	"backend/internal/scheduler"
 	"backend/internal/sessionstore"
 	"backend/internal/telemetry"
-	"backend/internal/ttl"
 	"backend/internal/websocket"
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
-	"net/http/pprof"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
-	"github.com/gin-gonic/gin"
+	"backend/internal/api/handlers"
+	"backend/internal/cluster"
+	"backend/internal/k8s"
+	"backend/internal/ttl"
+
 	"github.com/google/uuid"
 	"k8s.io/client-go/tools/clientcmd"
 )
@@ -69,7 +60,7 @@ func must(name string, err error) {
 // @name X-API-Key
 // @description API key (format: "sk_<key>")
 func main() {
-	// Load configuration
+	// Load configuration.
 	cfg, err := config.LoadConfig()
 	if err != nil {
 		slog.Error("Failed to load configuration", "error", err)
@@ -87,427 +78,66 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Initialize repository (MySQL via GORM)
-	repo, mysqlGormDB, err := database.NewRepositoryWithGormDB(cfg)
-	if err != nil {
-		slog.Error("Failed to initialize repository", "error", err)
-		os.Exit(1)
-	}
+	// Database + generic repository.
+	repo, mysqlGormDB, err := initDatabase(cfg)
+	must("database", err)
 
 	// Register database/sql pool metrics with OTel.
 	if cfg.Otel.Enabled {
-		sqlDB, err := mysqlGormDB.DB()
-		if err == nil {
-			if err := telemetry.StartDBMetrics(sqlDB); err != nil {
-				slog.Warn("Failed to register DB pool metrics", "error", err)
+		sqlDB, dbErr := mysqlGormDB.DB()
+		if dbErr == nil {
+			if metricsErr := telemetry.StartDBMetrics(sqlDB); metricsErr != nil {
+				slog.Warn("Failed to register DB pool metrics", "error", metricsErr)
 			}
 		}
 	}
 
-	// Initialize health checker with actual database dependency
+	// Health checker.
 	healthChecker := health.New()
 	healthChecker.AddCheck("database", func(ctx context.Context) error {
 		return repo.Ping(ctx)
 	})
 	healthChecker.SetReady(true)
 
-	// Create and start WebSocket hub
+	// WebSocket hub.
 	hub := websocket.NewHub()
 	go hub.Run()
 
-	// ------------------------------------------------------------------
-	// Create all domain-specific repositories via factory
-	// ------------------------------------------------------------------
-	repos, err := database.NewRepositorySet(cfg, mysqlGormDB)
-	if err != nil {
-		slog.Error("Failed to create domain repositories", "error", err)
-		os.Exit(1)
-	}
+	// Domain-specific repositories.
+	repos, err := initRepositories(cfg, mysqlGormDB)
+	must("domain repositories", err)
 
-	userRepo := repos.User
-	templateRepo := repos.StackTemplate
-	templateChartRepo := repos.TemplateChartConfig
-	definitionRepo := repos.StackDefinition
-	chartConfigRepo := repos.ChartConfig
-	instanceRepo := repos.StackInstance
-	overrideRepo := repos.ValueOverride
-	branchOverrideRepo := repos.ChartBranchOverride
-	auditRepo := repos.AuditLog
-	apiKeyRepo := repos.APIKey
-	deployLogRepo := repos.DeploymentLog
-	sharedValuesRepo := repos.SharedValues
-	quotaRepo := repos.ResourceQuota
-	quotaOverrideRepo := repos.InstanceQuotaOverride
-	templateVersionRepo := repos.TemplateVersion
-	notificationRepo := repos.Notification
-	favoriteRepo := repos.UserFavorite
-	cleanupPolicyRepo := repos.CleanupPolicy
-	clusterRepo := repos.Cluster
+	// Domain services (git, cluster, deployer, hooks, etc.).
+	svc, err := buildDomainServices(cfg, repos, hub, healthChecker)
+	must("domain services", err)
 
-	// ------------------------------------------------------------------
-	// Phase 1: Create domain services
-	// ------------------------------------------------------------------
-	gitRegistry := gitprovider.NewRegistry(gitprovider.Config{
-		AzureDevOps: gitprovider.AzureDevOpsConfig{
-			PAT:        cfg.GitProvider.AzureDevOpsPAT,
-			DefaultOrg: cfg.GitProvider.AzureDevOpsDefaultOrg,
-		},
-		GitLab: gitprovider.GitLabConfig{
-			Token:   cfg.GitProvider.GitLabToken,
-			BaseURL: cfg.GitProvider.GitLabBaseURL,
-		},
+	// Session store for token blocklist and OIDC state.
+	sessStore := buildSessionStore(cfg.SessionStore.Backend, mysqlGormDB)
+
+	// HTTP handlers.
+	hs, err := buildHandlers(cfg, repos, svc, sessStore, hub)
+	must("handlers", err)
+
+	// Router.
+	router, rateLimiters := buildRouter(cfg, hs, routerDeps{
+		Repo:          repo,
+		HealthChecker: healthChecker,
+		Hub:           hub,
+		SessionStore:  sessStore,
+		Repos:         repos,
+		Svc:           svc,
 	})
+	defer rateLimiters.Stop()
 
-	valuesGen := helm.NewValuesGenerator()
+	// Background services (TTL reaper, expiry warner, monitors, cleanup scheduler).
+	bgSvc, err := startBackgroundServices(svc, hs, repos, cfg, hub)
+	must("background services", err)
+	defer bgSvc.RefreshTokenCleanupCancel()
 
-	// ------------------------------------------------------------------
-	// Phase 3: Create deployment services
-	// ------------------------------------------------------------------
+	// HTTP server.
+	srv := startHTTPServer(router, cfg)
 
-	// Auto-create default cluster from KUBECONFIG_PATH for single-cluster migration
-	ensureDefaultCluster(clusterRepo, instanceRepo, cfg)
-
-	// Create cluster registry for multi-cluster client management
-	clusterRegistry := cluster.NewRegistry(cluster.RegistryOptions{
-		ClusterRepo: clusterRepo,
-		HelmBinary:  cfg.Deployment.HelmBinary,
-		HelmTimeout: cfg.Deployment.DeploymentTimeout,
-	})
-
-	// Register extended health checks for cluster, git, and helm.
-	healthChecker.AddCheck("cluster_registry", func(ctx context.Context) error {
-		return clusterRegistry.HealthCheck(ctx)
-	})
-	healthChecker.AddCheck("git_provider", func(ctx context.Context) error {
-		return gitRegistry.HealthCheck(ctx)
-	})
-	healthChecker.AddCheck("helm", deployer.HelmHealthCheck(cfg.Deployment.HelmBinary))
-
-	// Start cluster health poller
-	healthPoller := cluster.NewHealthPoller(cluster.HealthPollerConfig{
-		ClusterRepo: clusterRepo,
-		Registry:    clusterRegistry,
-		Interval:    cfg.Deployment.ClusterHealthPollInterval,
-		Hub:         hub,
-	})
-	healthPoller.Start()
-
-	// Start image pull secret refresher for clusters with registry config
-	secretRefresher := cluster.NewSecretRefresher(cluster.SecretRefresherConfig{
-		ClusterRepo:  clusterRepo,
-		InstanceRepo: instanceRepo,
-		Registry:     clusterRegistry,
-	})
-	secretRefresher.Start()
-
-	// K8s watcher — uses registry for multi-cluster monitoring
-	k8sWatcher := k8s.NewWatcher(clusterRegistry, instanceRepo, hub, 30*time.Second)
-	watcherCtx, watcherCancel := context.WithCancel(context.Background())
-	k8sWatcher.Start(watcherCtx)
-
-	// Load webhook subscription + action configuration (optional). When
-	// HOOKS_CONFIG_FILE is unset — or sets no subscriptions and no actions —
-	// the server starts with NIL dispatcher and registry handles: lifecycle
-	// hook calls become no-ops, and the /actions/{name} route returns 503
-	// (matches the documented contract). A non-nil registry with zero
-	// actions would otherwise make that route return 404 (unknown action),
-	// which misleads operators into thinking the feature is enabled.
-	hookCfg, actionSpecs, hookErr := hooks.LoadConfigFile(cfg.Deployment.HooksConfigFile)
-	if hookErr != nil {
-		slog.Error("failed to load hooks config", "file", cfg.Deployment.HooksConfigFile, "error", hookErr)
-		os.Exit(1)
-	}
-
-	var hookDispatcher *hooks.Dispatcher
-	if len(hookCfg.Subscriptions) > 0 {
-		hookDispatcher, hookErr = hooks.NewDispatcher(hookCfg, http.DefaultClient)
-		if hookErr != nil {
-			slog.Error("failed to build hooks dispatcher", "error", hookErr)
-			os.Exit(1)
-		}
-	}
-
-	var actionRegistry *hooks.ActionRegistry
-	if len(actionSpecs) > 0 {
-		actionRegistry, hookErr = hooks.NewActionRegistry(actionSpecs, http.DefaultClient)
-		if hookErr != nil {
-			slog.Error("failed to build action registry", "error", hookErr)
-			os.Exit(1)
-		}
-	}
-
-	var subscribedEvents []string
-	if hookDispatcher != nil {
-		subscribedEvents = hookDispatcher.EventNames()
-	}
-	var actionNames []string
-	if actionRegistry != nil {
-		actionNames = actionRegistry.Names()
-	}
-	slog.Info("hooks configured",
-		"config_file", cfg.Deployment.HooksConfigFile,
-		"subscribed_events", subscribedEvents,
-		"actions", actionNames,
-	)
-
-	// Lifecycle notifier — creates in-app notifications for stack events
-	lifecycleNotifier := notifier.NewNotifier(notificationRepo, hub, userRepo)
-
-	// Deployment manager — uses registry for multi-cluster deploys
-	deployManager := deployer.NewManager(deployer.ManagerConfig{
-		Registry:                   clusterRegistry,
-		InstanceRepo:               instanceRepo,
-		DeployLogRepo:              deployLogRepo,
-		Hub:                        hub,
-		TxRunner:                   repos.TxRunner,
-		MaxConcurrent:              int(cfg.Deployment.MaxConcurrentDeploys),
-		QuotaRepo:                  quotaRepo,
-		QuotaOverrideRepo:          quotaOverrideRepo,
-		WildcardTLSSourceNamespace: cfg.Deployment.WildcardTLSSourceNamespace,
-		WildcardTLSSourceSecret:    cfg.Deployment.WildcardTLSSourceSecret,
-		WildcardTLSTargetSecret:    cfg.Deployment.WildcardTLSTargetSecret,
-		StabilizeTimeout:           cfg.Deployment.StabilizeTimeout,
-		StabilizePollInterval:      cfg.Deployment.StabilizePollInterval,
-		Hooks:                      hookDispatcher,
-		Notifier:                   lifecycleNotifier,
-	})
-
-	// ------------------------------------------------------------------
-	// Phase 1: Create handlers
-	// ------------------------------------------------------------------
-	authHandler := handlers.NewAuthHandler(userRepo, &cfg.Auth, &cfg.OIDC)
-
-	// Create session store for token blocklist and OIDC state persistence.
-	var sessStore sessionstore.SessionStore
-	switch cfg.SessionStore.Backend {
-	case "memory":
-		sessStore = sessionstore.NewMemoryStore()
-	default:
-		sessStore = sessionstore.NewMySQLStore(mysqlGormDB)
-	}
-	authHandler.SetSessionStore(sessStore)
-
-	// Set up refresh token support if repository is available.
-	refreshTokenRepo := repos.RefreshToken
-	if refreshTokenRepo != nil {
-		authHandler.SetRefreshTokenRepo(refreshTokenRepo)
-	}
-
-	// OIDC authentication — conditionally initialize when enabled.
-	var oidcHandler *handlers.OIDCHandler
-	if cfg.OIDC.Enabled {
-		oidcProvider, oidcErr := auth.NewProvider(context.Background(), &cfg.OIDC)
-		if oidcErr != nil {
-			slog.Error("Failed to initialize OIDC provider", "error", oidcErr)
-			os.Exit(1)
-		}
-		oidcHandler = handlers.NewOIDCHandler(oidcProvider, sessStore, userRepo, &cfg.OIDC, &cfg.Auth)
-		if refreshTokenRepo != nil {
-			oidcHandler.SetRefreshTokenRepo(refreshTokenRepo)
-		}
-		slog.Info("OIDC authentication enabled", "provider_url", cfg.OIDC.ProviderURL)
-	}
-
-	templateHandler, err := handlers.NewTemplateHandlerWithVersions(templateRepo, templateChartRepo, definitionRepo, chartConfigRepo, templateVersionRepo, repos.TxRunner)
-	if err != nil {
-		slog.Error("failed to create template handler", "error", err)
-		os.Exit(1)
-	}
-	definitionHandler, err := handlers.NewDefinitionHandlerWithVersions(definitionRepo, chartConfigRepo, instanceRepo, templateRepo, templateChartRepo, templateVersionRepo, repos.TxRunner)
-	if err != nil {
-		slog.Error("failed to create definition handler", "error", err)
-		os.Exit(1)
-	}
-	templateVersionHandler := handlers.NewTemplateVersionHandler(templateVersionRepo, templateRepo)
-	instanceHandler, err := handlers.NewInstanceHandlerWithDeployer(
-		instanceRepo, overrideRepo, branchOverrideRepo, definitionRepo, chartConfigRepo,
-		templateRepo, templateChartRepo, valuesGen, userRepo,
-		deployManager, k8sWatcher, clusterRegistry, deployLogRepo, clusterRepo,
-		cfg.App.DefaultInstanceTTLMinutes,
-		repos.TxRunner,
-	)
-	if err != nil {
-		slog.Error("failed to create instance handler", "error", err)
-		os.Exit(1)
-	}
-	instanceHandler.WithHooks(hookDispatcher).WithActions(actionRegistry).WithNotifier(lifecycleNotifier)
-	gitHandler := handlers.NewGitHandler(gitRegistry)
-	auditLogHandler := handlers.NewAuditLogHandler(auditRepo)
-	userHandler := handlers.NewUserHandler(userRepo)
-	userHandler.SetSessionStore(sessStore)
-	if refreshTokenRepo != nil {
-		userHandler.SetRefreshTokenRepo(refreshTokenRepo)
-	}
-	userHandler.SetAccessTokenExpiration(cfg.Auth.AccessTokenExpiration)
-	userHandler.SetJWTExpiration(cfg.Auth.JWTExpiration)
-	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo, &cfg.Auth)
-
-	adminHandler := handlers.NewAdminHandler(clusterRegistry, instanceRepo)
-	clusterHandler := handlers.NewClusterHandlerWithQuotas(clusterRepo, clusterRegistry, instanceRepo, quotaRepo)
-	branchOverrideHandler := handlers.NewBranchOverrideHandler(branchOverrideRepo, instanceRepo)
-	instanceQuotaOverrideHandler := handlers.NewInstanceQuotaOverrideHandler(quotaOverrideRepo, instanceRepo)
-	sharedValuesHandler := handlers.NewSharedValuesHandler(sharedValuesRepo, clusterRepo)
-
-	notificationHandler := handlers.NewNotificationHandler(notificationRepo)
-
-	favoriteHandler := handlers.NewFavoriteHandler(favoriteRepo)
-
-	quickDeployHandler, err := handlers.NewQuickDeployHandler(
-		templateRepo, templateChartRepo, definitionRepo, chartConfigRepo,
-		instanceRepo, branchOverrideRepo, overrideRepo, valuesGen,
-		deployManager, userRepo, deployLogRepo, auditRepo,
-		hub, clusterRegistry, k8sWatcher,
-		cfg.App.DefaultInstanceTTLMinutes,
-		repos.TxRunner,
-	)
-	if err != nil {
-		slog.Error("failed to create quick deploy handler", "error", err)
-		os.Exit(1)
-	}
-
-	analyticsHandler := handlers.NewAnalyticsHandler(templateRepo, definitionRepo, instanceRepo, deployLogRepo, userRepo)
-	dashboardHandler := handlers.NewDashboardHandler(clusterRepo, instanceRepo, deployLogRepo, clusterRegistry)
-
-	// ------------------------------------------------------------------
-	// Phase 6.2: Cleanup policies
-	// ------------------------------------------------------------------
-	cleanupExecutor := deployer.NewCleanupExecutor(deployManager, definitionRepo, chartConfigRepo, instanceRepo)
-	cleanupScheduler := scheduler.NewScheduler(cleanupPolicyRepo, instanceRepo, auditRepo, cleanupExecutor, lifecycleNotifier)
-	cleanupPolicyHandler := handlers.NewCleanupPolicyHandler(cleanupPolicyRepo, cleanupScheduler)
-
-	// Auto-create admin user on startup if ADMIN_PASSWORD is set.
-	authHandler.EnsureAdminUser()
-
-	// Setup router — use gin.New() since SetupRoutes registers its own Logger and Recovery middleware.
-	router := gin.New()
-	rateLimiter := routes.SetupRoutes(router, routes.Deps{
-		Repository:                   repo,
-		HealthChecker:                healthChecker,
-		Config:                       cfg,
-		Hub:                          hub,
-		AuthHandler:                  authHandler,
-		TemplateHandler:              templateHandler,
-		DefinitionHandler:            definitionHandler,
-		InstanceHandler:              instanceHandler,
-		GitHandler:                   gitHandler,
-		AuditLogHandler:              auditLogHandler,
-		AuditLogger:                  auditRepo,
-		UserHandler:                  userHandler,
-		APIKeyHandler:                apiKeyHandler,
-		AdminHandler:                 adminHandler,
-		BranchOverrideHandler:        branchOverrideHandler,
-		InstanceQuotaOverrideHandler: instanceQuotaOverrideHandler,
-		TemplateVersionHandler:       templateVersionHandler,
-		NotificationHandler:          notificationHandler,
-		FavoriteHandler:              favoriteHandler,
-		QuickDeployHandler:           quickDeployHandler,
-		AnalyticsHandler:             analyticsHandler,
-		DashboardHandler:             dashboardHandler,
-		CleanupPolicyHandler:         cleanupPolicyHandler,
-		CleanupScheduler:             cleanupScheduler,
-		ClusterHandler:               clusterHandler,
-		SharedValuesHandler:          sharedValuesHandler,
-		UserRepo:                     userRepo,
-		APIKeyRepo:                   apiKeyRepo,
-		OIDCHandler:                  oidcHandler,
-		SessionStore:                 sessStore,
-		HealthVerbose:                cfg.Server.HealthVerbose,
-	})
-	defer rateLimiter.Stop()
-
-	// Start TTL reaper for auto-expiring stack instances.
-	expiryStopper := deployer.NewExpiryStopper(deployManager, definitionRepo, chartConfigRepo)
-	reaper := ttl.NewReaper(instanceRepo, auditRepo, hub, expiryStopper, 60*time.Second)
-	go reaper.Start()
-
-	// Start TTL expiry warner — warns users before their stack expires (#189).
-	expiryWarner := ttl.NewWarner(instanceRepo, lifecycleNotifier, 30*time.Minute, 60*time.Second)
-	go expiryWarner.Start()
-
-	// Start quota monitor — alerts admins when cluster resource usage is high (#190).
-	quotaMonitor := cluster.NewQuotaMonitor(cluster.QuotaMonitorConfig{
-		ClusterRepo:  clusterRepo,
-		InstanceRepo: instanceRepo,
-		QuotaRepo:    quotaRepo,
-		Registry:     clusterRegistry,
-		Notifier:     lifecycleNotifier,
-	})
-	quotaMonitor.Start()
-
-	// Start secret expiry monitor — alerts admins before secrets expire (#191).
-	secretMonitor := cluster.NewSecretMonitor(cluster.SecretMonitorConfig{
-		ClusterRepo:  clusterRepo,
-		InstanceRepo: instanceRepo,
-		Registry:     clusterRegistry,
-		Notifier:     lifecycleNotifier,
-	})
-	secretMonitor.Start()
-
-	// Periodically clean up expired refresh tokens (every hour).
-	refreshTokenCleanupCtx, refreshTokenCleanupCancel := context.WithCancel(context.Background())
-	defer refreshTokenCleanupCancel()
-	go func(ctx context.Context) {
-		ticker := time.NewTicker(time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				authHandler.CleanupExpiredTokens()
-			}
-		}
-	}(refreshTokenCleanupCtx)
-
-	// Start cleanup scheduler.
-	if err := cleanupScheduler.Start(); err != nil {
-		slog.Error("Failed to start cleanup scheduler", "error", err)
-		os.Exit(1)
-	}
-
-	// Start pprof server on a separate port when PPROF_ENABLED=true.
-	// Access at http://localhost:6060/debug/pprof/
-	if cfg.Server.PprofEnabled {
-		pprofMux := http.NewServeMux()
-		pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
-		pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-		pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-		pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-		pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-		pprofSrv := &http.Server{
-			Addr:         cfg.Server.PprofAddr,
-			Handler:      pprofMux,
-			ReadTimeout:  30 * time.Second,
-			WriteTimeout: 30 * time.Second,
-			IdleTimeout:  60 * time.Second,
-		}
-		go func() {
-			slog.Info("pprof server starting", "addr", cfg.Server.PprofAddr)
-			if err := pprofSrv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-				slog.Error("pprof server failed", "error", err)
-			}
-		}()
-	}
-
-	// Create server with timeouts
-	srv := &http.Server{
-		Addr:         fmt.Sprintf("%s:%s", cfg.Server.Host, cfg.Server.Port),
-		Handler:      router,
-		ReadTimeout:  cfg.Server.ReadTimeout,
-		WriteTimeout: cfg.Server.WriteTimeout,
-		IdleTimeout:  cfg.Server.IdleTimeout,
-	}
-
-	// Start server in a goroutine
-	go func() {
-		slog.Info("Server starting", "addr", srv.Addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slog.Error("Failed to start server", "error", err)
-			os.Exit(1)
-		}
-	}()
-
-	// Wait for interrupt signal
+	// Wait for interrupt signal.
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
@@ -520,20 +150,20 @@ func main() {
 
 	gracefulShutdown(srv, shutdownTimeout, shutdownDeps{
 		telemetry:        tel,
-		reaper:           reaper,
-		expiryWarner:     expiryWarner,
-		cleanupScheduler: cleanupScheduler,
-		deployManager:    deployManager,
-		healthPoller:     healthPoller,
-		secretRefresher:  secretRefresher,
-		quotaMonitor:     quotaMonitor,
-		secretMonitor:    secretMonitor,
-		k8sWatcher:       k8sWatcher,
+		reaper:           bgSvc.Reaper,
+		expiryWarner:     bgSvc.ExpiryWarner,
+		cleanupScheduler: svc.CleanupScheduler,
+		deployManager:    svc.DeployManager,
+		healthPoller:     svc.HealthPoller,
+		secretRefresher:  svc.SecretRefresher,
+		quotaMonitor:     bgSvc.QuotaMonitor,
+		secretMonitor:    bgSvc.SecretMonitor,
+		k8sWatcher:       svc.K8sWatcher,
 		hub:              hub,
-		clusterRegistry:  clusterRegistry,
-		watcherCancel:    watcherCancel,
+		clusterRegistry:  svc.ClusterRegistry,
+		watcherCancel:    svc.WatcherCancel,
 		sessionStore:     sessStore,
-		dashboardHandler: dashboardHandler,
+		dashboardHandler: hs.Dashboard,
 		repo:             repo,
 	})
 }

--- a/backend/api/main_test.go
+++ b/backend/api/main_test.go
@@ -917,7 +917,7 @@ func TestGracefulShutdown(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		gracefulShutdown(srv, 2*time.Second, shutdownDeps{
+		gracefulShutdown(&servers{Main: srv}, 2*time.Second, shutdownDeps{
 			reaper:           reaper,
 			cleanupScheduler: cleanupScheduler,
 			deployManager:    deployManager,
@@ -976,7 +976,7 @@ func TestGracefulShutdown_RepoCloseError(t *testing.T) {
 	// Should not panic even if repo.Close() errors.
 	done := make(chan struct{})
 	go func() {
-		gracefulShutdown(srv, 2*time.Second, shutdownDeps{
+		gracefulShutdown(&servers{Main: srv}, 2*time.Second, shutdownDeps{
 			reaper:           reaper,
 			cleanupScheduler: cleanupScheduler,
 			deployManager:    deployManager,

--- a/backend/internal/api/handlers/refresh_token_test.go
+++ b/backend/internal/api/handlers/refresh_token_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
 	"time"
 
+	"backend/internal/api/middleware"
 	"backend/internal/config"
 	"backend/internal/models"
 	"backend/internal/sessionstore"
@@ -163,6 +165,24 @@ func (m *MockRefreshTokenRepository) SetFindError(err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.findErr = err
+}
+
+func (m *MockRefreshTokenRepository) SetRevokeError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revokeErr = err
+}
+
+func (m *MockRefreshTokenRepository) SetRevokeAllError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revokeAllErr = err
+}
+
+func (m *MockRefreshTokenRepository) SetDeleteError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.deleteErr = err
 }
 
 // testAuthConfigWithRefresh returns an AuthConfig suitable for refresh token testing.
@@ -560,4 +580,628 @@ func TestRefreshNotEnabled(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotImplemented, w.Code)
+}
+
+// ---- CleanupExpiredTokens Tests ----
+
+func TestCleanupExpiredTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		hasRepo        bool
+		seedExpired    int
+		deleteErr      error
+		wantDeleteCall bool
+	}{
+		{
+			name:           "no repo configured — no-op",
+			hasRepo:        false,
+			wantDeleteCall: false,
+		},
+		{
+			name:           "no expired tokens",
+			hasRepo:        true,
+			seedExpired:    0,
+			wantDeleteCall: true,
+		},
+		{
+			name:           "deletes expired tokens",
+			hasRepo:        true,
+			seedExpired:    3,
+			wantDeleteCall: true,
+		},
+		{
+			name:           "DeleteExpired returns error — logs and returns",
+			hasRepo:        true,
+			deleteErr:      errors.New("db failure"),
+			wantDeleteCall: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := testAuthConfigWithRefresh()
+			h := NewAuthHandler(NewMockUserRepository(), cfg, &config.OIDCConfig{})
+
+			var refreshRepo *MockRefreshTokenRepository
+			if tt.hasRepo {
+				refreshRepo = NewMockRefreshTokenRepository()
+				if tt.deleteErr != nil {
+					refreshRepo.SetDeleteError(tt.deleteErr)
+				}
+				// Seed expired tokens.
+				for i := 0; i < tt.seedExpired; i++ {
+					_ = refreshRepo.Create(&models.RefreshToken{
+						ID:        fmt.Sprintf("rt-expired-%d", i),
+						UserID:    "uid-1",
+						TokenHash: fmt.Sprintf("hash-expired-%d", i),
+						ExpiresAt: time.Now().Add(-time.Hour), // already expired
+						CreatedAt: time.Now().Add(-2 * time.Hour),
+					})
+				}
+				h.SetRefreshTokenRepo(refreshRepo)
+			}
+
+			// Should not panic regardless of configuration.
+			h.CleanupExpiredTokens()
+
+			if tt.hasRepo && tt.deleteErr == nil && tt.seedExpired > 0 {
+				// Verify tokens were actually removed from the store.
+				refreshRepo.mu.RLock()
+				remaining := len(refreshRepo.tokens)
+				refreshRepo.mu.RUnlock()
+				assert.Equal(t, 0, remaining, "expired tokens should have been deleted")
+			}
+		})
+	}
+}
+
+// ---- Logout with access token blocklisting Tests ----
+
+func TestLogout_BlocklistsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		withBearerToken   bool
+		withSessionStore  bool
+		withRefreshCookie bool
+		wantTokenBlocked  bool
+		wantRefreshRevoke bool
+	}{
+		{
+			name:              "full logout — blocklists access token and revokes refresh token",
+			withBearerToken:   true,
+			withSessionStore:  true,
+			withRefreshCookie: true,
+			wantTokenBlocked:  true,
+			wantRefreshRevoke: true,
+		},
+		{
+			name:              "logout with bearer token only — no refresh cookie",
+			withBearerToken:   true,
+			withSessionStore:  true,
+			withRefreshCookie: false,
+			wantTokenBlocked:  true,
+			wantRefreshRevoke: false,
+		},
+		{
+			name:              "logout without session store — skips blocklist",
+			withBearerToken:   true,
+			withSessionStore:  false,
+			withRefreshCookie: true,
+			wantTokenBlocked:  false,
+			wantRefreshRevoke: true,
+		},
+		{
+			name:              "logout without bearer token — no blocklist",
+			withBearerToken:   false,
+			withSessionStore:  true,
+			withRefreshCookie: true,
+			wantTokenBlocked:  false,
+			wantRefreshRevoke: true,
+		},
+		{
+			name:              "minimal logout — no store, no cookie, no bearer",
+			withBearerToken:   false,
+			withSessionStore:  false,
+			withRefreshCookie: false,
+			wantTokenBlocked:  false,
+			wantRefreshRevoke: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			userRepo := NewMockUserRepository()
+			refreshRepo := NewMockRefreshTokenRepository()
+			seedUser(t, userRepo, "uid-1", "alice", "secret", "user")
+
+			var store *sessionstore.MemoryStore
+			if tt.withSessionStore {
+				store = sessionstore.NewMemoryStore()
+				defer store.Stop()
+			}
+
+			cfg := testAuthConfigWithRefresh()
+
+			// Set up refresh token if needed.
+			var refreshCookieValue string
+			if tt.withRefreshCookie {
+				raw := "logoutblock00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+				hash := hashRefreshToken(raw)
+				now := time.Now()
+				_ = refreshRepo.Create(&models.RefreshToken{
+					ID:           "rt-block-test",
+					UserID:       "uid-1",
+					TokenHash:    hash,
+					ExpiresAt:    now.Add(7 * 24 * time.Hour),
+					LastActivity: now,
+					CreatedAt:    now,
+				})
+				refreshCookieValue = raw
+			}
+
+			// Build router with or without session store.
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+			h := NewAuthHandler(userRepo, cfg, &config.OIDCConfig{})
+			h.SetRefreshTokenRepo(refreshRepo)
+			if store != nil {
+				h.SetSessionStore(store)
+			}
+			r.POST("/api/v1/auth/logout", h.Logout)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+
+			// Generate a real JWT so Logout can parse and blocklist it.
+			var jti string
+			if tt.withBearerToken {
+				token, err := middleware.GenerateTokenWithOpts(middleware.GenerateTokenOptions{
+					UserID:     "uid-1",
+					Username:   "alice",
+					Role:       "user",
+					Secret:     cfg.JWTSecret,
+					Expiration: cfg.AccessTokenExpiration,
+				})
+				require.NoError(t, err)
+				req.Header.Set("Authorization", "Bearer "+token)
+
+				// Parse back to get the JTI.
+				claims, err := middleware.ValidateJWT(token, cfg.JWTSecret)
+				require.NoError(t, err)
+				jti = claims.ID
+			}
+
+			if refreshCookieValue != "" {
+				req.AddCookie(&http.Cookie{Name: "refresh_token", Value: refreshCookieValue})
+			}
+
+			r.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			// Verify access token blocklist.
+			if tt.wantTokenBlocked && store != nil {
+				blocked, err := store.IsTokenBlocked(req.Context(), jti)
+				require.NoError(t, err)
+				assert.True(t, blocked, "access token JTI should be blocklisted after logout")
+			}
+
+			// Verify refresh token revocation.
+			if tt.wantRefreshRevoke {
+				refreshRepo.mu.RLock()
+				rt := refreshRepo.tokens["rt-block-test"]
+				refreshRepo.mu.RUnlock()
+				require.NotNil(t, rt)
+				assert.True(t, rt.Revoked, "refresh token should be revoked after logout")
+			}
+
+			// Verify refresh cookie is always cleared.
+			var cookieCleared bool
+			for _, c := range w.Result().Cookies() {
+				if c.Name == "refresh_token" && c.MaxAge < 0 {
+					cookieCleared = true
+					break
+				}
+			}
+			assert.True(t, cookieCleared, "refresh_token cookie should always be cleared on logout")
+		})
+	}
+}
+
+// ---- LogoutAll with session store blocklisting Tests ----
+
+func TestLogoutAll_BlocklistsAccessToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		callerUserID     string
+		callerJTI        string
+		callerExpiry     *time.Time
+		withSessionStore bool
+		withRefreshRepo  bool
+		revokeAllErr     error
+		wantStatus       int
+		wantTokenBlocked bool
+	}{
+		{
+			name:             "blocklists access token with JTI and expiry from context",
+			callerUserID:     "uid-1",
+			callerJTI:        "jti-abc",
+			callerExpiry:     timePtr(time.Now().Add(15 * time.Minute)),
+			withSessionStore: true,
+			withRefreshRepo:  true,
+			wantStatus:       http.StatusOK,
+			wantTokenBlocked: true,
+		},
+		{
+			name:             "blocklists access token — no expiry in context uses default",
+			callerUserID:     "uid-1",
+			callerJTI:        "jti-def",
+			callerExpiry:     nil, // no expiry
+			withSessionStore: true,
+			withRefreshRepo:  true,
+			wantStatus:       http.StatusOK,
+			wantTokenBlocked: true,
+		},
+		{
+			name:             "no session store — skips blocklist",
+			callerUserID:     "uid-1",
+			callerJTI:        "jti-ghi",
+			withSessionStore: false,
+			withRefreshRepo:  true,
+			wantStatus:       http.StatusOK,
+			wantTokenBlocked: false,
+		},
+		{
+			name:             "no JTI in context — skips blocklist",
+			callerUserID:     "uid-1",
+			callerJTI:        "",
+			withSessionStore: true,
+			withRefreshRepo:  true,
+			wantStatus:       http.StatusOK,
+			wantTokenBlocked: false,
+		},
+		{
+			name:             "no refresh repo — still clears cookie and succeeds",
+			callerUserID:     "uid-1",
+			callerJTI:        "jti-norepo",
+			withSessionStore: true,
+			withRefreshRepo:  false,
+			wantStatus:       http.StatusOK,
+			wantTokenBlocked: true,
+		},
+		{
+			name:             "RevokeAllForUser error returns 500",
+			callerUserID:     "uid-1",
+			callerJTI:        "jti-err",
+			withSessionStore: true,
+			withRefreshRepo:  true,
+			revokeAllErr:     errors.New("db failure"),
+			wantStatus:       http.StatusInternalServerError,
+			wantTokenBlocked: true, // blocklist happens before revoke
+		},
+		{
+			name:         "no userID in context returns 401",
+			callerUserID: "",
+			wantStatus:   http.StatusUnauthorized,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			userRepo := NewMockUserRepository()
+			cfg := testAuthConfigWithRefresh()
+
+			var store *sessionstore.MemoryStore
+			if tt.withSessionStore {
+				store = sessionstore.NewMemoryStore()
+				defer store.Stop()
+			}
+
+			gin.SetMode(gin.TestMode)
+			r := gin.New()
+
+			// Inject auth context to simulate what AuthRequired middleware does.
+			r.Use(func(c *gin.Context) {
+				if tt.callerUserID != "" {
+					c.Set("userID", tt.callerUserID)
+				}
+				if tt.callerJTI != "" {
+					c.Set("jti", tt.callerJTI)
+				}
+				if tt.callerExpiry != nil {
+					c.Set("tokenExpiry", *tt.callerExpiry)
+				}
+				c.Next()
+			})
+
+			h := NewAuthHandler(userRepo, cfg, &config.OIDCConfig{})
+			if store != nil {
+				h.SetSessionStore(store)
+			}
+			if tt.withRefreshRepo {
+				refreshRepo := NewMockRefreshTokenRepository()
+				if tt.revokeAllErr != nil {
+					refreshRepo.SetRevokeAllError(tt.revokeAllErr)
+				}
+				// Seed a token for the user so RevokeAllForUser has something to do.
+				now := time.Now()
+				_ = refreshRepo.Create(&models.RefreshToken{
+					ID:           "rt-logoutall-test",
+					UserID:       "uid-1",
+					TokenHash:    "somehash",
+					ExpiresAt:    now.Add(7 * 24 * time.Hour),
+					LastActivity: now,
+					CreatedAt:    now,
+				})
+				h.SetRefreshTokenRepo(refreshRepo)
+			}
+
+			r.POST("/api/v1/auth/logout-all", h.LogoutAll)
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPost, "/api/v1/auth/logout-all", nil)
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantTokenBlocked && store != nil && tt.callerJTI != "" {
+				blocked, err := store.IsTokenBlocked(req.Context(), tt.callerJTI)
+				require.NoError(t, err)
+				assert.True(t, blocked, "access token JTI should be blocklisted")
+			}
+
+			// Verify cookie is cleared on success.
+			if tt.wantStatus == http.StatusOK {
+				var cookieCleared bool
+				for _, c := range w.Result().Cookies() {
+					if c.Name == "refresh_token" && c.MaxAge < 0 {
+						cookieCleared = true
+						break
+					}
+				}
+				assert.True(t, cookieCleared, "refresh_token cookie should be cleared")
+			}
+		})
+	}
+}
+
+// ---- issueRefreshTokenWith max-tokens enforcement Tests ----
+
+func TestIssueRefreshToken_MaxTokensEnforcement(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		maxTokens      int
+		existingTokens int
+		excludeTokenID string
+		wantRevokeAll  bool
+		wantExcept     bool
+	}{
+		{
+			name:           "under limit — no revocation",
+			maxTokens:      5,
+			existingTokens: 3,
+		},
+		{
+			name:           "at limit without excludeTokenID — RevokeAllForUser",
+			maxTokens:      3,
+			existingTokens: 3,
+			wantRevokeAll:  true,
+		},
+		{
+			name:           "at limit with excludeTokenID — RevokeAllForUserExcept",
+			maxTokens:      3,
+			existingTokens: 3,
+			excludeTokenID: "rt-exclude-me",
+			wantRevokeAll:  true,
+			wantExcept:     true,
+		},
+		{
+			name:           "over limit without excludeTokenID",
+			maxTokens:      2,
+			existingTokens: 5,
+			wantRevokeAll:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			userRepo := NewMockUserRepository()
+			refreshRepo := NewMockRefreshTokenRepository()
+			seedUser(t, userRepo, "uid-1", "alice", "secret", "user")
+
+			cfg := testAuthConfigWithRefresh()
+			cfg.MaxRefreshTokensPerUser = tt.maxTokens
+
+			h := NewAuthHandler(userRepo, cfg, &config.OIDCConfig{})
+			h.SetRefreshTokenRepo(refreshRepo)
+
+			// Seed existing active tokens.
+			now := time.Now()
+			for i := 0; i < tt.existingTokens; i++ {
+				id := fmt.Sprintf("rt-existing-%d", i)
+				_ = refreshRepo.Create(&models.RefreshToken{
+					ID:           id,
+					UserID:       "uid-1",
+					TokenHash:    fmt.Sprintf("hash-%d", i),
+					ExpiresAt:    now.Add(7 * 24 * time.Hour),
+					LastActivity: now,
+					CreatedAt:    now,
+				})
+			}
+			// If testing excludeTokenID, seed that specific token too.
+			if tt.excludeTokenID != "" {
+				_ = refreshRepo.Create(&models.RefreshToken{
+					ID:           tt.excludeTokenID,
+					UserID:       "uid-1",
+					TokenHash:    "hash-exclude",
+					ExpiresAt:    now.Add(7 * 24 * time.Hour),
+					LastActivity: now,
+					CreatedAt:    now,
+				})
+			}
+
+			// Build a gin context for the handler.
+			gin.SetMode(gin.TestMode)
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest(http.MethodPost, "/", nil)
+			c.Request.Header.Set("User-Agent", "test-agent")
+
+			var rawToken string
+			var err error
+			if tt.excludeTokenID != "" {
+				rawToken, err = h.issueRefreshTokenWith(c, refreshRepo, "uid-1", tt.excludeTokenID)
+			} else {
+				rawToken, err = h.issueRefreshTokenWith(c, refreshRepo, "uid-1")
+			}
+
+			require.NoError(t, err)
+			assert.NotEmpty(t, rawToken, "should return a raw token")
+
+			refreshRepo.mu.RLock()
+			defer refreshRepo.mu.RUnlock()
+
+			if tt.wantRevokeAll {
+				if tt.wantExcept {
+					// The exclude token should NOT be revoked, others should be.
+					excludeToken := refreshRepo.tokens[tt.excludeTokenID]
+					require.NotNil(t, excludeToken)
+					assert.False(t, excludeToken.Revoked, "excluded token should not be revoked")
+
+					// Other pre-existing tokens should be revoked.
+					for _, tok := range refreshRepo.tokens {
+						if tok.UserID == "uid-1" && tok.ID != tt.excludeTokenID && tok.TokenHash != hashRefreshToken(rawToken) {
+							assert.True(t, tok.Revoked, "token %s should be revoked", tok.ID)
+						}
+					}
+				} else {
+					// All pre-existing tokens should be revoked.
+					for _, tok := range refreshRepo.tokens {
+						if tok.UserID == "uid-1" && tok.TokenHash != hashRefreshToken(rawToken) {
+							assert.True(t, tok.Revoked, "token %s should be revoked", tok.ID)
+						}
+					}
+				}
+			} else {
+				// No revocation expected — all existing tokens should still be active.
+				for _, tok := range refreshRepo.tokens {
+					if tok.TokenHash != hashRefreshToken(rawToken) {
+						assert.False(t, tok.Revoked, "token %s should not be revoked (under limit)", tok.ID)
+					}
+				}
+			}
+		})
+	}
+}
+
+// ---- EnsureAdminUser additional coverage Tests ----
+
+func TestEnsureAdminUser_CreateError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		adminUsername string
+		adminPassword string
+		seedExisting  bool
+		createErr     error
+		wantCreated   bool
+	}{
+		{
+			name:          "creates admin when not present",
+			adminUsername: "admin",
+			adminPassword: "admin-pass",
+			wantCreated:   true,
+		},
+		{
+			name:          "skips when admin already exists",
+			adminUsername: "admin",
+			adminPassword: "admin-pass",
+			seedExisting:  true,
+			wantCreated:   false,
+		},
+		{
+			name:          "skips when admin username is empty",
+			adminUsername: "",
+			adminPassword: "admin-pass",
+			wantCreated:   false,
+		},
+		{
+			name:          "skips when admin password is empty",
+			adminUsername: "admin",
+			adminPassword: "",
+			wantCreated:   false,
+		},
+		{
+			name:          "repo.Create error — logs and returns",
+			adminUsername: "admin",
+			adminPassword: "admin-pass",
+			createErr:     errors.New("db write failed"),
+			wantCreated:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := NewMockUserRepository()
+			if tt.seedExisting {
+				seedUser(t, repo, "existing-admin-id", tt.adminUsername, "old-pass", "admin")
+			}
+			if tt.createErr != nil {
+				repo.SetCreateError(tt.createErr)
+			}
+
+			cfg := &config.AuthConfig{
+				JWTSecret:     testJWTSecret,
+				JWTExpiration: time.Hour,
+				AdminUsername: tt.adminUsername,
+				AdminPassword: tt.adminPassword,
+			}
+			h := NewAuthHandler(repo, cfg, &config.OIDCConfig{})
+
+			// Should not panic.
+			h.EnsureAdminUser()
+
+			// Check if user was created.
+			user, err := repo.FindByUsername(tt.adminUsername)
+			if tt.wantCreated {
+				require.NoError(t, err)
+				assert.Equal(t, "admin", user.Role)
+				assert.Equal(t, "Administrator", user.DisplayName)
+				assert.True(t, user.ServiceAccount)
+			} else if tt.adminUsername != "" && !tt.seedExisting {
+				// Should not exist if createErr prevented creation.
+				if tt.createErr != nil {
+					assert.Error(t, err, "user should not have been created when repo.Create fails")
+				}
+			}
+		})
+	}
+}
+
+// timePtr is a helper to create a *time.Time for table-driven tests.
+func timePtr(t time.Time) *time.Time {
+	return &t
 }

--- a/backend/internal/api/handlers/refresh_token_test.go
+++ b/backend/internal/api/handlers/refresh_token_test.go
@@ -588,34 +588,29 @@ func TestCleanupExpiredTokens(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name           string
-		hasRepo        bool
-		seedExpired    int
-		deleteErr      error
-		wantDeleteCall bool
+		name        string
+		hasRepo     bool
+		seedExpired int
+		deleteErr   error
 	}{
 		{
-			name:           "no repo configured — no-op",
-			hasRepo:        false,
-			wantDeleteCall: false,
+			name:    "no repo configured — no-op",
+			hasRepo: false,
 		},
 		{
-			name:           "no expired tokens",
-			hasRepo:        true,
-			seedExpired:    0,
-			wantDeleteCall: true,
+			name:        "no expired tokens",
+			hasRepo:     true,
+			seedExpired: 0,
 		},
 		{
-			name:           "deletes expired tokens",
-			hasRepo:        true,
-			seedExpired:    3,
-			wantDeleteCall: true,
+			name:        "deletes expired tokens",
+			hasRepo:     true,
+			seedExpired: 3,
 		},
 		{
-			name:           "DeleteExpired returns error — logs and returns",
-			hasRepo:        true,
-			deleteErr:      errors.New("db failure"),
-			wantDeleteCall: true,
+			name:      "DeleteExpired returns error — logs and returns",
+			hasRepo:   true,
+			deleteErr: errors.New("db failure"),
 		},
 	}
 

--- a/backend/internal/api/routes/routes_test.go
+++ b/backend/internal/api/routes/routes_test.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -10,8 +11,12 @@ import (
 
 	"backend/internal/api/handlers"
 	"backend/internal/config"
+	"backend/internal/database"
+	"backend/internal/gitprovider"
 	"backend/internal/health"
+	"backend/internal/helm"
 	"backend/internal/models"
+	"backend/internal/sessionstore"
 	"backend/internal/websocket"
 
 	"github.com/gin-gonic/gin"
@@ -741,4 +746,946 @@ func TestSetupRoutes_SwaggerGatedByConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---- additional stub repos for full-handler construction ----
+
+type stubStackTemplateRepo struct{}
+
+func (s *stubStackTemplateRepo) Create(_ *models.StackTemplate) error                       { return nil }
+func (s *stubStackTemplateRepo) FindByID(_ string) (*models.StackTemplate, error)           { return nil, nil }
+func (s *stubStackTemplateRepo) Update(_ *models.StackTemplate) error                       { return nil }
+func (s *stubStackTemplateRepo) Delete(_ string) error                                      { return nil }
+func (s *stubStackTemplateRepo) List() ([]models.StackTemplate, error)                      { return nil, nil }
+func (s *stubStackTemplateRepo) ListPaged(_, _ int) ([]models.StackTemplate, int64, error)  { return nil, 0, nil }
+func (s *stubStackTemplateRepo) ListPublished() ([]models.StackTemplate, error)             { return nil, nil }
+func (s *stubStackTemplateRepo) ListPublishedPaged(_, _ int) ([]models.StackTemplate, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubStackTemplateRepo) ListByOwner(_ string) ([]models.StackTemplate, error) { return nil, nil }
+func (s *stubStackTemplateRepo) Count() (int64, error)                                { return 0, nil }
+
+type stubStackDefinitionRepo struct{}
+
+func (s *stubStackDefinitionRepo) Create(_ *models.StackDefinition) error             { return nil }
+func (s *stubStackDefinitionRepo) FindByID(_ string) (*models.StackDefinition, error) { return nil, nil }
+func (s *stubStackDefinitionRepo) FindByName(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) Update(_ *models.StackDefinition) error               { return nil }
+func (s *stubStackDefinitionRepo) Delete(_ string) error                                { return nil }
+func (s *stubStackDefinitionRepo) List() ([]models.StackDefinition, error)              { return nil, nil }
+func (s *stubStackDefinitionRepo) ListPaged(_, _ int) ([]models.StackDefinition, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubStackDefinitionRepo) ListByOwner(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) ListByTemplate(_ string) ([]models.StackDefinition, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) CountByTemplateIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) ListIDsByTemplateIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackDefinitionRepo) Count() (int64, error) { return 0, nil }
+
+type stubStackInstanceRepo struct{}
+
+func (s *stubStackInstanceRepo) Create(_ *models.StackInstance) error              { return nil }
+func (s *stubStackInstanceRepo) FindByID(_ string) (*models.StackInstance, error)  { return nil, nil }
+func (s *stubStackInstanceRepo) FindByNamespace(_ string) (*models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) Update(_ *models.StackInstance) error               { return nil }
+func (s *stubStackInstanceRepo) Delete(_ string) error                              { return nil }
+func (s *stubStackInstanceRepo) List() ([]models.StackInstance, error)              { return nil, nil }
+func (s *stubStackInstanceRepo) ListPaged(_, _ int) ([]models.StackInstance, int, error) {
+	return nil, 0, nil
+}
+func (s *stubStackInstanceRepo) ListByOwner(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) FindByName(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) FindByCluster(_ string) ([]models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) CountByClusterAndOwner(_, _ string) (int, error) { return 0, nil }
+func (s *stubStackInstanceRepo) CountAll() (int, error)                          { return 0, nil }
+func (s *stubStackInstanceRepo) CountByStatus(_ string) (int, error)             { return 0, nil }
+func (s *stubStackInstanceRepo) CountByDefinitionIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) CountByOwnerIDs(_ []string) (map[string]int, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListIDsByDefinitionIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListIDsByOwnerIDs(_ []string) (map[string][]string, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ExistsByDefinitionAndStatus(_, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubStackInstanceRepo) ListExpired() ([]*models.StackInstance, error)   { return nil, nil }
+func (s *stubStackInstanceRepo) ListExpiringSoon(_ time.Duration) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+func (s *stubStackInstanceRepo) ListByStatus(_ string, _ int) ([]*models.StackInstance, error) {
+	return nil, nil
+}
+
+type stubChartConfigRepo struct{}
+
+func (s *stubChartConfigRepo) Create(_ *models.ChartConfig) error             { return nil }
+func (s *stubChartConfigRepo) FindByID(_ string) (*models.ChartConfig, error) { return nil, nil }
+func (s *stubChartConfigRepo) Update(_ *models.ChartConfig) error             { return nil }
+func (s *stubChartConfigRepo) Delete(_ string) error                          { return nil }
+func (s *stubChartConfigRepo) ListByDefinition(_ string) ([]models.ChartConfig, error) {
+	return nil, nil
+}
+
+type stubTemplateChartConfigRepo struct{}
+
+func (s *stubTemplateChartConfigRepo) Create(_ *models.TemplateChartConfig) error { return nil }
+func (s *stubTemplateChartConfigRepo) FindByID(_ string) (*models.TemplateChartConfig, error) {
+	return nil, nil
+}
+func (s *stubTemplateChartConfigRepo) Update(_ *models.TemplateChartConfig) error { return nil }
+func (s *stubTemplateChartConfigRepo) Delete(_ string) error                      { return nil }
+func (s *stubTemplateChartConfigRepo) ListByTemplate(_ string) ([]models.TemplateChartConfig, error) {
+	return nil, nil
+}
+
+type stubValueOverrideRepo struct{}
+
+func (s *stubValueOverrideRepo) Create(_ *models.ValueOverride) error             { return nil }
+func (s *stubValueOverrideRepo) FindByID(_ string) (*models.ValueOverride, error) { return nil, nil }
+func (s *stubValueOverrideRepo) FindByInstanceAndChart(_, _ string) (*models.ValueOverride, error) {
+	return nil, nil
+}
+func (s *stubValueOverrideRepo) Update(_ *models.ValueOverride) error { return nil }
+func (s *stubValueOverrideRepo) Delete(_ string) error                { return nil }
+func (s *stubValueOverrideRepo) ListByInstance(_ string) ([]models.ValueOverride, error) {
+	return nil, nil
+}
+
+type stubChartBranchOverrideRepo struct{}
+
+func (s *stubChartBranchOverrideRepo) List(_ string) ([]*models.ChartBranchOverride, error) {
+	return nil, nil
+}
+func (s *stubChartBranchOverrideRepo) Get(_, _ string) (*models.ChartBranchOverride, error) {
+	return nil, nil
+}
+func (s *stubChartBranchOverrideRepo) Set(_ *models.ChartBranchOverride) error { return nil }
+func (s *stubChartBranchOverrideRepo) Delete(_, _ string) error                { return nil }
+func (s *stubChartBranchOverrideRepo) DeleteByInstance(_ string) error         { return nil }
+
+type stubInstanceQuotaOverrideRepo struct{}
+
+func (s *stubInstanceQuotaOverrideRepo) GetByInstanceID(_ context.Context, _ string) (*models.InstanceQuotaOverride, error) {
+	return nil, nil
+}
+func (s *stubInstanceQuotaOverrideRepo) Upsert(_ context.Context, _ *models.InstanceQuotaOverride) error {
+	return nil
+}
+func (s *stubInstanceQuotaOverrideRepo) Delete(_ context.Context, _ string) error { return nil }
+
+type stubUserFavoriteRepo struct{}
+
+func (s *stubUserFavoriteRepo) List(_ string) ([]*models.UserFavorite, error)  { return nil, nil }
+func (s *stubUserFavoriteRepo) Add(_ *models.UserFavorite) error               { return nil }
+func (s *stubUserFavoriteRepo) Remove(_, _, _ string) error                    { return nil }
+func (s *stubUserFavoriteRepo) IsFavorite(_, _, _ string) (bool, error)        { return false, nil }
+
+type stubNotificationRepo struct{}
+
+func (s *stubNotificationRepo) Create(_ context.Context, _ *models.Notification) error { return nil }
+func (s *stubNotificationRepo) ListByUser(_ context.Context, _ string, _ bool, _, _ int) ([]models.Notification, int64, error) {
+	return nil, 0, nil
+}
+func (s *stubNotificationRepo) CountUnread(_ context.Context, _ string) (int64, error) { return 0, nil }
+func (s *stubNotificationRepo) MarkAsRead(_ context.Context, _, _ string) error        { return nil }
+func (s *stubNotificationRepo) MarkAllAsRead(_ context.Context, _ string) error        { return nil }
+func (s *stubNotificationRepo) GetPreferences(_ context.Context, _ string) ([]models.NotificationPreference, error) {
+	return nil, nil
+}
+func (s *stubNotificationRepo) UpdatePreference(_ context.Context, _ *models.NotificationPreference) error {
+	return nil
+}
+
+type stubCleanupPolicyRepo struct{}
+
+func (s *stubCleanupPolicyRepo) Create(_ *models.CleanupPolicy) error             { return nil }
+func (s *stubCleanupPolicyRepo) FindByID(_ string) (*models.CleanupPolicy, error) { return nil, nil }
+func (s *stubCleanupPolicyRepo) Update(_ *models.CleanupPolicy) error             { return nil }
+func (s *stubCleanupPolicyRepo) Delete(_ string) error                            { return nil }
+func (s *stubCleanupPolicyRepo) List() ([]models.CleanupPolicy, error)            { return nil, nil }
+func (s *stubCleanupPolicyRepo) ListEnabled() ([]models.CleanupPolicy, error)     { return nil, nil }
+
+type stubClusterRepo struct{}
+
+func (s *stubClusterRepo) Create(_ *models.Cluster) error             { return nil }
+func (s *stubClusterRepo) FindByID(_ string) (*models.Cluster, error) { return nil, nil }
+func (s *stubClusterRepo) Update(_ *models.Cluster) error             { return nil }
+func (s *stubClusterRepo) Delete(_ string) error                      { return nil }
+func (s *stubClusterRepo) List() ([]models.Cluster, error)            { return nil, nil }
+func (s *stubClusterRepo) FindDefault() (*models.Cluster, error)      { return nil, nil }
+func (s *stubClusterRepo) SetDefault(_ string) error                  { return nil }
+
+type stubSharedValuesRepo struct{}
+
+func (s *stubSharedValuesRepo) Create(_ *models.SharedValues) error             { return nil }
+func (s *stubSharedValuesRepo) FindByID(_ string) (*models.SharedValues, error) { return nil, nil }
+func (s *stubSharedValuesRepo) FindByClusterAndID(_, _ string) (*models.SharedValues, error) {
+	return nil, nil
+}
+func (s *stubSharedValuesRepo) Update(_ *models.SharedValues) error                  { return nil }
+func (s *stubSharedValuesRepo) Delete(_ string) error                                { return nil }
+func (s *stubSharedValuesRepo) ListByCluster(_ string) ([]models.SharedValues, error) { return nil, nil }
+
+type stubTemplateVersionRepo struct{}
+
+func (s *stubTemplateVersionRepo) Create(_ context.Context, _ *models.TemplateVersion) error {
+	return nil
+}
+func (s *stubTemplateVersionRepo) ListByTemplate(_ context.Context, _ string) ([]models.TemplateVersion, error) {
+	return nil, nil
+}
+func (s *stubTemplateVersionRepo) GetByID(_ context.Context, _, _ string) (*models.TemplateVersion, error) {
+	return nil, nil
+}
+func (s *stubTemplateVersionRepo) GetLatestByTemplate(_ context.Context, _ string) (*models.TemplateVersion, error) {
+	return nil, nil
+}
+
+type stubDeploymentLogRepo struct{}
+
+func (s *stubDeploymentLogRepo) Create(_ context.Context, _ *models.DeploymentLog) error { return nil }
+func (s *stubDeploymentLogRepo) FindByID(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) Update(_ context.Context, _ *models.DeploymentLog) error { return nil }
+func (s *stubDeploymentLogRepo) ListByInstance(_ context.Context, _ string) ([]models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) ListByInstancePaginated(_ context.Context, _ models.DeploymentLogFilters) (*models.DeploymentLogResult, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) GetLatestByInstance(_ context.Context, _ string) (*models.DeploymentLog, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) SummarizeByInstance(_ context.Context, _ string) (*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) SummarizeBatch(_ context.Context, _ []string) (map[string]*models.DeployLogSummary, error) {
+	return nil, nil
+}
+func (s *stubDeploymentLogRepo) CountByAction(_ context.Context, _ string) (int, error) {
+	return 0, nil
+}
+func (s *stubDeploymentLogRepo) ListRecentGlobal(_ context.Context, _ int) ([]models.DeploymentLogWithContext, error) {
+	return nil, nil
+}
+
+type stubAuditLogRepo struct{}
+
+func (s *stubAuditLogRepo) Create(_ *models.AuditLog) error                     { return nil }
+func (s *stubAuditLogRepo) List(_ models.AuditLogFilters) (*models.AuditLogResult, error) {
+	return nil, nil
+}
+
+type stubSessionStore struct{}
+
+func (s *stubSessionStore) BlockToken(_ context.Context, _ string, _ time.Time) error { return nil }
+func (s *stubSessionStore) IsTokenBlocked(_ context.Context, _ string) (bool, error)  { return false, nil }
+func (s *stubSessionStore) BlockUser(_ context.Context, _ string, _ time.Time) error  { return nil }
+func (s *stubSessionStore) IsUserBlocked(_ context.Context, _ string) (bool, error)   { return false, nil }
+func (s *stubSessionStore) UnblockUser(_ context.Context, _ string) error             { return nil }
+func (s *stubSessionStore) SaveOIDCState(_ context.Context, _ string, _ sessionstore.OIDCStateData, _ time.Duration) error {
+	return nil
+}
+func (s *stubSessionStore) ConsumeOIDCState(_ context.Context, _ string) (*sessionstore.OIDCStateData, error) {
+	return nil, nil
+}
+func (s *stubSessionStore) Cleanup(_ context.Context) error { return nil }
+func (s *stubSessionStore) Stop()                           {}
+
+type stubTxRunner struct{}
+
+func (s *stubTxRunner) RunInTx(fn func(repos database.TxRepos) error) error {
+	return fn(database.TxRepos{})
+}
+
+// ---- full deps helper ----
+
+// setupFullRouter creates a Gin engine with ALL handlers registered, exercising
+// every code path in SetupRoutes. Only used for route-registration validation,
+// not for handler logic.
+func setupFullRouter(t *testing.T) (*gin.Engine, *RateLimiters) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockRepo := handlers.NewMockRepository()
+
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+
+	cfg := testConfig()
+
+	userRepo := &stubUserRepo{}
+	apiKeyRepo := &stubAPIKeyRepo{}
+	templateRepo := &stubStackTemplateRepo{}
+	definitionRepo := &stubStackDefinitionRepo{}
+	instanceRepo := &stubStackInstanceRepo{}
+	chartConfigRepo := &stubChartConfigRepo{}
+	templateChartRepo := &stubTemplateChartConfigRepo{}
+	overrideRepo := &stubValueOverrideRepo{}
+	branchOverrideRepo := &stubChartBranchOverrideRepo{}
+	clusterRepo := &stubClusterRepo{}
+	deployLogRepo := &stubDeploymentLogRepo{}
+
+	valuesGen := helm.NewValuesGenerator()
+
+	authHandler := handlers.NewAuthHandler(userRepo, &cfg.Auth, &cfg.OIDC)
+	templateHandler := handlers.NewTemplateHandler(templateRepo, templateChartRepo, definitionRepo, chartConfigRepo)
+	definitionHandler := handlers.NewDefinitionHandler(definitionRepo, chartConfigRepo, instanceRepo, templateRepo, templateChartRepo)
+	instanceHandler := handlers.NewInstanceHandler(
+		instanceRepo, overrideRepo, branchOverrideRepo,
+		definitionRepo, chartConfigRepo, templateRepo, templateChartRepo,
+		valuesGen, userRepo, 0,
+	)
+	gitHandler := handlers.NewGitHandler(gitprovider.NewRegistry(gitprovider.Config{}))
+	auditLogHandler := handlers.NewAuditLogHandler(&stubAuditLogRepo{})
+	userHandler := handlers.NewUserHandler(userRepo)
+	apiKeyHandler := handlers.NewAPIKeyHandler(apiKeyRepo, userRepo, &cfg.Auth)
+	adminHandler := handlers.NewAdminHandler(nil, instanceRepo)
+	branchOverrideHandler := handlers.NewBranchOverrideHandler(branchOverrideRepo, instanceRepo)
+	instanceQuotaHandler := handlers.NewInstanceQuotaOverrideHandler(&stubInstanceQuotaOverrideRepo{}, instanceRepo)
+	favoriteHandler := handlers.NewFavoriteHandler(&stubUserFavoriteRepo{})
+	analyticsHandler := handlers.NewAnalyticsHandler(templateRepo, definitionRepo, instanceRepo, deployLogRepo, userRepo)
+	cleanupPolicyHandler := handlers.NewCleanupPolicyHandler(&stubCleanupPolicyRepo{}, nil)
+	clusterHandler := handlers.NewClusterHandler(clusterRepo, nil, instanceRepo)
+	sharedValuesHandler := handlers.NewSharedValuesHandler(&stubSharedValuesRepo{}, clusterRepo)
+	dashboardHandler := handlers.NewDashboardHandler(clusterRepo, instanceRepo, deployLogRepo, nil)
+	templateVersionHandler := handlers.NewTemplateVersionHandler(&stubTemplateVersionRepo{}, templateRepo)
+	notificationHandler := handlers.NewNotificationHandler(&stubNotificationRepo{})
+
+	// OIDC handler with nil provider (safe for route registration only).
+	oidcHandler := handlers.NewOIDCHandler(nil, &stubSessionStore{}, userRepo, &cfg.OIDC, &cfg.Auth)
+
+	// QuickDeployHandler requires a non-nil txRunner.
+	quickDeployHandler, err := handlers.NewQuickDeployHandler(
+		templateRepo, templateChartRepo, definitionRepo, chartConfigRepo,
+		instanceRepo, branchOverrideRepo, overrideRepo, valuesGen,
+		nil, userRepo, deployLogRepo, &stubAuditLogRepo{}, hub, nil, nil, 0,
+		&stubTxRunner{},
+	)
+	require.NoError(t, err)
+
+	rl := SetupRoutes(router, Deps{
+		Repository:                  mockRepo,
+		HealthChecker:               healthChecker,
+		Config:                      cfg,
+		Hub:                         hub,
+		AuthHandler:                 authHandler,
+		TemplateHandler:             templateHandler,
+		DefinitionHandler:           definitionHandler,
+		InstanceHandler:             instanceHandler,
+		GitHandler:                  gitHandler,
+		AuditLogHandler:             auditLogHandler,
+		AuditLogger:                 &stubAuditLogger{},
+		UserHandler:                 userHandler,
+		APIKeyHandler:               apiKeyHandler,
+		AdminHandler:                adminHandler,
+		BranchOverrideHandler:       branchOverrideHandler,
+		InstanceQuotaOverrideHandler: instanceQuotaHandler,
+		FavoriteHandler:             favoriteHandler,
+		QuickDeployHandler:          quickDeployHandler,
+		AnalyticsHandler:            analyticsHandler,
+		CleanupPolicyHandler:        cleanupPolicyHandler,
+		ClusterHandler:              clusterHandler,
+		SharedValuesHandler:         sharedValuesHandler,
+		DashboardHandler:            dashboardHandler,
+		TemplateVersionHandler:      templateVersionHandler,
+		NotificationHandler:         notificationHandler,
+		OIDCHandler:                 oidcHandler,
+		UserRepo:                    userRepo,
+		APIKeyRepo:                  apiKeyRepo,
+		ClusterRepo:                 clusterRepo,
+		InstanceRepo:                instanceRepo,
+		SessionStore:                &stubSessionStore{},
+	})
+	t.Cleanup(func() { rl.Stop() })
+
+	return router, rl
+}
+
+// collectRoutes extracts "METHOD /path" strings from a Gin engine.
+func collectRoutes(router *gin.Engine) map[string]bool {
+	m := make(map[string]bool)
+	for _, r := range router.Routes() {
+		m[r.Method+" "+r.Path] = true
+	}
+	return m
+}
+
+// ---- comprehensive route registration tests ----
+
+func TestSetupRoutes_AllHandlers_RegistersCompleteAPI(t *testing.T) {
+	t.Parallel()
+
+	router, _ := setupFullRouter(t)
+	registered := collectRoutes(router)
+
+	// Every route declared in routes.go grouped by domain.
+	expected := []struct {
+		method string
+		path   string
+	}{
+		// WebSocket
+		{"GET", "/ws"},
+
+		// Health
+		{"GET", "/health"},
+		{"GET", "/health/live"},
+		{"GET", "/health/ready"},
+
+		// Ping + Items (always registered)
+		{"GET", "/api/v1/ping"},
+		{"GET", "/api/v1/items"},
+		{"POST", "/api/v1/items"},
+		{"GET", "/api/v1/items/:id"},
+		{"PUT", "/api/v1/items/:id"},
+		{"DELETE", "/api/v1/items/:id"},
+
+		// Auth
+		{"POST", "/api/v1/auth/login"},
+		{"POST", "/api/v1/auth/register"},
+		{"GET", "/api/v1/auth/me"},
+		{"POST", "/api/v1/auth/refresh"},
+		{"POST", "/api/v1/auth/logout"},
+		{"POST", "/api/v1/auth/logout-all"},
+
+		// OIDC (enabled — OIDCHandler is non-nil)
+		{"GET", "/api/v1/auth/oidc/config"},
+		{"GET", "/api/v1/auth/oidc/authorize"},
+		{"GET", "/api/v1/auth/oidc/callback"},
+
+		// Templates
+		{"GET", "/api/v1/templates"},
+		{"POST", "/api/v1/templates"},
+		{"GET", "/api/v1/templates/:id"},
+		{"PUT", "/api/v1/templates/:id"},
+		{"DELETE", "/api/v1/templates/:id"},
+		{"POST", "/api/v1/templates/:id/publish"},
+		{"POST", "/api/v1/templates/:id/unpublish"},
+		{"POST", "/api/v1/templates/:id/instantiate"},
+		{"POST", "/api/v1/templates/:id/clone"},
+
+		// Bulk template operations
+		{"POST", "/api/v1/templates/bulk/delete"},
+		{"POST", "/api/v1/templates/bulk/publish"},
+		{"POST", "/api/v1/templates/bulk/unpublish"},
+
+		// Template chart configs
+		{"POST", "/api/v1/templates/:id/charts"},
+		{"PUT", "/api/v1/templates/:id/charts/:chartId"},
+		{"DELETE", "/api/v1/templates/:id/charts/:chartId"},
+
+		// Template versions
+		{"GET", "/api/v1/templates/:id/versions"},
+		{"GET", "/api/v1/templates/:id/versions/diff"},
+		{"GET", "/api/v1/templates/:id/versions/:versionId"},
+
+		// Quick deploy
+		{"POST", "/api/v1/templates/:id/quick-deploy"},
+
+		// Stack Definitions
+		{"GET", "/api/v1/stack-definitions"},
+		{"POST", "/api/v1/stack-definitions"},
+		{"POST", "/api/v1/stack-definitions/import"},
+		{"GET", "/api/v1/stack-definitions/:id"},
+		{"GET", "/api/v1/stack-definitions/:id/export"},
+		{"PUT", "/api/v1/stack-definitions/:id"},
+		{"DELETE", "/api/v1/stack-definitions/:id"},
+		{"GET", "/api/v1/stack-definitions/:id/check-upgrade"},
+		{"POST", "/api/v1/stack-definitions/:id/upgrade"},
+		{"POST", "/api/v1/stack-definitions/:id/charts"},
+		{"PUT", "/api/v1/stack-definitions/:id/charts/:chartId"},
+		{"DELETE", "/api/v1/stack-definitions/:id/charts/:chartId"},
+
+		// Stack Instances
+		{"GET", "/api/v1/stack-instances"},
+		{"POST", "/api/v1/stack-instances"},
+		{"GET", "/api/v1/stack-instances/compare"},
+		{"GET", "/api/v1/stack-instances/recent"},
+		{"GET", "/api/v1/stack-instances/:id"},
+		{"PUT", "/api/v1/stack-instances/:id"},
+		{"DELETE", "/api/v1/stack-instances/:id"},
+		{"POST", "/api/v1/stack-instances/:id/clone"},
+		{"GET", "/api/v1/stack-instances/:id/values"},
+		{"GET", "/api/v1/stack-instances/:id/values/:chartId"},
+		{"GET", "/api/v1/stack-instances/:id/overrides"},
+		{"PUT", "/api/v1/stack-instances/:id/overrides/:chartId"},
+		{"POST", "/api/v1/stack-instances/:id/deploy"},
+		{"GET", "/api/v1/stack-instances/:id/deploy-preview"},
+		{"POST", "/api/v1/stack-instances/:id/stop"},
+		{"POST", "/api/v1/stack-instances/:id/clean"},
+		{"POST", "/api/v1/stack-instances/:id/actions/:name"},
+		{"POST", "/api/v1/stack-instances/:id/extend"},
+		{"GET", "/api/v1/stack-instances/:id/deploy-log"},
+		{"GET", "/api/v1/stack-instances/:id/deploy-log/:logId/values"},
+		{"POST", "/api/v1/stack-instances/:id/rollback"},
+		{"GET", "/api/v1/stack-instances/:id/status"},
+		{"GET", "/api/v1/stack-instances/:id/pods"},
+
+		// Bulk instance operations
+		{"POST", "/api/v1/stack-instances/bulk/deploy"},
+		{"POST", "/api/v1/stack-instances/bulk/stop"},
+		{"POST", "/api/v1/stack-instances/bulk/clean"},
+		{"POST", "/api/v1/stack-instances/bulk/delete"},
+
+		// Branch overrides
+		{"GET", "/api/v1/stack-instances/:id/branches"},
+		{"PUT", "/api/v1/stack-instances/:id/branches/:chartId"},
+		{"DELETE", "/api/v1/stack-instances/:id/branches/:chartId"},
+
+		// Instance quota overrides
+		{"GET", "/api/v1/stack-instances/:id/quota-overrides"},
+		{"PUT", "/api/v1/stack-instances/:id/quota-overrides"},
+		{"DELETE", "/api/v1/stack-instances/:id/quota-overrides"},
+
+		// Git
+		{"GET", "/api/v1/git/branches"},
+		{"GET", "/api/v1/git/validate-branch"},
+		{"GET", "/api/v1/git/providers"},
+
+		// Audit logs
+		{"GET", "/api/v1/audit-logs"},
+		{"GET", "/api/v1/audit-logs/export"},
+
+		// Users
+		{"GET", "/api/v1/users"},
+		{"DELETE", "/api/v1/users/:id"},
+		{"PUT", "/api/v1/users/:id/disable"},
+		{"PUT", "/api/v1/users/:id/enable"},
+
+		// API keys
+		{"GET", "/api/v1/users/:id/api-keys"},
+		{"POST", "/api/v1/users/:id/api-keys"},
+		{"DELETE", "/api/v1/users/:id/api-keys/:keyId"},
+
+		// Admin
+		{"GET", "/api/v1/admin/orphaned-namespaces"},
+		{"DELETE", "/api/v1/admin/orphaned-namespaces/:namespace"},
+
+		// Cleanup policies
+		{"GET", "/api/v1/admin/cleanup-policies"},
+		{"POST", "/api/v1/admin/cleanup-policies"},
+		{"PUT", "/api/v1/admin/cleanup-policies/:id"},
+		{"DELETE", "/api/v1/admin/cleanup-policies/:id"},
+		{"POST", "/api/v1/admin/cleanup-policies/:id/run"},
+
+		// Clusters
+		{"GET", "/api/v1/clusters"},
+		{"GET", "/api/v1/clusters/:id"},
+		{"POST", "/api/v1/clusters"},
+		{"PUT", "/api/v1/clusters/:id"},
+		{"DELETE", "/api/v1/clusters/:id"},
+		{"POST", "/api/v1/clusters/:id/test"},
+		{"POST", "/api/v1/clusters/:id/default"},
+		{"GET", "/api/v1/clusters/:id/health/summary"},
+		{"GET", "/api/v1/clusters/:id/health/nodes"},
+		{"GET", "/api/v1/clusters/:id/namespaces"},
+		{"GET", "/api/v1/clusters/:id/quotas"},
+		{"PUT", "/api/v1/clusters/:id/quotas"},
+		{"DELETE", "/api/v1/clusters/:id/quotas"},
+		{"GET", "/api/v1/clusters/:id/utilization"},
+
+		// Shared values
+		{"GET", "/api/v1/clusters/:id/shared-values"},
+		{"POST", "/api/v1/clusters/:id/shared-values"},
+		{"PUT", "/api/v1/clusters/:id/shared-values/:valueId"},
+		{"DELETE", "/api/v1/clusters/:id/shared-values/:valueId"},
+
+		// Analytics
+		{"GET", "/api/v1/analytics/overview"},
+		{"GET", "/api/v1/analytics/templates"},
+		{"GET", "/api/v1/analytics/users"},
+
+		// Dashboard
+		{"GET", "/api/v1/dashboard"},
+
+		// Notifications
+		{"GET", "/api/v1/notifications"},
+		{"GET", "/api/v1/notifications/count"},
+		{"POST", "/api/v1/notifications/:id/read"},
+		{"POST", "/api/v1/notifications/read-all"},
+		{"GET", "/api/v1/notifications/preferences"},
+		{"PUT", "/api/v1/notifications/preferences"},
+
+		// Favorites
+		{"GET", "/api/v1/favorites"},
+		{"POST", "/api/v1/favorites"},
+		{"DELETE", "/api/v1/favorites/:entityType/:entityId"},
+		{"GET", "/api/v1/favorites/check"},
+	}
+
+	for _, e := range expected {
+		key := e.method + " " + e.path
+		assert.True(t, registered[key], "expected route not registered: %s", key)
+	}
+
+	// Verify we haven't missed documenting any routes.
+	expectedSet := make(map[string]bool, len(expected))
+	for _, e := range expected {
+		expectedSet[e.method+" "+e.path] = true
+	}
+	for key := range registered {
+		assert.True(t, expectedSet[key], "unexpected route registered that is not in expected list: %s", key)
+	}
+}
+
+func TestSetupRoutes_OIDCEnabled_RegistersOIDCRoutes(t *testing.T) {
+	t.Parallel()
+
+	router, _ := setupFullRouter(t)
+	registered := collectRoutes(router)
+
+	oidcRoutes := []string{
+		"GET /api/v1/auth/oidc/config",
+		"GET /api/v1/auth/oidc/authorize",
+		"GET /api/v1/auth/oidc/callback",
+	}
+	for _, route := range oidcRoutes {
+		assert.True(t, registered[route], "OIDC route missing when OIDCHandler is set: %s", route)
+	}
+}
+
+func TestSetupRoutes_OIDCDisabled_FallbackConfigOnly(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockRepo := handlers.NewMockRepository()
+
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+
+	cfg := testConfig()
+	authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+
+	rl := SetupRoutes(router, Deps{
+		Repository:    mockRepo,
+		HealthChecker: healthChecker,
+		Config:        cfg,
+		Hub:           hub,
+		AuthHandler:   authHandler,
+		OIDCHandler:   nil, // OIDC disabled
+		UserRepo:      &stubUserRepo{},
+		APIKeyRepo:    &stubAPIKeyRepo{},
+	})
+	t.Cleanup(func() { rl.Stop() })
+
+	registered := collectRoutes(router)
+
+	// The fallback config endpoint should be registered.
+	assert.True(t, registered["GET /api/v1/auth/oidc/config"],
+		"OIDC fallback config route should be registered when OIDC is disabled")
+
+	// The authorize and callback endpoints should NOT be registered.
+	assert.False(t, registered["GET /api/v1/auth/oidc/authorize"],
+		"OIDC authorize should NOT be registered when OIDC is disabled")
+	assert.False(t, registered["GET /api/v1/auth/oidc/callback"],
+		"OIDC callback should NOT be registered when OIDC is disabled")
+}
+
+func TestSetupRoutes_LoginRateLimiterBranching(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		loginRateLimit   int32
+		wantLoginLimiter bool
+	}{
+		{
+			name:             "login rate limiter created when LoginRateLimit > 0",
+			loginRateLimit:   10,
+			wantLoginLimiter: true,
+		},
+		{
+			name:             "login rate limiter nil when LoginRateLimit is 0",
+			loginRateLimit:   0,
+			wantLoginLimiter: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			mockRepo := handlers.NewMockRepository()
+
+			healthChecker := health.New()
+			healthChecker.SetReady(true)
+
+			hub := websocket.NewHub()
+			go hub.Run()
+			t.Cleanup(func() { hub.Shutdown() })
+
+			cfg := testConfig()
+			cfg.Server.LoginRateLimit = tt.loginRateLimit
+			authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+
+			rl := SetupRoutes(router, Deps{
+				Repository:    mockRepo,
+				HealthChecker: healthChecker,
+				Config:        cfg,
+				Hub:           hub,
+				AuthHandler:   authHandler,
+				UserRepo:      &stubUserRepo{},
+				APIKeyRepo:    &stubAPIKeyRepo{},
+			})
+			t.Cleanup(func() { rl.Stop() })
+
+			if tt.wantLoginLimiter {
+				require.NotNil(t, rl.Login, "expected login rate limiter to be created")
+			} else {
+				require.Nil(t, rl.Login, "expected login rate limiter to be nil")
+			}
+
+			// Login and refresh endpoints should be reachable regardless.
+			registered := collectRoutes(router)
+			assert.True(t, registered["POST /api/v1/auth/login"], "login route must be registered")
+			assert.True(t, registered["POST /api/v1/auth/refresh"], "refresh route must be registered")
+		})
+	}
+}
+
+func TestSetupRoutes_ClusterHandlerFallbackConstruction(t *testing.T) {
+	t.Parallel()
+
+	// When ClusterHandler is nil but ClusterRepo and InstanceRepo are set,
+	// SetupRoutes constructs a fallback ClusterHandler internally.
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockRepo := handlers.NewMockRepository()
+
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+
+	cfg := testConfig()
+	authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+
+	rl := SetupRoutes(router, Deps{
+		Repository:    mockRepo,
+		HealthChecker: healthChecker,
+		Config:        cfg,
+		Hub:           hub,
+		AuthHandler:   authHandler,
+		UserRepo:      &stubUserRepo{},
+		APIKeyRepo:    &stubAPIKeyRepo{},
+		ClusterHandler: nil, // explicitly nil
+		ClusterRepo:    &stubClusterRepo{},
+		InstanceRepo:   &stubStackInstanceRepo{},
+	})
+	t.Cleanup(func() { rl.Stop() })
+
+	registered := collectRoutes(router)
+
+	// Cluster routes should be registered via the fallback handler.
+	clusterRoutes := []string{
+		"GET /api/v1/clusters",
+		"GET /api/v1/clusters/:id",
+		"POST /api/v1/clusters",
+		"PUT /api/v1/clusters/:id",
+		"DELETE /api/v1/clusters/:id",
+		"POST /api/v1/clusters/:id/test",
+		"POST /api/v1/clusters/:id/default",
+	}
+	for _, route := range clusterRoutes {
+		assert.True(t, registered[route], "cluster route missing with fallback handler: %s", route)
+	}
+}
+
+func TestSetupRoutes_ClusterHandlerNotRegisteredWithoutDeps(t *testing.T) {
+	t.Parallel()
+
+	// When ClusterHandler, ClusterRepo, AND InstanceRepo are all nil,
+	// no cluster routes should be registered.
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockRepo := handlers.NewMockRepository()
+
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+
+	cfg := testConfig()
+	authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+
+	rl := SetupRoutes(router, Deps{
+		Repository:     mockRepo,
+		HealthChecker:  healthChecker,
+		Config:         cfg,
+		Hub:            hub,
+		AuthHandler:    authHandler,
+		UserRepo:       &stubUserRepo{},
+		APIKeyRepo:     &stubAPIKeyRepo{},
+		ClusterHandler: nil,
+		ClusterRepo:    nil,
+		InstanceRepo:   nil,
+	})
+	t.Cleanup(func() { rl.Stop() })
+
+	registered := collectRoutes(router)
+	assert.False(t, registered["GET /api/v1/clusters"],
+		"cluster routes should NOT be registered when all cluster deps are nil")
+}
+
+func TestSetupRoutes_OtelMiddlewareGatedByConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{"otel disabled", false},
+		{"otel enabled", true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gin.SetMode(gin.TestMode)
+			router := gin.New()
+			mockRepo := handlers.NewMockRepository()
+
+			healthChecker := health.New()
+			healthChecker.SetReady(true)
+
+			hub := websocket.NewHub()
+			go hub.Run()
+			t.Cleanup(func() { hub.Shutdown() })
+
+			cfg := testConfig()
+			cfg.Otel.Enabled = tt.enabled
+			cfg.Otel.ServiceName = "test-svc"
+			authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+
+			rl := SetupRoutes(router, Deps{
+				Repository:    mockRepo,
+				HealthChecker: healthChecker,
+				Config:        cfg,
+				Hub:           hub,
+				AuthHandler:   authHandler,
+				UserRepo:      &stubUserRepo{},
+				APIKeyRepo:    &stubAPIKeyRepo{},
+			})
+			t.Cleanup(func() { rl.Stop() })
+
+			// Routes should still work regardless of OTel config.
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+			router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestSetupRoutes_APIKeyRoutesWithoutUserHandler(t *testing.T) {
+	t.Parallel()
+
+	// When UserHandler is nil but APIKeyHandler is set, the /users/:id/api-keys
+	// routes should still be registered.
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockRepo := handlers.NewMockRepository()
+
+	healthChecker := health.New()
+	healthChecker.SetReady(true)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	t.Cleanup(func() { hub.Shutdown() })
+
+	cfg := testConfig()
+	authHandler := handlers.NewAuthHandler(&stubUserRepo{}, &cfg.Auth, &cfg.OIDC)
+	apiKeyHandler := handlers.NewAPIKeyHandler(&stubAPIKeyRepo{}, &stubUserRepo{}, &cfg.Auth)
+
+	rl := SetupRoutes(router, Deps{
+		Repository:    mockRepo,
+		HealthChecker: healthChecker,
+		Config:        cfg,
+		Hub:           hub,
+		AuthHandler:   authHandler,
+		UserHandler:   nil, // no user handler
+		APIKeyHandler: apiKeyHandler,
+		UserRepo:      &stubUserRepo{},
+		APIKeyRepo:    &stubAPIKeyRepo{},
+		AuditLogger:   &stubAuditLogger{},
+	})
+	t.Cleanup(func() { rl.Stop() })
+
+	registered := collectRoutes(router)
+	assert.True(t, registered["GET /api/v1/users/:id/api-keys"], "api-keys list route should be registered without UserHandler")
+	assert.True(t, registered["POST /api/v1/users/:id/api-keys"], "api-keys create route should be registered without UserHandler")
+	assert.True(t, registered["DELETE /api/v1/users/:id/api-keys/:keyId"], "api-keys delete route should be registered without UserHandler")
+
+	// User management routes should NOT be registered.
+	assert.False(t, registered["GET /api/v1/users"], "user list should not be registered when UserHandler is nil")
+}
+
+func TestSetupRoutes_SecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	router, _ := setupMinimalRouter(t)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/api/v1/ping", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// SecurityHeaders middleware should set standard security headers.
+	assert.NotEmpty(t, w.Header().Get("X-Content-Type-Options"),
+		"SecurityHeaders middleware should set X-Content-Type-Options")
+}
+
+func TestRateLimiters_Stop_NilSafe(t *testing.T) {
+	t.Parallel()
+
+	// Calling Stop on nil RateLimiters should not panic.
+	var rl *RateLimiters
+	assert.NotPanics(t, func() { rl.Stop() })
+
+	// Calling Stop with nil fields should not panic.
+	rl2 := &RateLimiters{}
+	assert.NotPanics(t, func() { rl2.Stop() })
 }

--- a/backend/internal/database/cluster_encryption_test.go
+++ b/backend/internal/database/cluster_encryption_test.go
@@ -1,0 +1,158 @@
+package database
+
+import (
+	"testing"
+
+	"backend/internal/models"
+	"backend/pkg/crypto"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecryptKubeconfig(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("test-key-for-encryption"),
+	}
+
+	cluster := &models.Cluster{
+		KubeconfigData: "apiVersion: v1\nkind: Config\nclusters: []",
+	}
+	original := cluster.KubeconfigData
+
+	restored, err := repo.encryptKubeconfig(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, original, restored)
+	assert.NotEqual(t, original, cluster.KubeconfigData, "data should be encrypted")
+
+	err = repo.decryptKubeconfig(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, original, cluster.KubeconfigData)
+}
+
+func TestEncryptKubeconfig_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("test-key"),
+	}
+
+	cluster := &models.Cluster{KubeconfigData: ""}
+	restored, err := repo.encryptKubeconfig(cluster)
+	require.NoError(t, err)
+	assert.Empty(t, restored)
+	assert.Empty(t, cluster.KubeconfigData)
+}
+
+func TestEncryptKubeconfig_NoEncryptionKey(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{}
+	cluster := &models.Cluster{KubeconfigData: "some data"}
+
+	_, err := repo.encryptKubeconfig(cluster)
+	assert.Error(t, err, "should fail when encryption key is not set")
+}
+
+func TestDecryptKubeconfig_EmptyData(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("test-key"),
+	}
+	cluster := &models.Cluster{KubeconfigData: ""}
+
+	err := repo.decryptKubeconfig(cluster)
+	require.NoError(t, err)
+	assert.Empty(t, cluster.KubeconfigData)
+}
+
+func TestDecryptKubeconfig_NoKey(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{}
+	cluster := &models.Cluster{KubeconfigData: "ciphertext-here"}
+
+	err := repo.decryptKubeconfig(cluster)
+	require.NoError(t, err, "should skip decryption when no key")
+	assert.Equal(t, "ciphertext-here", cluster.KubeconfigData)
+}
+
+func TestDecryptKubeconfig_PlaintextData(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("test-key"),
+	}
+	cluster := &models.Cluster{KubeconfigData: "not-base64-data"}
+
+	err := repo.decryptKubeconfig(cluster)
+	require.NoError(t, err, "should treat non-base64 as plaintext")
+	assert.Equal(t, "not-base64-data", cluster.KubeconfigData)
+}
+
+func TestEncryptDecryptRegistryPassword(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("test-key-for-encryption"),
+	}
+
+	cluster := &models.Cluster{RegistryPassword: "super-secret-password"}
+	original := cluster.RegistryPassword
+
+	restored, err := repo.encryptRegistryPassword(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, original, restored)
+	assert.NotEqual(t, original, cluster.RegistryPassword, "password should be encrypted")
+
+	err = repo.decryptRegistryPassword(cluster)
+	require.NoError(t, err)
+	assert.Equal(t, original, cluster.RegistryPassword)
+}
+
+func TestEncryptRegistryPassword_EmptyOrNoKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		password string
+		hasKey   bool
+	}{
+		{"empty password", "", true},
+		{"no encryption key", "secret", false},
+		{"both empty", "", false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			repo := &GORMClusterRepository{}
+			if tt.hasKey {
+				repo.encryptionKey = crypto.DeriveKey("key")
+			}
+			cluster := &models.Cluster{RegistryPassword: tt.password}
+
+			restored, err := repo.encryptRegistryPassword(cluster)
+			require.NoError(t, err)
+			assert.Equal(t, tt.password, restored)
+			assert.Equal(t, tt.password, cluster.RegistryPassword)
+		})
+	}
+}
+
+func TestDecryptRegistryPassword_PlaintextData(t *testing.T) {
+	t.Parallel()
+
+	repo := &GORMClusterRepository{
+		encryptionKey: crypto.DeriveKey("key"),
+	}
+	cluster := &models.Cluster{RegistryPassword: "not-base64"}
+
+	err := repo.decryptRegistryPassword(cluster)
+	require.NoError(t, err, "should treat non-base64 as plaintext")
+	assert.Equal(t, "not-base64", cluster.RegistryPassword)
+}

--- a/backend/internal/database/cursor_test.go
+++ b/backend/internal/database/cursor_test.go
@@ -1,0 +1,91 @@
+package database
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func rawEncode(s string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(s))
+}
+
+func TestAuditCursor_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 8, 14, 30, 0, 123456789, time.UTC)
+	id := "audit-entry-42"
+
+	encoded := encodeAuditCursor(ts, id)
+	require.NotEmpty(t, encoded)
+
+	gotTS, gotID, err := decodeAuditCursor(encoded)
+	require.NoError(t, err)
+	assert.True(t, ts.Equal(gotTS), "timestamp mismatch: want %v, got %v", ts, gotTS)
+	assert.Equal(t, id, gotID)
+}
+
+func TestAuditCursor_DecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{"invalid base64", "%%%not-valid%%%"},
+		{"missing separator", rawEncode("nopipe")},
+		{"empty timestamp", rawEncode("|some-id")},
+		{"empty id", rawEncode("2026-05-08T14:30:00Z|")},
+		{"bad timestamp format", rawEncode("not-a-time|some-id")},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := decodeAuditCursor(tt.cursor)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestDeployLogCursor_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 1, 15, 9, 0, 0, 999000000, time.UTC)
+	id := "deploy-log-99"
+
+	encoded := encodeDeployLogCursor(ts, id)
+	require.NotEmpty(t, encoded)
+
+	gotTS, gotID, err := decodeDeployLogCursor(encoded)
+	require.NoError(t, err)
+	assert.True(t, ts.Equal(gotTS))
+	assert.Equal(t, id, gotID)
+}
+
+func TestDeployLogCursor_DecodeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		cursor string
+	}{
+		{"invalid base64", "!!!invalid!!!"},
+		{"missing separator", rawEncode("nopipe")},
+		{"empty id", rawEncode("2026-05-08T14:30:00Z|")},
+		{"bad timestamp", rawEncode("xyz|some-id")},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := decodeDeployLogCursor(tt.cursor)
+			assert.Error(t, err)
+		})
+	}
+}

--- a/backend/internal/notifier/notifier_test.go
+++ b/backend/internal/notifier/notifier_test.go
@@ -298,4 +298,294 @@ func TestNewNotifier(t *testing.T) {
 		n := NewNotifier(repo, hub, nil)
 		assert.NotNil(t, n)
 	})
+
+	t.Run("creates notifier with all dependencies", func(t *testing.T) {
+		t.Parallel()
+		repo := newMockNotificationRepo()
+		hub := websocket.NewHub()
+		userRepo := &mockUserRepository{}
+		n := NewNotifier(repo, hub, userRepo)
+		assert.NotNil(t, n)
+	})
+}
+
+// ---- Mock UserRepository ----
+
+type mockUserRepository struct {
+	mu           sync.Mutex
+	users        []models.User
+	listByRolesErr error
+	listByRolesCalled bool
+	rolesReceived []string
+}
+
+func (m *mockUserRepository) ListByRoles(roles []string) ([]models.User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listByRolesCalled = true
+	m.rolesReceived = roles
+	if m.listByRolesErr != nil {
+		return nil, m.listByRolesErr
+	}
+	return m.users, nil
+}
+
+// Stub methods to satisfy models.UserRepository interface.
+func (m *mockUserRepository) Create(_ *models.User) error                             { return nil }
+func (m *mockUserRepository) FindByID(_ string) (*models.User, error)                 { return nil, nil }
+func (m *mockUserRepository) FindByIDs(_ []string) (map[string]*models.User, error)   { return nil, nil }
+func (m *mockUserRepository) FindByUsername(_ string) (*models.User, error)            { return nil, nil }
+func (m *mockUserRepository) FindByExternalID(_, _ string) (*models.User, error)      { return nil, nil }
+func (m *mockUserRepository) Update(_ *models.User) error                             { return nil }
+func (m *mockUserRepository) Delete(_ string) error                                   { return nil }
+func (m *mockUserRepository) List() ([]models.User, error)                            { return nil, nil }
+func (m *mockUserRepository) Count() (int64, error)                                   { return 0, nil }
+
+// ---- NotifySystem Tests ----
+
+func TestNotifySystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		userRepo         *mockUserRepository
+		nilUserRepo      bool
+		createErr        error
+		wantErr          bool
+		wantCreatedCount int
+		wantRoles        []string
+	}{
+		{
+			name: "notifies all admin and devops users",
+			userRepo: &mockUserRepository{
+				users: []models.User{
+					{ID: "admin-1", Username: "alice", Role: "admin"},
+					{ID: "devops-1", Username: "bob", Role: "devops"},
+					{ID: "admin-2", Username: "carol", Role: "admin"},
+				},
+			},
+			wantCreatedCount: 3,
+			wantRoles:        []string{"admin", "devops"},
+		},
+		{
+			name:             "nil userRepo returns nil without error",
+			nilUserRepo:      true,
+			wantCreatedCount: 0,
+		},
+		{
+			name: "ListByRoles error is propagated",
+			userRepo: &mockUserRepository{
+				listByRolesErr: errors.New("database unavailable"),
+			},
+			wantErr:          true,
+			wantCreatedCount: 0,
+			wantRoles:        []string{"admin", "devops"},
+		},
+		{
+			name: "empty admin list creates no notifications",
+			userRepo: &mockUserRepository{
+				users: []models.User{},
+			},
+			wantCreatedCount: 0,
+			wantRoles:        []string{"admin", "devops"},
+		},
+		{
+			name: "single user notified",
+			userRepo: &mockUserRepository{
+				users: []models.User{
+					{ID: "devops-solo", Username: "dave", Role: "devops"},
+				},
+			},
+			wantCreatedCount: 1,
+			wantRoles:        []string{"admin", "devops"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := newMockNotificationRepo()
+			if tt.createErr != nil {
+				repo.SetCreateError(tt.createErr)
+			}
+
+			var userRepo models.UserRepository
+			if !tt.nilUserRepo {
+				userRepo = tt.userRepo
+			}
+
+			n := NewNotifier(repo, nil, userRepo)
+
+			err := n.NotifySystem(
+				context.Background(),
+				"system_alert",
+				"Cluster Unhealthy",
+				"Cluster prod-eu lost connectivity",
+				"cluster",
+				"cluster-99",
+			)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.wantCreatedCount, len(repo.Created()))
+
+			// Verify roles passed to ListByRoles if userRepo was provided.
+			if tt.userRepo != nil && tt.wantRoles != nil {
+				tt.userRepo.mu.Lock()
+				assert.True(t, tt.userRepo.listByRolesCalled, "ListByRoles should have been called")
+				assert.Equal(t, tt.wantRoles, tt.userRepo.rolesReceived)
+				tt.userRepo.mu.Unlock()
+			}
+		})
+	}
+}
+
+func TestNotifySystem_CreateFailureContinuesToNextUser(t *testing.T) {
+	t.Parallel()
+
+	// Custom repo that fails on the first Create call, succeeds on subsequent.
+	repo := &failOnceMockNotificationRepo{
+		failOnCallN: 1,
+		failErr:     errors.New("transient DB error"),
+	}
+
+	userRepo := &mockUserRepository{
+		users: []models.User{
+			{ID: "user-1", Username: "alice", Role: "admin"},
+			{ID: "user-2", Username: "bob", Role: "admin"},
+			{ID: "user-3", Username: "carol", Role: "devops"},
+		},
+	}
+
+	n := NewNotifier(repo, nil, userRepo)
+
+	err := n.NotifySystem(
+		context.Background(),
+		"warning",
+		"Disk Full",
+		"Node disk usage above 90%",
+		"node",
+		"node-5",
+	)
+
+	// NotifySystem should not return an error even if individual Notify calls fail.
+	assert.NoError(t, err)
+
+	// Should have attempted all 3 users; only 2 succeed (first fails).
+	repo.mu.Lock()
+	assert.Equal(t, 3, repo.callCount, "all 3 users should have been attempted")
+	assert.Len(t, repo.created, 2, "2 notifications should have been created (1 failed)")
+	repo.mu.Unlock()
+}
+
+func TestNotifySystem_VerifiesNotificationContent(t *testing.T) {
+	t.Parallel()
+
+	userRepo := &mockUserRepository{
+		users: []models.User{
+			{ID: "admin-42", Username: "sysadmin", Role: "admin"},
+		},
+	}
+
+	repo := newMockNotificationRepo()
+	n := NewNotifier(repo, nil, userRepo)
+
+	err := n.NotifySystem(
+		context.Background(),
+		"cluster_warning",
+		"Node Pressure",
+		"Memory pressure on node-3",
+		"cluster",
+		"cluster-7",
+	)
+
+	require.NoError(t, err)
+
+	created := repo.Created()
+	require.Len(t, created, 1)
+
+	notif := created[0]
+	assert.Equal(t, "admin-42", notif.UserID)
+	assert.Equal(t, "cluster_warning", notif.Type)
+	assert.Equal(t, "Node Pressure", notif.Title)
+	assert.Equal(t, "Memory pressure on node-3", notif.Message)
+	assert.Equal(t, "cluster", notif.EntityType)
+	assert.Equal(t, "cluster-7", notif.EntityID)
+	assert.False(t, notif.IsRead)
+	assert.NotEmpty(t, notif.ID)
+}
+
+func TestNotifySystem_WithHubBroadcasts(t *testing.T) {
+	t.Parallel()
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	userRepo := &mockUserRepository{
+		users: []models.User{
+			{ID: "admin-ws", Username: "wsadmin", Role: "admin"},
+		},
+	}
+
+	repo := newMockNotificationRepo()
+	n := NewNotifier(repo, hub, userRepo)
+
+	err := n.NotifySystem(
+		context.Background(),
+		"deploy",
+		"Deploy Started",
+		"Deploying to prod",
+		"instance",
+		"inst-1",
+	)
+
+	assert.NoError(t, err)
+	created := repo.Created()
+	require.Len(t, created, 1)
+	assert.Equal(t, "admin-ws", created[0].UserID)
+}
+
+// ---- failOnceMockNotificationRepo ----
+
+// failOnceMockNotificationRepo fails on the Nth Create call and succeeds on others.
+type failOnceMockNotificationRepo struct {
+	mu          sync.Mutex
+	created     []*models.Notification
+	callCount   int
+	failOnCallN int
+	failErr     error
+}
+
+func (m *failOnceMockNotificationRepo) Create(_ context.Context, notification *models.Notification) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.callCount++
+	if m.callCount == m.failOnCallN {
+		return m.failErr
+	}
+	cp := *notification
+	m.created = append(m.created, &cp)
+	return nil
+}
+
+func (m *failOnceMockNotificationRepo) ListByUser(_ context.Context, _ string, _ bool, _, _ int) ([]models.Notification, int64, error) {
+	return nil, 0, nil
+}
+func (m *failOnceMockNotificationRepo) CountUnread(_ context.Context, _ string) (int64, error) {
+	return 0, nil
+}
+func (m *failOnceMockNotificationRepo) MarkAsRead(_ context.Context, _, _ string) error { return nil }
+func (m *failOnceMockNotificationRepo) MarkAllAsRead(_ context.Context, _ string) error { return nil }
+func (m *failOnceMockNotificationRepo) GetPreferences(_ context.Context, _ string) ([]models.NotificationPreference, error) {
+	return nil, nil
+}
+func (m *failOnceMockNotificationRepo) UpdatePreference(_ context.Context, _ *models.NotificationPreference) error {
+	return nil
 }

--- a/backend/internal/scheduler/scheduler_test.go
+++ b/backend/internal/scheduler/scheduler_test.go
@@ -500,3 +500,25 @@ func TestRunPolicyNotFound(t *testing.T) {
 	_, err = s.RunPolicy("nonexistent", true)
 	assert.Error(t, err)
 }
+
+func TestActionPastTense(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		action string
+		want   string
+	}{
+		{"stop", "stopped"},
+		{"clean", "cleaned"},
+		{"delete", "deleted"},
+		{"restart", "restarted"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.action, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, actionPastTense(tt.action))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes #216

- Extracts the ~470-line `main()` into 7 focused bootstrap functions in `api/bootstrap.go`
- `main()` is now ~100 lines calling these in sequence — thin orchestrator
- Each function takes explicit dependencies and returns results, making them independently testable
- Added 18 test cases in `bootstrap_test.go` (buildSessionStore, startHTTPServer, struct assertions)

## Functions extracted

| Function | Purpose |
|---|---|
| `initDatabase` | GORM DB connection, returns repo + *gorm.DB |
| `initRepositories` | All domain-specific repos via factory |
| `buildSessionStore` | Memory vs MySQL session store factory |
| `buildDomainServices` | Git, cluster, deployer, hooks, notifier |
| `buildHandlers` | All 21 HTTP handlers + OIDC init |
| `buildRouter` | Gin engine + route wiring |
| `startBackgroundServices` | TTL reaper, monitors, cleanup scheduler |
| `startHTTPServer` | HTTP server + optional pprof |

## Review fixes applied

- `startBackgroundServices` stops all started services on cleanup scheduler failure (no goroutine leaks)
- `startHTTPServer` preserves `os.Exit(1)` on ListenAndServe bind failure
- Removed unused `Cfg` field from `routerDeps` struct

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./... -short` — all 26 packages pass (28 pass, 2 skip in api/)
- [x] No behavioral changes — pure refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)