### PR TITLE
feat: admin password reset for local/service accounts

### DIFF
--- a/backend/.air.toml
+++ b/backend/.air.toml
@@ -1,7 +1,7 @@
 root = "."
 tmp_dir = "tmp"
 [build]
-  cmd = "go build -o ./tmp/main ./api/main.go"
+  cmd = "go build -o ./tmp/main ./api/"
   bin = "./tmp/main"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor"]

--- a/backend/internal/api/handlers/users.go
+++ b/backend/internal/api/handlers/users.go
@@ -198,7 +198,7 @@ func (h *UserHandler) setDisabled(c *gin.Context, disabled bool) {
 // @Produce      json
 // @Security     BearerAuth
 // @Param        id       path      string                 true  "User ID"
-// @Param        request  body      resetPasswordRequest   true  "New password"
+// @Param        request  body      ResetPasswordRequest   true  "New password"
 // @Success      200  {object}  map[string]string
 // @Failure      400  {object}  map[string]string
 // @Failure      401  {object}  map[string]string
@@ -213,7 +213,7 @@ func (h *UserHandler) ResetUserPassword(c *gin.Context) {
 		return
 	}
 
-	var req resetPasswordRequest
+	var req ResetPasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": msgInvalidRequestFormat})
 		return
@@ -256,10 +256,23 @@ func (h *UserHandler) ResetUserPassword(c *gin.Context) {
 			slog.Warn("Failed to revoke refresh tokens after password reset", "user_id", id, "error", err)
 		}
 	}
+	if h.sessionStore != nil {
+		ttl := h.accessTokenExpiration
+		if h.jwtExpiration > ttl {
+			ttl = h.jwtExpiration
+		}
+		if ttl <= 0 {
+			ttl = 24 * time.Hour
+		}
+		if err := h.sessionStore.BlockUser(c.Request.Context(), id, time.Now().Add(ttl)); err != nil {
+			slog.Warn("Failed to block user in session store after password reset", "user_id", id, "error", err)
+		}
+	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "Password reset successfully"})
 }
 
-type resetPasswordRequest struct {
+// ResetPasswordRequest is the request body for password reset.
+type ResetPasswordRequest struct {
 	Password string `json:"password" binding:"required"`
 }

--- a/backend/internal/api/handlers/users.go
+++ b/backend/internal/api/handlers/users.go
@@ -10,6 +10,7 @@ import (
 	"backend/internal/sessionstore"
 
 	"github.com/gin-gonic/gin"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // UserHandler handles user management endpoints.
@@ -187,4 +188,78 @@ func (h *UserHandler) setDisabled(c *gin.Context, disabled bool) {
 		action = "disabled"
 	}
 	c.JSON(http.StatusOK, gin.H{"message": "User " + action + " successfully"})
+}
+
+// ResetUserPassword godoc
+// @Summary      Reset user password
+// @Description  Resets the password for a local/service account user. Admin only.
+// @Tags         users
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id       path      string                 true  "User ID"
+// @Param        request  body      resetPasswordRequest   true  "New password"
+// @Success      200  {object}  map[string]string
+// @Failure      400  {object}  map[string]string
+// @Failure      401  {object}  map[string]string
+// @Failure      403  {object}  map[string]string
+// @Failure      404  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
+// @Router       /api/v1/users/{id}/password [put]
+func (h *UserHandler) ResetUserPassword(c *gin.Context) {
+	id := c.Param("id")
+	if id == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "User ID is required"})
+		return
+	}
+
+	var req resetPasswordRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": msgInvalidRequestFormat})
+		return
+	}
+
+	if len(req.Password) < 8 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at least 8 characters"})
+		return
+	}
+
+	user, err := h.userRepo.FindByID(id)
+	if err != nil {
+		status, message := mapError(err, "User")
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	if user.AuthProvider != "" && user.AuthProvider != "local" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Cannot reset password for non-local user"})
+		return
+	}
+
+	bcryptSem <- struct{}{}
+	hash, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
+	<-bcryptSem
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})
+		return
+	}
+
+	user.PasswordHash = string(hash)
+	if err := h.userRepo.Update(user); err != nil {
+		status, message := mapError(err, "User")
+		c.JSON(status, gin.H{"error": message})
+		return
+	}
+
+	if h.refreshTokenRepo != nil {
+		if err := h.refreshTokenRepo.RevokeAllForUser(id); err != nil {
+			slog.Warn("Failed to revoke refresh tokens after password reset", "user_id", id, "error", err)
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Password reset successfully"})
+}
+
+type resetPasswordRequest struct {
+	Password string `json:"password" binding:"required"`
 }

--- a/backend/internal/api/handlers/users_test.go
+++ b/backend/internal/api/handlers/users_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"backend/internal/api/middleware"
@@ -12,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // setupUserRouter creates a gin engine wired to UserHandler routes, mirroring the production
@@ -28,6 +30,7 @@ func setupUserRouter(userRepo *MockUserRepository, callerID, callerRole string) 
 		users.DELETE("/:id", adminMW, h.DeleteUser)
 		users.PUT("/:id/disable", adminMW, h.DisableUser)
 		users.PUT("/:id/enable", adminMW, h.EnableUser)
+		users.PUT("/:id/password", adminMW, h.ResetUserPassword)
 	}
 	return r
 }
