### PR TITLE
fix: notification preferences sends bare array (#218)

### DIFF
--- a/backend/internal/api/handlers/notifications_test.go
+++ b/backend/internal/api/handlers/notifications_test.go
@@ -571,6 +571,11 @@ func TestNotificationHandler_UpdatePreferences(t *testing.T) {
 			body:           `[{"enabled":true}]`,
 			expectedStatus: http.StatusBadRequest,
 		},
+		{
+			name:           "wrapped in object rejects (regression: #218)",
+			body:           `{"preferences":[{"event_type":"deployment.success","enabled":true}]}`,
+			expectedStatus: http.StatusBadRequest,
+		},
 	}
 
 	for _, tt := range tests {

--- a/frontend/src/api/__tests__/client.test.ts
+++ b/frontend/src/api/__tests__/client.test.ts
@@ -1633,7 +1633,7 @@ describe('notificationService', () => {
     api.put.mockResolvedValueOnce(mockResponse(undefined));
 
     await notificationService.updatePreferences(prefs);
-    expect(api.put).toHaveBeenCalledWith('/api/v1/notifications/preferences', { preferences: prefs });
+    expect(api.put).toHaveBeenCalledWith('/api/v1/notifications/preferences', prefs);
   });
 
   it('updatePreferences throws on error', async () => {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2056,7 +2056,7 @@ export const notificationService = {
    */
   updatePreferences: async (preferences: { event_type: string; enabled: boolean }[]): Promise<void> => {
     try {
-      await api.put('/api/v1/notifications/preferences', { preferences });
+      await api.put('/api/v1/notifications/preferences', preferences);
     } catch (error) {
       console.error('Failed to update notification preferences:', error);
       throw error;


### PR DESCRIPTION
## Summary

Closes #218

- Frontend sent `{ preferences: [...] }` (wrapped in object) but the backend `ShouldBindJSON` expects `[...]` (bare array), causing 400 Bad Request
- One-char fix: remove the wrapping object in `api.put()` call

## Test plan

- [x] Backend regression test: wrapped-object format returns 400
- [x] Frontend NotificationCenter tests pass (10/10)
- [ ] Manual: toggle a notification preference, verify save succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)