### PR TITLE
feat: guided first-run setup wizard for new users

### DIFF
--- a/frontend/src/components/SetupWizard/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard/__tests__/SetupWizard.test.tsx
@@ -12,6 +12,7 @@ const renderWizard = (props: Partial<React.ComponentProps<typeof SetupWizard>> =
         hasTemplates={false}
         hasInstances={false}
         isAdmin={true}
+        isDevOps={true}
         onDismiss={vi.fn()}
         {...props}
       />
@@ -59,10 +60,17 @@ describe('SetupWizard', () => {
   });
 
   it('calls onDismiss when skip button is clicked', async () => {
+    const user = userEvent.setup();
     const onDismiss = vi.fn();
     renderWizard({ onDismiss });
-    await userEvent.click(screen.getByText('Skip setup'));
+    await user.click(screen.getByText('Skip setup'));
     expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('shows info alert for non-devops users on template step', () => {
+    renderWizard({ hasClusters: true, hasTemplates: false, isDevOps: false });
+    expect(screen.getByText(/Only DevOps users can create templates/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Create a Template' })).not.toBeInTheDocument();
   });
 
   it('shows step progress text', () => {

--- a/frontend/src/components/SetupWizard/__tests__/SetupWizard.test.tsx
+++ b/frontend/src/components/SetupWizard/__tests__/SetupWizard.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import SetupWizard from '../index';
+
+const renderWizard = (props: Partial<React.ComponentProps<typeof SetupWizard>> = {}) =>
+  render(
+    <MemoryRouter>
+      <SetupWizard
+        hasClusters={false}
+        hasTemplates={false}
+        hasInstances={false}
+        isAdmin={true}
+        onDismiss={vi.fn()}
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+
+describe('SetupWizard', () => {
+  it('renders welcome heading', () => {
+    renderWizard();
+    expect(screen.getByText('Welcome to Stack Manager')).toBeInTheDocument();
+  });
+
+  it('renders all three step labels', () => {
+    renderWizard();
+    expect(screen.getAllByText('Register a Cluster').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('Create a Template')).toBeInTheDocument();
+    expect(screen.getByText('Deploy an Instance')).toBeInTheDocument();
+  });
+
+  it('shows cluster step as active when no clusters exist', () => {
+    renderWizard({ hasClusters: false });
+    expect(screen.getByRole('button', { name: 'Register a Cluster' })).toBeInTheDocument();
+  });
+
+  it('shows template step as active when clusters exist but no templates', () => {
+    renderWizard({ hasClusters: true, hasTemplates: false });
+    expect(screen.getByRole('button', { name: 'Create a Template' })).toBeInTheDocument();
+  });
+
+  it('shows instance step as active when clusters and templates exist', () => {
+    renderWizard({ hasClusters: true, hasTemplates: true, hasInstances: false });
+    expect(screen.getByRole('button', { name: 'Deploy an Instance' })).toBeInTheDocument();
+  });
+
+  it('shows info alert for non-admin users on cluster step', () => {
+    renderWizard({ isAdmin: false, hasClusters: false });
+    expect(screen.getByText(/Only administrators can register clusters/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Register a Cluster' })).not.toBeInTheDocument();
+  });
+
+  it('shows action button for admin users on cluster step', () => {
+    renderWizard({ isAdmin: true, hasClusters: false });
+    expect(screen.getByRole('button', { name: 'Register a Cluster' })).toBeInTheDocument();
+    expect(screen.queryByText(/Only administrators/)).not.toBeInTheDocument();
+  });
+
+  it('calls onDismiss when skip button is clicked', async () => {
+    const onDismiss = vi.fn();
+    renderWizard({ onDismiss });
+    await userEvent.click(screen.getByText('Skip setup'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('shows step progress text', () => {
+    renderWizard({ hasClusters: false });
+    expect(screen.getByText('Step 1 of 3')).toBeInTheDocument();
+  });
+
+  it('shows step 2 of 3 when on template step', () => {
+    renderWizard({ hasClusters: true, hasTemplates: false });
+    expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/SetupWizard/index.tsx
+++ b/frontend/src/components/SetupWizard/index.tsx
@@ -20,6 +20,7 @@ interface SetupWizardProps {
   hasTemplates: boolean;
   hasInstances: boolean;
   isAdmin: boolean;
+  isDevOps: boolean;
   onDismiss: () => void;
 }
 
@@ -44,7 +45,7 @@ const steps = [
   },
 ];
 
-const SetupWizard = ({ hasClusters, hasTemplates, hasInstances, isAdmin, onDismiss }: SetupWizardProps) => {
+const SetupWizard = ({ hasClusters, hasTemplates, hasInstances, isAdmin, isDevOps, onDismiss }: SetupWizardProps) => {
   const navigate = useNavigate();
 
   const activeStep = useMemo(() => {
@@ -103,6 +104,10 @@ const SetupWizard = ({ hasClusters, hasTemplates, hasInstances, isAdmin, onDismi
           {activeStep === 0 && !isAdmin ? (
             <Alert severity="info" sx={{ maxWidth: 480, mx: 'auto' }}>
               Only administrators can register clusters. Ask your admin to add one, then return here.
+            </Alert>
+          ) : activeStep === 1 && !isDevOps ? (
+            <Alert severity="info" sx={{ maxWidth: 480, mx: 'auto' }}>
+              Only DevOps users can create templates. Ask your team lead to create one, then return here.
             </Alert>
           ) : (
             <Button

--- a/frontend/src/components/SetupWizard/index.tsx
+++ b/frontend/src/components/SetupWizard/index.tsx
@@ -1,0 +1,126 @@
+import { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  Stepper,
+  Step,
+  StepLabel,
+  Alert,
+} from '@mui/material';
+import CloudOutlinedIcon from '@mui/icons-material/CloudOutlined';
+import ViewModuleOutlinedIcon from '@mui/icons-material/ViewModuleOutlined';
+import RocketLaunchOutlinedIcon from '@mui/icons-material/RocketLaunchOutlined';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+
+interface SetupWizardProps {
+  hasClusters: boolean;
+  hasTemplates: boolean;
+  hasInstances: boolean;
+  isAdmin: boolean;
+  onDismiss: () => void;
+}
+
+const steps = [
+  {
+    label: 'Register a Cluster',
+    icon: <CloudOutlinedIcon sx={{ fontSize: 48 }} />,
+    description: 'Register a Kubernetes cluster where your stacks will run. Clusters provide the compute environment for deployments.',
+    adminRoute: '/admin/clusters',
+  },
+  {
+    label: 'Create a Template',
+    icon: <ViewModuleOutlinedIcon sx={{ fontSize: 48 }} />,
+    description: 'Templates define reusable stack configurations with Helm charts. Create one to standardize deployments across your team.',
+    route: '/templates/new',
+  },
+  {
+    label: 'Deploy an Instance',
+    icon: <RocketLaunchOutlinedIcon sx={{ fontSize: 48 }} />,
+    description: 'Deploy a running instance of your stack to a cluster. Instances are created from templates or stack definitions.',
+    route: '/stack-instances/new',
+  },
+];
+
+const SetupWizard = ({ hasClusters, hasTemplates, hasInstances, isAdmin, onDismiss }: SetupWizardProps) => {
+  const navigate = useNavigate();
+
+  const activeStep = useMemo(() => {
+    if (!hasClusters) return 0;
+    if (!hasTemplates) return 1;
+    if (!hasInstances) return 2;
+    return 3;
+  }, [hasClusters, hasTemplates, hasInstances]);
+
+  const completedSteps = useMemo(() => {
+    const completed = new Set<number>();
+    if (hasClusters) completed.add(0);
+    if (hasTemplates) completed.add(1);
+    if (hasInstances) completed.add(2);
+    return completed;
+  }, [hasClusters, hasTemplates, hasInstances]);
+
+  return (
+    <Box sx={{ maxWidth: 720, mx: 'auto', mt: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
+        <Box>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Welcome to Stack Manager
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Get started by completing these steps to deploy your first stack.
+          </Typography>
+        </Box>
+        <Button size="small" onClick={onDismiss} sx={{ whiteSpace: 'nowrap' }}>
+          Skip setup
+        </Button>
+      </Box>
+
+      <Stepper activeStep={activeStep} alternativeLabel sx={{ mb: 4 }}>
+        {steps.map((step, index) => (
+          <Step key={step.label} completed={completedSteps.has(index)}>
+            <StepLabel>{step.label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+
+      {activeStep < steps.length && (
+        <Paper sx={{ p: 4, textAlign: 'center' }}>
+          <Box sx={{ color: completedSteps.has(activeStep) ? 'success.main' : 'text.secondary', mb: 2 }}>
+            {completedSteps.has(activeStep) ? <CheckCircleIcon sx={{ fontSize: 48 }} /> : steps[activeStep].icon}
+          </Box>
+
+          <Typography variant="h6" gutterBottom>
+            {steps[activeStep].label}
+          </Typography>
+
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 3, maxWidth: 480, mx: 'auto' }}>
+            {steps[activeStep].description}
+          </Typography>
+
+          {activeStep === 0 && !isAdmin ? (
+            <Alert severity="info" sx={{ maxWidth: 480, mx: 'auto' }}>
+              Only administrators can register clusters. Ask your admin to add one, then return here.
+            </Alert>
+          ) : (
+            <Button
+              variant="contained"
+              size="large"
+              onClick={() => navigate(activeStep === 0 ? steps[0].adminRoute! : steps[activeStep].route!)}
+            >
+              {steps[activeStep].label}
+            </Button>
+          )}
+        </Paper>
+      )}
+
+      <Typography variant="body2" color="text.secondary" sx={{ mt: 3, textAlign: 'center' }}>
+        Step {Math.min(activeStep + 1, steps.length)} of {steps.length}
+      </Typography>
+    </Box>
+  );
+};
+
+export default SetupWizard;

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -493,13 +493,14 @@ const Dashboard = () => {
     return <Alert severity="error">{error}</Alert>;
   }
 
-  if (!wizardDismissed && (clusters.length === 0 || templates.length === 0 || instances.length === 0)) {
+  if (!wizardDismissed && instances.length === 0 && (clusters.length === 0 || templates.length === 0)) {
     return (
       <SetupWizard
         hasClusters={clusters.length > 0}
         hasTemplates={templates.length > 0}
-        hasInstances={instances.length > 0}
+        hasInstances={false}
         isAdmin={user?.role === 'admin'}
+        isDevOps={user?.role === 'admin' || user?.role === 'devops'}
         onDismiss={handleDismissWizard}
       />
     );

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -493,13 +493,13 @@ const Dashboard = () => {
     return <Alert severity="error">{error}</Alert>;
   }
 
-  if (!wizardDismissed && clusters.length === 0 && instances.length === 0) {
+  if (!wizardDismissed && (clusters.length === 0 || templates.length === 0 || instances.length === 0)) {
     return (
       <SetupWizard
         hasClusters={clusters.length > 0}
         hasTemplates={templates.length > 0}
         hasInstances={instances.length > 0}
-        isAdmin={user?.role === 'admin' || user?.role === 'devops'}
+        isAdmin={user?.role === 'admin'}
         onDismiss={handleDismissWizard}
       />
     );

--- a/frontend/src/pages/StackInstances/Dashboard.tsx
+++ b/frontend/src/pages/StackInstances/Dashboard.tsx
@@ -39,11 +39,14 @@ import StatusBadge from '../../components/StatusBadge';
 import FavoriteButton from '../../components/FavoriteButton';
 import ExpiryChip from './ExpiryChip';
 import DashboardWidgets from './widgets/DashboardWidgets';
-import { instanceService, clusterService, favoriteService } from '../../api/client';
-import type { StackInstance, Cluster, NamespaceStatus, UserFavorite, BulkOperationResponse } from '../../types';
+import { instanceService, clusterService, favoriteService, templateService } from '../../api/client';
+import type { StackInstance, Cluster, StackTemplate, NamespaceStatus, UserFavorite, BulkOperationResponse } from '../../types';
 import LoadingState from '../../components/LoadingState';
 import EmptyState from '../../components/EmptyState';
+import SetupWizard from '../../components/SetupWizard';
 import { useNotification } from '../../context/NotificationContext';
+import { useAuth } from '../../context/AuthContext';
+import { isSetupWizardDismissed, dismissSetupWizard } from '../../utils/setupWizard';
 
 const STATUSES = ['All', 'draft', 'deploying', 'stabilizing', 'running', 'partial', 'stopped', 'error'];
 
@@ -189,11 +192,14 @@ const InstanceCard = ({ instance, isSelected, isFavorite, clusterName, url, k8sH
 const Dashboard = () => {
   const [instances, setInstances] = useState<StackInstance[]>([]);
   const [clusters, setClusters] = useState<Cluster[]>([]);
+  const [templates, setTemplates] = useState<StackTemplate[]>([]);
   const [favorites, setFavorites] = useState<UserFavorite[]>([]);
   const [recentInstances, setRecentInstances] = useState<StackInstance[]>([]);
   const [loading, setLoading] = useState(true);
   const searchRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [wizardDismissed, setWizardDismissed] = useState(() => isSetupWizardDismissed());
+  const { user } = useAuth();
   const [search, setSearch] = useState('');
   const [statusFilter, setStatusFilter] = useState('All');
   const [instanceUrls, setInstanceUrls] = useState<Record<string, string>>({});
@@ -225,14 +231,16 @@ const Dashboard = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const [instData, clsData, favData, recentData] = await Promise.all([
+        const [instData, clsData, tmplData, favData, recentData] = await Promise.all([
           instanceService.list(),
           clusterService.list().catch(() => [] as Cluster[]),
+          templateService.list().catch(() => [] as StackTemplate[]),
           favoriteService.list().catch(() => [] as UserFavorite[]),
           instanceService.recent().catch(() => [] as StackInstance[]),
         ]);
         setInstances(instData || []);
         setClusters(clsData || []);
+        setTemplates(tmplData || []);
         setFavorites(favData || []);
         setRecentInstances(recentData || []);
       } catch {
@@ -472,12 +480,29 @@ const Dashboard = () => {
     setBulkAction(null);
   }, []);
 
+  const handleDismissWizard = useCallback(() => {
+    dismissSetupWizard();
+    setWizardDismissed(true);
+  }, []);
+
   if (loading) {
     return <LoadingState label="Loading instances..." />;
   }
 
   if (error) {
     return <Alert severity="error">{error}</Alert>;
+  }
+
+  if (!wizardDismissed && clusters.length === 0 && instances.length === 0) {
+    return (
+      <SetupWizard
+        hasClusters={clusters.length > 0}
+        hasTemplates={templates.length > 0}
+        hasInstances={instances.length > 0}
+        isAdmin={user?.role === 'admin' || user?.role === 'devops'}
+        onDismiss={handleDismissWizard}
+      />
+    );
   }
 
   const allFilteredSelected = filtered.length > 0 && selectedIds.size === filtered.length;

--- a/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
@@ -72,7 +72,8 @@ vi.mock('../../../context/AuthContext', () => ({
   }),
 }));
 
-import { instanceService, favoriteService, clusterService } from '../../../api/client';
+import { instanceService, favoriteService, clusterService, templateService } from '../../../api/client';
+import { isSetupWizardDismissed } from '../../../utils/setupWizard';
 import useCountdown from '../../../hooks/useCountdown';
 
 const mockInstance = (overrides: Record<string, unknown> = {}) => ({
@@ -97,9 +98,11 @@ describe('Dashboard', () => {
   // Reset default mocks that survive clearAllMocks
   beforeEach(() => {
     localStorage.clear();
+    (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(true);
     (instanceService.recent as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (favoriteService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 'c1', name: 'dev' }]);
+    (templateService.list as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 't1', name: 'Web' }]);
   });
 
   it('shows loading spinner initially', () => {
@@ -145,7 +148,7 @@ describe('Dashboard', () => {
     });
   });
 
-  it('shows empty state when no instances but clusters exist', async () => {
+  it('shows empty state when no instances but wizard dismissed', async () => {
     (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     render(
       <MemoryRouter>
@@ -971,6 +974,10 @@ describe('Dashboard', () => {
   });
 
   describe('Setup Wizard', () => {
+    beforeEach(() => {
+      (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    });
+
     it('shows wizard when no clusters and no instances', async () => {
       (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -986,8 +993,8 @@ describe('Dashboard', () => {
       });
     });
 
-    it('does not show wizard when clusters exist', async () => {
-      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    it('does not show wizard when all resources exist', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([mockInstance()]);
       render(
         <MemoryRouter>
           <NotificationProvider>
@@ -1001,9 +1008,9 @@ describe('Dashboard', () => {
       expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
     });
 
-    it('does not show wizard when instances exist', async () => {
-      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([mockInstance()]);
-      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    it('shows wizard at step 2 when clusters exist but no templates', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (templateService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       render(
         <MemoryRouter>
           <NotificationProvider>
@@ -1012,13 +1019,12 @@ describe('Dashboard', () => {
         </MemoryRouter>
       );
       await waitFor(() => {
-        expect(screen.getByText('Test Instance')).toBeInTheDocument();
+        expect(screen.getByText('Welcome to Stack Manager')).toBeInTheDocument();
       });
-      expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Create a Template' })).toBeInTheDocument();
     });
 
     it('does not show wizard when dismissed', async () => {
-      const { isSetupWizardDismissed } = await import('../../../utils/setupWizard');
       (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(true);
       (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
       (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
@@ -1033,7 +1039,6 @@ describe('Dashboard', () => {
         expect(screen.getByText(/no stack instances found/i)).toBeInTheDocument();
       });
       expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
-      (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(false);
     });
 
     it('hides wizard and shows dashboard when skip is clicked', async () => {

--- a/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Dashboard.test.tsx
@@ -24,6 +24,11 @@ vi.mock('../../../hooks/useCountdown', () => ({
   default: vi.fn().mockReturnValue(null),
 }));
 
+vi.mock('../../../utils/setupWizard', () => ({
+  isSetupWizardDismissed: vi.fn().mockReturnValue(false),
+  dismissSetupWizard: vi.fn(),
+}));
+
 vi.mock('../../../api/client', () => ({
   instanceService: {
     list: vi.fn(),
@@ -36,6 +41,9 @@ vi.mock('../../../api/client', () => ({
     getPods: vi.fn().mockRejectedValue(new Error('no pods')),
   },
   clusterService: {
+    list: vi.fn().mockResolvedValue([]),
+  },
+  templateService: {
     list: vi.fn().mockResolvedValue([]),
   },
   favoriteService: {
@@ -88,8 +96,10 @@ describe('Dashboard', () => {
 
   // Reset default mocks that survive clearAllMocks
   beforeEach(() => {
+    localStorage.clear();
     (instanceService.recent as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (favoriteService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([{ id: 'c1', name: 'dev' }]);
   });
 
   it('shows loading spinner initially', () => {
@@ -135,7 +145,7 @@ describe('Dashboard', () => {
     });
   });
 
-  it('shows empty state when no instances', async () => {
+  it('shows empty state when no instances but clusters exist', async () => {
     (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     render(
       <MemoryRouter>
@@ -957,6 +967,93 @@ describe('Dashboard', () => {
         expect(screen.getByText('Stack Instances')).toBeInTheDocument();
       });
       expect(screen.getByRole('button', { name: /compare/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Setup Wizard', () => {
+    it('shows wizard when no clusters and no instances', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Welcome to Stack Manager')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show wizard when clusters exist', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Stack Instances')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
+    });
+
+    it('does not show wizard when instances exist', async () => {
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([mockInstance()]);
+      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Test Instance')).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
+    });
+
+    it('does not show wizard when dismissed', async () => {
+      const { isSetupWizardDismissed } = await import('../../../utils/setupWizard');
+      (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText(/no stack instances found/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
+      (isSetupWizardDismissed as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    });
+
+    it('hides wizard and shows dashboard when skip is clicked', async () => {
+      const user = userEvent.setup();
+      (instanceService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      (clusterService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+      render(
+        <MemoryRouter>
+          <NotificationProvider>
+            <Dashboard />
+          </NotificationProvider>
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('Welcome to Stack Manager')).toBeInTheDocument();
+      });
+      await user.click(screen.getByText('Skip setup'));
+      await waitFor(() => {
+        expect(screen.queryByText('Welcome to Stack Manager')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/pages/StackInstances/__tests__/Form.test.tsx
+++ b/frontend/src/pages/StackInstances/__tests__/Form.test.tsx
@@ -343,7 +343,7 @@ describe('StackInstances Form', () => {
 
     // Branch field should update to the definition's default branch
     await waitFor(() => {
-      const branchInput = screen.getByRole('combobox', { name: /branch/i });
+      const branchInput = screen.getByRole('textbox', { name: /branch/i });
       expect(branchInput).toHaveValue('develop');
     });
   });

--- a/frontend/src/utils/__tests__/setupWizard.test.ts
+++ b/frontend/src/utils/__tests__/setupWizard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { isSetupWizardDismissed, dismissSetupWizard, resetSetupWizard } from '../setupWizard';
+
+describe('setupWizard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe('isSetupWizardDismissed', () => {
+    it('returns false when nothing stored', () => {
+      expect(isSetupWizardDismissed()).toBe(false);
+    });
+
+    it('returns false for non-true values', () => {
+      localStorage.setItem('setupWizardDismissed', 'false');
+      expect(isSetupWizardDismissed()).toBe(false);
+    });
+
+    it('returns true after dismiss', () => {
+      dismissSetupWizard();
+      expect(isSetupWizardDismissed()).toBe(true);
+    });
+
+    it('handles localStorage errors gracefully', () => {
+      const spy = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+        throw new Error('access denied');
+      });
+      expect(isSetupWizardDismissed()).toBe(false);
+      spy.mockRestore();
+    });
+  });
+
+  describe('dismissSetupWizard', () => {
+    it('stores true in localStorage', () => {
+      dismissSetupWizard();
+      expect(localStorage.getItem('setupWizardDismissed')).toBe('true');
+    });
+
+    it('handles localStorage errors gracefully', () => {
+      const spy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+        throw new Error('quota exceeded');
+      });
+      expect(() => dismissSetupWizard()).not.toThrow();
+      spy.mockRestore();
+    });
+  });
+
+  describe('resetSetupWizard', () => {
+    it('clears the dismissed state', () => {
+      dismissSetupWizard();
+      expect(isSetupWizardDismissed()).toBe(true);
+      resetSetupWizard();
+      expect(isSetupWizardDismissed()).toBe(false);
+    });
+  });
+});

--- a/frontend/src/utils/setupWizard.ts
+++ b/frontend/src/utils/setupWizard.ts
@@ -1,0 +1,25 @@
+const STORAGE_KEY = 'setupWizardDismissed';
+
+export function isSetupWizardDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function dismissSetupWizard(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, 'true');
+  } catch {
+    // Ignore localStorage errors
+  }
+}
+
+export function resetSetupWizard(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Ignore localStorage errors
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a 3-step setup wizard (Register Cluster → Create Template → Deploy Instance) that replaces the empty dashboard for new users
- Wizard auto-advances based on live API data when users return after completing each step
- Dismissal persists in localStorage; non-admin users see an info message on the cluster step
- Fixes pre-existing Form test using wrong ARIA role query for the branch input

Closes #123

## Test plan
- [ ] Start with empty DB, log in as admin — wizard appears at `/`
- [ ] Click "Skip setup" — dashboard shows, refresh — wizard stays hidden
- [ ] Create a cluster, return to `/` — wizard advances to step 2
- [ ] Log in as non-admin with no clusters — cluster step shows "ask your admin" message
- [ ] `cd frontend && npm run build` passes
- [ ] `npx vitest run` — all tests pass (942/942)

🤖 Generated with [Claude Code](https://claude.com/claude-code)