@@ -260,4 +263,122 @@ func TestEnableUser(t *testing.T) {
 	got, err := userRepo.FindByID("user-1")
 	require.NoError(t, err)
 	assert.False(t, got.Disabled, "user should be enabled after PUT /enable")
+}
+
+// ---- TestResetUserPassword ----
+
+func TestResetUserPassword(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		callerID     string
+		callerRole   string
+		targetID     string
+		body         string
+		seedTarget   bool
+		authProvider string
+		wantStatus   int
+		wantChanged  bool
+	}{
+		{
+			name:        "admin resets local user password",
+			callerID:    "admin-1",
+			callerRole:  "admin",
+			targetID:    "user-1",
+			body:        `{"password":"newsecurepassword"}`,
+			seedTarget:  true,
+			wantStatus:  http.StatusOK,
+			wantChanged: true,
+		},
+		{
+			name:         "admin resets password for user with empty auth_provider (legacy local)",
+			callerID:     "admin-1",
+			callerRole:   "admin",
+			targetID:     "user-2",
+			body:         `{"password":"newsecurepassword"}`,
+			seedTarget:   true,
+			authProvider: "",
+			wantStatus:   http.StatusOK,
+			wantChanged:  true,
+		},
+		{
+			name:         "rejects OIDC user",
+			callerID:     "admin-1",
+			callerRole:   "admin",
+			targetID:     "oidc-user",
+			body:         `{"password":"newsecurepassword"}`,
+			seedTarget:   true,
+			authProvider: "oidc",
+			wantStatus:   http.StatusBadRequest,
+		},
+		{
+			name:       "rejects short password",
+			callerID:   "admin-1",
+			callerRole: "admin",
+			targetID:   "user-1",
+			body:       `{"password":"short"}`,
+			seedTarget: true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "rejects missing password field",
+			callerID:   "admin-1",
+			callerRole: "admin",
+			targetID:   "user-1",
+			body:       `{}`,
+			seedTarget: true,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:       "non-admin gets 403",
+			callerID:   "user-1",
+			callerRole: "user",
+			targetID:   "user-2",
+			body:       `{"password":"newsecurepassword"}`,
+			seedTarget: true,
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "target not found returns 404",
+			callerID:   "admin-1",
+			callerRole: "admin",
+			targetID:   "ghost",
+			body:       `{"password":"newsecurepassword"}`,
+			seedTarget: false,
+			wantStatus: http.StatusNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			userRepo := NewMockUserRepository()
+			var oldHash string
+			if tt.seedTarget {
+				u := seedUser(t, userRepo, tt.targetID, tt.targetID+"-name", "oldpassword", "user")
+				if tt.authProvider != "" {
+					u.AuthProvider = tt.authProvider
+					require.NoError(t, userRepo.Update(u))
+				}
+				oldHash = u.PasswordHash
+			}
+
+			router := setupUserRouter(userRepo, tt.callerID, tt.callerRole)
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest(http.MethodPut, "/api/v1/users/"+tt.targetID+"/password", strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantStatus, w.Code)
+
+			if tt.wantChanged {
+				u, err := userRepo.FindByID(tt.targetID)
+				require.NoError(t, err)
+				assert.NotEqual(t, oldHash, u.PasswordHash, "password hash should have changed")
+				assert.NoError(t, bcrypt.CompareHashAndPassword([]byte(u.PasswordHash), []byte("newsecurepassword")))
+			}
+		})
+	}
 }

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -392,6 +392,7 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 				users.DELETE("/:id", admin, deps.UserHandler.DeleteUser)
 				users.PUT("/:id/disable", admin, deps.UserHandler.DisableUser)
 				users.PUT("/:id/enable", admin, deps.UserHandler.EnableUser)
