### PR TITLE
fix: dark mode polish for YamlEditor and DeploymentLogViewer

### DIFF
--- a/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
+++ b/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
@@ -1,8 +1,12 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DeploymentLogViewer from '../index';
 import type { DeploymentLog } from '../../../types';
+
+vi.mock('../../../context/ThemeContext', () => ({
+  useThemeMode: () => ({ mode: 'dark', toggleMode: vi.fn() }),
+}));
 
 // jsdom doesn't implement scrollIntoView
 beforeAll(() => {

--- a/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
+++ b/frontend/src/components/DeploymentLogViewer/__tests__/DeploymentLogViewer.test.tsx
@@ -1,12 +1,8 @@
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import DeploymentLogViewer from '../index';
 import type { DeploymentLog } from '../../../types';
-
-vi.mock('../../../context/ThemeContext', () => ({
-  useThemeMode: () => ({ mode: 'dark', toggleMode: vi.fn() }),
-}));
 
 // jsdom doesn't implement scrollIntoView
 beforeAll(() => {

--- a/frontend/src/components/DeploymentLogViewer/index.tsx
+++ b/frontend/src/components/DeploymentLogViewer/index.tsx
@@ -9,7 +9,6 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { DeploymentLog } from '../../types';
-import { useThemeMode } from '../../context/ThemeContext';
 
 interface DeploymentLogViewerProps {
   logs: DeploymentLog[];
@@ -46,22 +45,20 @@ const formatDuration = (startedAt: string, completedAt: string): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-const terminalSx = (mode: 'light' | 'dark') =>
-  ({
-    p: 2,
-    bgcolor: mode === 'dark' ? '#1e1e1e' : '#fafafa',
-    color: mode === 'dark' ? '#d4d4d4' : '#1e1e1e',
-    fontFamily: 'monospace',
-    fontSize: '0.8rem',
-    lineHeight: 1.6,
-    maxHeight: 300,
-    overflow: 'auto',
-    whiteSpace: 'pre-wrap',
-    wordBreak: 'break-all',
-  }) as const;
+const terminalSx = {
+  p: 2,
+  bgcolor: 'background.paper',
+  color: 'text.primary',
+  fontFamily: 'monospace',
+  fontSize: '0.8rem',
+  lineHeight: 1.6,
+  maxHeight: 300,
+  overflow: 'auto',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+} as const;
 
 const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogViewerProps) => {
-  const { mode } = useThemeMode();
   const bottomRef = useRef<HTMLDivElement>(null);
   const streamContainerRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState<string | false>(false);
@@ -163,14 +160,14 @@ const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogVie
               {isStreaming ? (
                 <Box
                   ref={isExpanded ? streamContainerRef : undefined}
-                  sx={terminalSx(mode)}
+                  sx={terminalSx}
                 >
                   {lines.map((line, i) => (
                     <div key={`line-${i}`}>{line || '\u00A0'}</div>
                   ))}
                 </Box>
               ) : log.output ? (
-                <Box sx={terminalSx(mode)}>
+                <Box sx={terminalSx}>
                   {log.output}
                   {log.error_message && (
                     <Box sx={{ color: 'error.main', mt: 1 }}>

--- a/frontend/src/components/DeploymentLogViewer/index.tsx
+++ b/frontend/src/components/DeploymentLogViewer/index.tsx
@@ -9,6 +9,7 @@ import {
 } from '@mui/material';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import type { DeploymentLog } from '../../types';
+import { useThemeMode } from '../../context/ThemeContext';
 
 interface DeploymentLogViewerProps {
   logs: DeploymentLog[];
@@ -45,20 +46,22 @@ const formatDuration = (startedAt: string, completedAt: string): string => {
   return `${minutes}m ${remainingSeconds}s`;
 };
 
-const terminalSx = {
-  p: 2,
-  bgcolor: '#1e1e1e',
-  color: '#d4d4d4',
-  fontFamily: 'monospace',
-  fontSize: '0.8rem',
-  lineHeight: 1.6,
-  maxHeight: 300,
-  overflow: 'auto',
-  whiteSpace: 'pre-wrap',
-  wordBreak: 'break-all',
-} as const;
+const terminalSx = (mode: 'light' | 'dark') =>
+  ({
+    p: 2,
+    bgcolor: mode === 'dark' ? '#1e1e1e' : '#fafafa',
+    color: mode === 'dark' ? '#d4d4d4' : '#1e1e1e',
+    fontFamily: 'monospace',
+    fontSize: '0.8rem',
+    lineHeight: 1.6,
+    maxHeight: 300,
+    overflow: 'auto',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
+  }) as const;
 
 const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogViewerProps) => {
+  const { mode } = useThemeMode();
   const bottomRef = useRef<HTMLDivElement>(null);
   const streamContainerRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState<string | false>(false);
@@ -160,17 +163,17 @@ const DeploymentLogViewer = ({ logs, loading, streamingLines }: DeploymentLogVie
               {isStreaming ? (
                 <Box
                   ref={isExpanded ? streamContainerRef : undefined}
-                  sx={terminalSx}
+                  sx={terminalSx(mode)}
                 >
                   {lines.map((line, i) => (
                     <div key={`line-${i}`}>{line || '\u00A0'}</div>
                   ))}
                 </Box>
               ) : log.output ? (
-                <Box sx={terminalSx}>
+                <Box sx={terminalSx(mode)}>
                   {log.output}
                   {log.error_message && (
-                    <Box sx={{ color: '#f44336', mt: 1 }}>
+                    <Box sx={{ color: 'error.main', mt: 1 }}>
                       Error: {log.error_message}
                     </Box>
                   )}

--- a/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
+++ b/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import YamlEditor from '../index';
 
+const mockUseThemeMode = vi.fn().mockReturnValue({ mode: 'dark', toggleMode: vi.fn() });
+
 vi.mock('../../../context/ThemeContext', () => ({
-  useThemeMode: () => ({ mode: 'dark', toggleMode: vi.fn() }),
+  useThemeMode: () => mockUseThemeMode(),
 }));
 
 // Mock the Monaco Editor since it requires a browser environment
@@ -12,12 +14,14 @@ vi.mock('@monaco-editor/react', () => ({
     value,
     onChange,
     options,
+    theme,
   }: {
     value: string;
     onChange?: (value: string | undefined) => void;
     options?: { readOnly?: boolean };
+    theme?: string;
   }) => (
-    <div data-testid="monaco-editor">
+    <div data-testid="monaco-editor" data-theme={theme}>
       <textarea
         data-testid="monaco-textarea"
         value={value}
@@ -73,5 +77,17 @@ describe('YamlEditor', () => {
   it('renders the editor container', () => {
     render(<YamlEditor {...defaultProps} />);
     expect(screen.getByTestId('monaco-editor')).toBeInTheDocument();
+  });
+
+  it('uses vs-dark theme in dark mode', () => {
+    mockUseThemeMode.mockReturnValue({ mode: 'dark', toggleMode: vi.fn() });
+    render(<YamlEditor {...defaultProps} />);
+    expect(screen.getByTestId('monaco-editor')).toHaveAttribute('data-theme', 'vs-dark');
+  });
+
+  it('uses vs theme in light mode', () => {
+    mockUseThemeMode.mockReturnValue({ mode: 'light', toggleMode: vi.fn() });
+    render(<YamlEditor {...defaultProps} />);
+    expect(screen.getByTestId('monaco-editor')).toHaveAttribute('data-theme', 'vs');
   });
 });

--- a/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
+++ b/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import YamlEditor from '../index';
 
-const mockUseThemeMode = vi.fn().mockReturnValue({ mode: 'dark', toggleMode: vi.fn() });
+const { mockUseThemeMode } = vi.hoisted(() => ({
+  mockUseThemeMode: vi.fn().mockReturnValue({ mode: 'dark', toggleMode: vi.fn() }),
+}));
 
 vi.mock('../../../context/ThemeContext', () => ({
   useThemeMode: () => mockUseThemeMode(),

--- a/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
+++ b/frontend/src/components/YamlEditor/__tests__/YamlEditor.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import YamlEditor from '../index';
 
+vi.mock('../../../context/ThemeContext', () => ({
+  useThemeMode: () => ({ mode: 'dark', toggleMode: vi.fn() }),
+}));
+
 // Mock the Monaco Editor since it requires a browser environment
 vi.mock('@monaco-editor/react', () => ({
   default: ({

--- a/frontend/src/components/YamlEditor/index.tsx
+++ b/frontend/src/components/YamlEditor/index.tsx
@@ -2,6 +2,7 @@ import Editor, { type OnMount } from '@monaco-editor/react';
 import { Box, Typography } from '@mui/material';
 import { useState, useCallback, useRef } from 'react';
 import yaml from 'js-yaml';
+import { useThemeMode } from '../../context/ThemeContext';
 
 type EditorInstance = Parameters<OnMount>[0];
 
@@ -15,6 +16,7 @@ interface YamlEditorProps {
 }
 
 const YamlEditor = ({ value, onChange, label, height = '300px', readOnly = false, error }: YamlEditorProps) => {
+  const { mode } = useThemeMode();
   const [validationError, setValidationError] = useState<string | null>(null);
   const editorRef = useRef<EditorInstance | null>(null);
 
@@ -60,6 +62,7 @@ const YamlEditor = ({ value, onChange, label, height = '300px', readOnly = false
           value={value}
           onChange={handleChange}
           onMount={handleEditorMount}
+          theme={mode === 'dark' ? 'vs-dark' : 'vs'}
           options={{
             readOnly,
             minimap: { enabled: false },


### PR DESCRIPTION
## Summary
- **YamlEditor**: Switch Monaco editor theme between `vs` / `vs-dark` based on app theme mode
- **DeploymentLogViewer**: Replace hardcoded hex colors (`#1e1e1e`, `#d4d4d4`, `#f44336`) with theme-aware values; use `error.main` token for error text
- Add `useThemeMode` mocks to both component test files

Closes #127

## Test plan
- [ ] Toggle dark/light mode — YAML editors on Template Builder and Definition Form switch theme
- [ ] Toggle dark/light mode — deployment log terminal in Instance Detail adapts background/text colors
- [ ] Error messages in deployment logs use correct theme error color in both modes
- [ ] `cd frontend && npx vitest run` — 943/943 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)