+				users.PUT("/:id/password", admin, deps.UserHandler.ResetUserPassword)
 			}
 		}
 

--- a/backend/internal/api/routes/routes_test.go
+++ b/backend/internal/api/routes/routes_test.go
@@ -1280,6 +1280,7 @@ func TestSetupRoutes_AllHandlers_RegistersCompleteAPI(t *testing.T) {
 		{"DELETE", "/api/v1/users/:id"},
 		{"PUT", "/api/v1/users/:id/disable"},
 		{"PUT", "/api/v1/users/:id/enable"},
+		{"PUT", "/api/v1/users/:id/password"},
 
 		// API keys
 		{"GET", "/api/v1/users/:id/api-keys"},

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -164,6 +164,96 @@ test.describe('Admin User Management', () => {
     await apiDeleteUser(request, token, userId).catch(() => {});
   });
 
+  test('reset password for a local user and verify login', async ({ page, request }) => {
+    const token = await apiLogin(request);
+    const username = uniqueName('pw-reset');
+    const userId = await apiCreateUser(request, token, username);
+
+    await page.reload();
+    await expect(page.getByRole('heading', { level: 1, name: 'User Management' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('cell', { name: username, exact: true })).toBeVisible({ timeout: 10_000 });
+
+    // Click reset password button
+    await page.getByRole('button', { name: `Reset password for ${username}` }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('heading', { name: 'Reset Password' })).toBeVisible();
+
+    // Submit button should be disabled until password meets minimum length
+    const submitBtn = dialog.getByRole('button', { name: 'Reset Password' });
+    await expect(submitBtn).toBeDisabled();
+
+    await dialog.getByLabel('New Password').fill('newpass123');
+    await expect(submitBtn).toBeEnabled();
+    await submitBtn.click();
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // Verify login with new password works
+    const loginRes = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { username, password: 'newpass123' },
+    });
+    expect(loginRes.ok()).toBe(true);
+
+    // Old password should no longer work
+    const oldLoginRes = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { username, password: 'testpass123' },
+    });
+    expect(oldLoginRes.ok()).toBe(false);
+
+    // Cleanup
+    await apiDeleteUser(request, token, userId);
+  });
+
+  test('reset password button is hidden for OIDC users', async ({ page, request }) => {
+    // Create a local user and verify button exists
+    const token = await apiLogin(request);
+    const localUser = uniqueName('local');
+    const localId = await apiCreateUser(request, token, localUser);
+
+    await page.reload();
+    await expect(page.getByRole('cell', { name: localUser, exact: true })).toBeVisible({ timeout: 10_000 });
+
+    // Local user should have the reset button
+    await expect(page.getByRole('button', { name: `Reset password for ${localUser}` })).toBeVisible();
+
+    // The admin user (also local) should have the reset button
+    await expect(page.getByRole('button', { name: /reset password for admin/i })).toBeVisible();
+
+    // Cleanup
+    await apiDeleteUser(request, token, localId);
+  });
+
+  test('cancel password reset closes dialog without changes', async ({ page, request }) => {
+    const token = await apiLogin(request);
+    const username = uniqueName('pw-cancel');
+    const userId = await apiCreateUser(request, token, username);
+
+    await page.reload();
+    await expect(page.getByRole('cell', { name: username, exact: true })).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole('button', { name: `Reset password for ${username}` }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('heading', { name: 'Reset Password' })).toBeVisible();
+    await dialog.getByLabel('New Password').fill('shouldnotapply');
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(dialog).not.toBeVisible({ timeout: 10_000 });
+
+    // Original password should still work
+    const loginRes = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { username, password: 'testpass123' },
+    });
+    expect(loginRes.ok()).toBe(true);
+
+    // Cleanup
+    await apiDeleteUser(request, token, userId);
+  });
+
   test('non-admin users cannot access user management', async ({ page, request }) => {
     // Create a regular user
     const token = await apiLogin(request);

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -5,11 +5,16 @@ import { loginAsAdmin, uniqueName, API_BASE, ADMIN_PASSWORD } from './helpers';
  * Helper: login via API and return the JWT token.
  */
 async function apiLogin(request: import('@playwright/test').APIRequestContext): Promise<string> {
-  const res = await request.post(`${API_BASE}/api/v1/auth/login`, {
-    data: { username: 'admin', password: ADMIN_PASSWORD },
-  });
-  expect(res.ok()).toBe(true);
-  const body = await res.json();
+  let res;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    res = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { username: 'admin', password: ADMIN_PASSWORD },
+    });
+    if (res.status() !== 429) break;
+    await new Promise((r) => setTimeout(r, 2000 * (attempt + 1)));
+  }
+  expect(res!.ok(), `Login API failed with status ${res!.status()}`).toBe(true);
+  const body = await res!.json();
   return body.token;
 }
 

--- a/frontend/e2e/admin-users.spec.ts
+++ b/frontend/e2e/admin-users.spec.ts
@@ -213,7 +213,7 @@ test.describe('Admin User Management', () => {
     await apiDeleteUser(request, token, userId);
   });
 
-  test('reset password button is hidden for OIDC users', async ({ page, request }) => {
+  test('reset password button is visible for local users', async ({ page, request }) => {
     // Create a local user and verify button exists
     const token = await apiLogin(request);
     const localUser = uniqueName('local');

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1369,6 +1369,9 @@ export const userService = {
       throw error;
     }
   },
+  resetPassword: async (id: string, password: string): Promise<void> => {
+    await api.put(`/api/v1/users/${id}/password`, { password });
+  },
 };
 
 /** API key management service for per-user key CRUD. Maps to `/api/v1/users/:id/api-keys`. */

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1369,8 +1369,19 @@ export const userService = {
       throw error;
     }
   },
+  /**
+   * Reset a local user's password. Admin only. Revokes all active sessions.
+   * @param id - User ID
+   * @param password - New password (minimum 8 characters)
+   * @see PUT /api/v1/users/:id/password
+   */
   resetPassword: async (id: string, password: string): Promise<void> => {
-    await api.put(`/api/v1/users/${id}/password`, { password });
+    try {
+      await api.put(`/api/v1/users/${id}/password`, { password });
+    } catch (error) {
+      console.error('Failed to reset user password:', error);
+      throw error;
+    }
   },
 };
 

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -48,6 +48,9 @@ function userFromPayload(payload: JwtPayload): User {
     username: payload.username,
     display_name: payload.username,
     role: payload.role,
+    auth_provider: payload.auth_provider ?? 'local',
+    disabled: false,
+    service_account: false,
     created_at: '',
     updated_at: '',
   };

--- a/frontend/src/context/__tests__/AuthContext.test.tsx
+++ b/frontend/src/context/__tests__/AuthContext.test.tsx
@@ -122,6 +122,9 @@ describe('AuthContext', () => {
         username: 'alice',
         display_name: 'alice',
         role: 'devops',
+        auth_provider: 'local',
+        disabled: false,
+        service_account: false,
         created_at: '',
         updated_at: '',
       });

--- a/frontend/src/pages/Admin/Users/__tests__/AdminUsers.test.tsx
+++ b/frontend/src/pages/Admin/Users/__tests__/AdminUsers.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import AdminUsers from '../index';
 
@@ -8,6 +9,7 @@ vi.mock('../../../../api/client', () => ({
     list: vi.fn(),
     create: vi.fn(),
     delete: vi.fn(),
+    resetPassword: vi.fn(),
   },
   apiKeyService: {
     list: vi.fn(),
@@ -28,6 +30,9 @@ const adminUser = {
   username: 'admin',
   role: 'admin',
   display_name: 'Admin User',
+  auth_provider: 'local',
+  disabled: false,
+  service_account: false,
   created_at: '2026-01-01T00:00:00Z',
   updated_at: '2026-01-01T00:00:00Z',
 };
@@ -39,8 +44,22 @@ const mockUsers = [
     username: 'alice',
     role: 'devops',
     display_name: 'Alice',
+    auth_provider: 'local',
+    disabled: false,
+    service_account: false,
     created_at: '2026-02-01T00:00:00Z',
     updated_at: '2026-02-01T00:00:00Z',
+  },
+  {
+    id: '3',
+    username: 'oidc-bob',
+    role: 'user',
+    display_name: 'Bob (OIDC)',
+    auth_provider: 'oidc',
+    disabled: false,
+    service_account: false,
+    created_at: '2026-03-01T00:00:00Z',
+    updated_at: '2026-03-01T00:00:00Z',
   },
 ];
 
@@ -170,6 +189,135 @@ describe('AdminUsers Page', () => {
       const chips = screen.getAllByText('admin');
       expect(chips.length).toBeGreaterThan(0);
       expect(screen.getByText('devops')).toBeInTheDocument();
+    });
+  });
+
+  describe('Password Reset', () => {
+    it('shows reset password button for local users only', async () => {
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      expect(screen.getByRole('button', { name: /reset password for admin/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /reset password for alice/i })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /reset password for oidc-bob/i })).not.toBeInTheDocument();
+    });
+
+    it('opens password reset dialog when button is clicked', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      expect(screen.getByRole('heading', { name: 'Reset Password' })).toBeInTheDocument();
+      expect(screen.getByText(/set a new password for/i)).toBeInTheDocument();
+    });
+
+    it('disables submit when password is too short', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      const submitBtn = screen.getByRole('button', { name: /reset password$/i });
+      expect(submitBtn).toBeDisabled();
+      await user.type(screen.getByLabelText(/new password/i), 'short');
+      expect(submitBtn).toBeDisabled();
+    });
+
+    it('enables submit when password meets minimum length', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      await user.type(screen.getByLabelText(/new password/i), 'longenough');
+      expect(screen.getByRole('button', { name: /reset password$/i })).toBeEnabled();
+    });
+
+    it('calls resetPassword API and closes dialog on success', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      (userService.resetPassword as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      await user.type(screen.getByLabelText(/new password/i), 'newsecurepass');
+      await user.click(screen.getByRole('button', { name: /reset password$/i }));
+      await waitFor(() => {
+        expect(userService.resetPassword).toHaveBeenCalledWith('2', 'newsecurepass');
+      });
+      await waitFor(() => {
+        expect(screen.queryByText('Reset Password')).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows error when API call fails', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      (userService.resetPassword as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('fail'));
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      await user.type(screen.getByLabelText(/new password/i), 'newsecurepass');
+      await user.click(screen.getByRole('button', { name: /reset password$/i }));
+      await waitFor(() => {
+        expect(screen.getByText(/failed to reset password/i)).toBeInTheDocument();
+      });
+    });
+
+    it('closes dialog when cancel is clicked', async () => {
+      const user = userEvent.setup();
+      (userService.list as ReturnType<typeof vi.fn>).mockResolvedValue(mockUsers);
+      render(
+        <MemoryRouter>
+          <AdminUsers />
+        </MemoryRouter>
+      );
+      await waitFor(() => {
+        expect(screen.getByText('alice')).toBeInTheDocument();
+      });
+      await user.click(screen.getByRole('button', { name: /reset password for alice/i }));
+      expect(screen.getByRole('heading', { name: 'Reset Password' })).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      await waitFor(() => {
+        expect(screen.queryByRole('heading', { name: 'Reset Password' })).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -33,6 +33,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import CheckIcon from '@mui/icons-material/Check';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
+import LockResetIcon from '@mui/icons-material/LockReset';
 import { userService, apiKeyService } from '../../../api/client';
 import { useAuth } from '../../../context/AuthContext';
 import type { User, APIKey, CreateUserRequest, CreateAPIKeyRequest, CreateAPIKeyResponse } from '../../../types';
@@ -83,6 +84,12 @@ const AdminUsers = () => {
   const [rawKeyData, setRawKeyData] = useState<CreateAPIKeyResponse | null>(null);
   const [keyCopied, setKeyCopied] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Password reset dialog
+  const [resetPasswordTarget, setResetPasswordTarget] = useState<User | null>(null);
+  const [resetPasswordValue, setResetPasswordValue] = useState('');
+  const [resetPasswordError, setResetPasswordError] = useState<string | null>(null);
+  const [resetPasswordLoading, setResetPasswordLoading] = useState(false);
 
   // Revoke API key confirm
   const [revokeKeyTarget, setRevokeKeyTarget] = useState<{ userId: string; key: APIKey } | null>(null);
@@ -172,6 +179,24 @@ const AdminUsers = () => {
     } catch {
       setError('Failed to delete user');
       setDeleteUserTarget(null);
+    }
+  };
+
+  const handleResetPassword = async () => {
+    if (!resetPasswordTarget || resetPasswordValue.length < 8) {
+      setResetPasswordError('Password must be at least 8 characters');
+      return;
+    }
+    setResetPasswordLoading(true);
+    setResetPasswordError(null);
+    try {
+      await userService.resetPassword(resetPasswordTarget.id, resetPasswordValue);
+      setResetPasswordTarget(null);
+      setResetPasswordValue('');
+    } catch {
+      setResetPasswordError('Failed to reset password');
+    } finally {
+      setResetPasswordLoading(false);
     }
   };
 
@@ -294,6 +319,21 @@ const AdminUsers = () => {
                       </TableCell>
                       <TableCell sx={{ display: { xs: 'none', md: 'table-cell' } }}>{new Date(u.created_at).toLocaleDateString()}</TableCell>
                       <TableCell>
+                        {(!u.auth_provider || u.auth_provider === 'local') && (
+                          <Tooltip title="Reset password">
+                            <IconButton
+                              size="small"
+                              onClick={() => {
+                                setResetPasswordTarget(u);
+                                setResetPasswordValue('');
+                                setResetPasswordError(null);
+                              }}
+                              aria-label={`Reset password for ${u.username}`}
+                            >
+                              <LockResetIcon fontSize="small" />
+                            </IconButton>
+                          </Tooltip>
+                        )}
                         <Tooltip title={u.id === currentUser.id ? 'Cannot delete your own account' : 'Delete user'}>
                           <span>
                             <IconButton
@@ -558,6 +598,46 @@ const AdminUsers = () => {
             }}
           >
             Done
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* ── Reset Password Dialog ────────────────────────────────── */}
+      <Dialog
+        open={Boolean(resetPasswordTarget)}
+        onClose={() => setResetPasswordTarget(null)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Reset Password</DialogTitle>
+        <DialogContent>
+          {resetPasswordError && <Alert severity="error" sx={{ mb: 2, mt: 1 }}>{resetPasswordError}</Alert>}
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2, mt: 1 }}>
+            Set a new password for <strong>{resetPasswordTarget?.username}</strong>.
+            Existing sessions will be revoked.
+          </Typography>
+          <TextField
+            label="New Password"
+            type="password"
+            value={resetPasswordValue}
+            onChange={(e) => setResetPasswordValue(e.target.value)}
+            required
+            fullWidth
+            size="small"
+            autoFocus
+            helperText="Minimum 8 characters"
+            error={resetPasswordValue.length > 0 && resetPasswordValue.length < 8}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setResetPasswordTarget(null)}>Cancel</Button>
+          <Button
+            variant="contained"
+            color="warning"
+            onClick={handleResetPassword}
+            disabled={resetPasswordLoading || resetPasswordValue.length < 8}
+          >
+            {resetPasswordLoading ? <CircularProgress size={20} /> : 'Reset Password'}
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -624,7 +624,6 @@ const AdminUsers = () => {
             required
             fullWidth
             size="small"
-            autoFocus
             helperText="Minimum 8 characters"
             error={resetPasswordValue.length > 0 && resetPasswordValue.length < 8}
           />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,6 +3,9 @@ export interface User {
   username: string;
   display_name: string;
   role: string;
+  auth_provider: string;
+  disabled: boolean;
+  service_account: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
- Add PUT /api/v1/users/:id/password endpoint (admin-only) to reset passwords for local/service account users
- Rejects OIDC-linked accounts with 400, validates minimum 8 characters, revokes refresh tokens after reset
- Admin UI: password reset button (LockResetIcon) shown only for local users, with dialog and validation
- Add auth_provider, disabled, service_account fields to frontend User type

Closes #220

## Test plan
- [x] Backend: 7 table-driven tests (success, OIDC guard, short password, missing field, 403, 404, empty auth_provider)
- [x] Frontend: 7 tests (button visibility for local vs OIDC users, dialog open/close/cancel, validation, API success/failure)
- [x] go test ./internal/api/handlers/ passes
- [x] npx vitest run — 952/952 tests pass
- [ ] Manual: log in as admin, reset a local user password, verify login with new password works
- [ ] Manual: verify OIDC user rows do not show the reset button

Generated with [Claude Code](https://claude.com/claude-code)