### PR TITLE
feat: require API key expiration, default 90 days

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -943,10 +943,129 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "CLI auth success page (HTML)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "302": {
                         "description": "Redirect to login with error",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    "410": {
+                        "description": "CLI session expired (HTML)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error (HTML, CLI flow only)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/oidc/cli-auth": {
+            "post": {
+                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Start CLI SSO authentication flow",
+                "responses": {
+                    "200": {
+                        "description": "session_id, login_url, expires_in",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/oidc/cli-token": {
+            "post": {
+                "description": "Returns the current status of a CLI auth session. Returns pending while waiting for the user to complete browser authentication, or completed with a JWT token once done.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Poll CLI SSO authentication status",
+                "parameters": [
+                    {
+                        "description": "CLI token poll request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CLITokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "status, token (when completed), username, user_id",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "session expired or not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -6975,7 +7094,7 @@ const docTemplate = `{
                         "BearerAuth": []
                     }
                 ],
-                "description": "Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.",
+                "description": "Generates a new API key. An expiration is required: set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, the expiry must not exceed the limit. The raw key is returned once in raw_key and cannot be retrieved again.",
                 "consumes": [
                     "application/json"
                 ],
@@ -7196,6 +7315,15 @@ const docTemplate = `{
                                 "type": "string"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }
@@ -7266,6 +7394,109 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Resets the password for a local/service account user. Admin only.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Reset user password",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ResetPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7528,6 +7759,17 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "template_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CLITokenRequest": {
+            "type": "object",
+            "required": [
+                "session_id"
+            ],
+            "properties": {
+                "session_id": {
                     "type": "string"
                 }
             }
@@ -8124,7 +8366,21 @@ const docTemplate = `{
                 "role": {
                     "type": "string"
                 },
+                "service_account": {
+                    "type": "boolean"
+                },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ResetPasswordRequest": {
+            "type": "object",
+            "required": [
+                "password"
+            ],
+            "properties": {
+                "password": {
                     "type": "string"
                 }
             }
@@ -9589,6 +9845,9 @@ const docTemplate = `{
                 },
                 "role": {
                     "type": "string"
+                },
+                "service_account": {
+                    "type": "boolean"
                 },
                 "updated_at": {
                     "type": "string"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -7165,6 +7165,15 @@ const docTemplate = `{
                                 "type": "string"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -7163,6 +7163,15 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -941,10 +941,129 @@
                     }
                 ],
                 "responses": {
+                    "200": {
+                        "description": "CLI auth success page (HTML)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "302": {
                         "description": "Redirect to login with error",
                         "schema": {
                             "type": "string"
+                        }
+                    },
+                    "410": {
+                        "description": "CLI session expired (HTML)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal error (HTML, CLI flow only)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/oidc/cli-auth": {
+            "post": {
+                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Start CLI SSO authentication flow",
+                "responses": {
+                    "200": {
+                        "description": "session_id, login_url, expires_in",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/auth/oidc/cli-token": {
+            "post": {
+                "description": "Returns the current status of a CLI auth session. Returns pending while waiting for the user to complete browser authentication, or completed with a JWT token once done.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "auth"
+                ],
+                "summary": "Poll CLI SSO authentication status",
+                "parameters": [
+                    {
+                        "description": "CLI token poll request",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CLITokenRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "status, token (when completed), username, user_id",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "410": {
+                        "description": "session expired or not found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     }
                 }
@@ -6973,7 +7092,7 @@
                         "BearerAuth": []
                     }
                 ],
-                "description": "Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.",
+                "description": "Generates a new API key. An expiration is required: set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, the expiry must not exceed the limit. The raw key is returned once in raw_key and cannot be retrieved again.",
                 "consumes": [
                     "application/json"
                 ],
@@ -7194,6 +7313,15 @@
                                 "type": "string"
                             }
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }
@@ -7264,6 +7392,109 @@
                     },
                     "404": {
                         "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/users/{id}/password": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Resets the password for a local/service account user. Admin only.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Reset user password",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "New password",
+                        "name": "request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.ResetPasswordRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
@@ -7526,6 +7757,17 @@
                     "type": "string"
                 },
                 "template_name": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.CLITokenRequest": {
+            "type": "object",
+            "required": [
+                "session_id"
+            ],
+            "properties": {
+                "session_id": {
                     "type": "string"
                 }
             }
@@ -8122,7 +8364,21 @@
                 "role": {
                     "type": "string"
                 },
+                "service_account": {
+                    "type": "boolean"
+                },
                 "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.ResetPasswordRequest": {
+            "type": "object",
+            "required": [
+                "password"
+            ],
+            "properties": {
+                "password": {
                     "type": "string"
                 }
             }
@@ -9587,6 +9843,9 @@
                 },
                 "role": {
                     "type": "string"
+                },
+                "service_account": {
+                    "type": "boolean"
                 },
                 "updated_at": {
                     "type": "string"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -83,6 +83,13 @@ definitions:
       template_name:
         type: string
     type: object
+  handlers.CLITokenRequest:
+    properties:
+      session_id:
+        type: string
+    required:
+    - session_id
+    type: object
   handlers.ChartConfigExportData:
     properties:
       build_pipeline_id:
@@ -467,11 +474,20 @@ definitions:
         type: string
       role:
         type: string
+      service_account:
+        type: boolean
       username:
         type: string
     required:
     - password
     - username
+    type: object
+  handlers.ResetPasswordRequest:
+    properties:
+      password:
+        type: string
+    required:
+    - password
     type: object
   handlers.TemplateDetailResponse:
     properties:
@@ -1443,6 +1459,8 @@ definitions:
         type: string
       role:
         type: string
+      service_account:
+        type: boolean
       updated_at:
         type: string
       username:
@@ -2110,11 +2128,94 @@ paths:
       produces:
       - text/html
       responses:
+        "200":
+          description: CLI auth success page (HTML)
+          schema:
+            type: string
         "302":
           description: Redirect to login with error
           schema:
             type: string
+        "410":
+          description: CLI session expired (HTML)
+          schema:
+            type: string
+        "500":
+          description: Internal error (HTML, CLI flow only)
+          schema:
+            type: string
       summary: OIDC callback
+      tags:
+      - auth
+  /api/v1/auth/oidc/cli-auth:
+    post:
+      description: Generates a session ID and OIDC authorization URL for CLI-based
+        SSO login. The CLI opens the returned login_url in a browser and polls cli-token
+        until authentication completes.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: session_id, login_url, expires_in
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Start CLI SSO authentication flow
+      tags:
+      - auth
+  /api/v1/auth/oidc/cli-token:
+    post:
+      consumes:
+      - application/json
+      description: Returns the current status of a CLI auth session. Returns pending
+        while waiting for the user to complete browser authentication, or completed
+        with a JWT token once done.
+      parameters:
+      - description: CLI token poll request
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.CLITokenRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: status, token (when completed), username, user_id
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "410":
+          description: session expired or not found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Poll CLI SSO authentication status
       tags:
       - auth
   /api/v1/auth/oidc/config:
@@ -6110,10 +6211,10 @@ paths:
     post:
       consumes:
       - application/json
-      description: Generates a new API key. Optionally set expires_at (YYYY-MM-DD
-        or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS
-        is configured, keys without explicit expiry are auto-capped. The raw key is
-        returned once in raw_key and cannot be retrieved again.
+      description: 'Generates a new API key. An expiration is required: set expires_at
+        (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If
+        API_KEY_MAX_LIFETIME_DAYS is configured, the expiry must not exceed the limit.
+        The raw key is returned once in raw_key and cannot be retrieved again.'
       parameters:
       - description: User ID
         in: path
@@ -6255,6 +6356,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       security:
       - BearerAuth: []
       summary: Disable a user
@@ -6304,9 +6411,76 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       security:
       - BearerAuth: []
       summary: Enable a user
+      tags:
+      - users
+  /api/v1/users/{id}/password:
+    put:
+      consumes:
+      - application/json
+      description: Resets the password for a local/service account user. Admin only.
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: New password
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.ResetPasswordRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "403":
+          description: Forbidden
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Reset user password
       tags:
       - users
   /health:

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -6258,6 +6258,12 @@ paths:
             additionalProperties:
               type: string
             type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
       security:
       - BearerAuth: []
       summary: Create an API key for a user

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -65,6 +65,7 @@ type CreateAPIKeyResponse struct {
 // @Failure      401  {object}  map[string]string
 // @Failure      403  {object}  map[string]string
 // @Failure      404  {object}  map[string]string
+// @Failure      500  {object}  map[string]string
 // @Router       /api/v1/users/{id}/api-keys [post]
 func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 	userID := c.Param("id")

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -53,7 +53,7 @@ type CreateAPIKeyResponse struct {
 
 // CreateAPIKey godoc
 // @Summary      Create an API key for a user
-// @Description  Generates a new API key. An expiration is required: set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, the expiry is capped. The raw key is returned once in raw_key and cannot be retrieved again.
+// @Description  Generates a new API key. An expiration is required: set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, the expiry must not exceed the limit. The raw key is returned once in raw_key and cannot be retrieved again.
 // @Tags         api-keys
 // @Accept       json
 // @Produce      json

--- a/backend/internal/api/handlers/api_keys.go
+++ b/backend/internal/api/handlers/api_keys.go
@@ -53,7 +53,7 @@ type CreateAPIKeyResponse struct {
 
 // CreateAPIKey godoc
 // @Summary      Create an API key for a user
-// @Description  Generates a new API key. Optionally set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, keys without explicit expiry are auto-capped. The raw key is returned once in raw_key and cannot be retrieved again.
+// @Description  Generates a new API key. An expiration is required: set expires_at (YYYY-MM-DD or RFC3339) or expires_in_days (positive int), but not both. If API_KEY_MAX_LIFETIME_DAYS is configured, the expiry is capped. The raw key is returned once in raw_key and cannot be retrieved again.
 // @Tags         api-keys
 // @Accept       json
 // @Produce      json
@@ -132,19 +132,18 @@ func (h *APIKeyHandler) CreateAPIKey(c *gin.Context) {
 		return
 	}
 
+	if expiresAt == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Expiration is required; set expires_at or expires_in_days"})
+		return
+	}
+
 	// Enforce max lifetime policy.
 	if h.apiKeyMaxLifetimeDays > 0 {
-		// Compute maxExpiry as end-of-day so date-only boundary values aren't rejected.
 		maxDate := now.AddDate(0, 0, h.apiKeyMaxLifetimeDays)
 		maxExpiry := time.Date(maxDate.Year(), maxDate.Month(), maxDate.Day(), 23, 59, 59, 999999999, time.UTC)
-		if expiresAt != nil {
-			if expiresAt.After(maxExpiry) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Expiry exceeds maximum allowed lifetime of %d days", h.apiKeyMaxLifetimeDays)})
-				return
-			}
-		} else {
-			// Auto-cap: no expiry requested but max lifetime is configured.
-			expiresAt = &maxExpiry
+		if expiresAt.After(maxExpiry) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Expiry exceeds maximum allowed lifetime of %d days", h.apiKeyMaxLifetimeDays)})
+			return
 		}
 	}
 

--- a/backend/internal/api/handlers/api_keys_test.go
+++ b/backend/internal/api/handlers/api_keys_test.go
@@ -88,7 +88,7 @@ func TestCreateAPIKey(t *testing.T) {
 			callerID:     "user-1",
 			callerRole:   "user",
 			targetUserID: "user-1",
-			body:         `{"name":"ci-token"}`,
+			body:         `{"name":"ci-token","expires_in_days":90}`,
 			setupRepos: func(u *MockUserRepository, a *MockAPIKeyRepository) {
 				seedUser(t, u, "user-1", "alice", "testpass", "user")
 			},
@@ -100,7 +100,7 @@ func TestCreateAPIKey(t *testing.T) {
 			callerID:     "admin-1",
 			callerRole:   "admin",
 			targetUserID: "user-2",
-			body:         `{"name":"deploy-key"}`,
+			body:         `{"name":"deploy-key","expires_in_days":90}`,
 			setupRepos: func(u *MockUserRepository, a *MockAPIKeyRepository) {
 				seedUser(t, u, "user-2", "bob", "testpass", "user")
 			},
@@ -141,7 +141,7 @@ func TestCreateAPIKey(t *testing.T) {
 			callerID:     "admin-1",
 			callerRole:   "admin",
 			targetUserID: "user-1",
-			body:         `{"name":"my-key"}`,
+			body:         `{"name":"my-key","expires_in_days":90}`,
 			setupRepos: func(u *MockUserRepository, a *MockAPIKeyRepository) {
 				seedUser(t, u, "user-1", "alice", "testpass", "user")
 				a.SetCreateError(errors.New("db failure"))
@@ -394,11 +394,10 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 			wantErrSubstr: "maximum allowed lifetime of 365 days",
 		},
 		{
-			name:           "no expiry with max 365 - auto-capped",
-			maxDays:        365,
-			body:           `{"name":"ci-key"}`,
-			wantStatus:     http.StatusCreated,
-			wantExpiryDays: 365,
+			name:       "no expiry with max 365 - rejected",
+			maxDays:    365,
+			body:       `{"name":"ci-key"}`,
+			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:       "expires_at within max - success",
@@ -414,10 +413,10 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 			wantErrSubstr: "maximum allowed lifetime of 365 days",
 		},
 		{
-			name:       "no expiry with max 0 (no limit) - no expiry set",
+			name:       "no expiry without max limit - rejected",
 			maxDays:    0,
 			body:       `{"name":"ci-key"}`,
-			wantStatus: http.StatusCreated,
+			wantStatus: http.StatusBadRequest,
 		},
 		{
 			name:           "expires_in_days exactly at max - success",
@@ -491,10 +490,6 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 					assert.InDelta(t, 0, diff.Seconds(), 86460, "expires_at should be ~%d days from now", tt.wantExpiryDays)
 				}
 
-				if tt.name == "no expiry with max 0 (no limit) - no expiry set" {
-					_, hasExpiry := resp["expires_at"]
-					assert.False(t, hasExpiry, "expires_at should not be set when no limit and no expiry requested")
-				}
 			}
 		})
 	}

--- a/backend/internal/api/handlers/api_keys_test.go
+++ b/backend/internal/api/handlers/api_keys_test.go
@@ -486,8 +486,8 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 					require.NoError(t, err)
 					now := time.Now().UTC()
 					expectedDate := now.AddDate(0, 0, tt.wantExpiryDays)
-					// Auto-cap uses end-of-day; expires_in_days uses exact offset.
-					// Allow up to 24h + 60s tolerance to cover both cases.
+					// expires_in_days uses exact offset; date-only expires_at uses end-of-day.
+					// Allow up to 24h + 60s tolerance to cover both formats.
 					diff := parsed.Sub(expectedDate)
 					assert.InDelta(t, 0, diff.Seconds(), 86460, "expires_at should be ~%d days from now", tt.wantExpiryDays)
 				}

--- a/backend/internal/api/handlers/api_keys_test.go
+++ b/backend/internal/api/handlers/api_keys_test.go
@@ -394,10 +394,11 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 			wantErrSubstr: "maximum allowed lifetime of 365 days",
 		},
 		{
-			name:       "no expiry with max 365 - rejected",
-			maxDays:    365,
-			body:       `{"name":"ci-key"}`,
-			wantStatus: http.StatusBadRequest,
+			name:          "no expiry with max 365 - rejected",
+			maxDays:       365,
+			body:          `{"name":"ci-key"}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "Expiration is required",
 		},
 		{
 			name:       "expires_at within max - success",
@@ -413,10 +414,11 @@ func TestCreateAPIKeyExpiration(t *testing.T) {
 			wantErrSubstr: "maximum allowed lifetime of 365 days",
 		},
 		{
-			name:       "no expiry without max limit - rejected",
-			maxDays:    0,
-			body:       `{"name":"ci-key"}`,
-			wantStatus: http.StatusBadRequest,
+			name:          "no expiry without max limit - rejected",
+			maxDays:       0,
+			body:          `{"name":"ci-key"}`,
+			wantStatus:    http.StatusBadRequest,
+			wantErrSubstr: "Expiration is required",
 		},
 		{
 			name:           "expires_in_days exactly at max - success",

--- a/frontend/e2e/profile.spec.ts
+++ b/frontend/e2e/profile.spec.ts
@@ -103,7 +103,7 @@ test.describe('Profile Page', () => {
     // Key should appear with an expiry date (not "Never")
     const row = page.getByRole('row').filter({ hasText: keyName });
     await expect(row).toBeVisible({ timeout: 10_000 });
-    await expect(row.getByText('Never')).not.toBeVisible().catch(() => {});
+    await expect(row.locator('text=Never')).toHaveCount(0);
 
     // Cleanup
     const token = await page.evaluate(() => localStorage.getItem('token'));

--- a/frontend/e2e/profile.spec.ts
+++ b/frontend/e2e/profile.spec.ts
@@ -138,7 +138,7 @@ test.describe('Profile Page', () => {
 
     await page.request.post(`${API_BASE}/api/v1/users/${me.id}/api-keys`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { name: keyName },
+      data: { name: keyName, expires_in_days: 90 },
     });
 
     // Reload to see the key
@@ -174,7 +174,7 @@ test.describe('Profile Page', () => {
 
     await page.request.post(`${API_BASE}/api/v1/users/${me.id}/api-keys`, {
       headers: { Authorization: `Bearer ${token}` },
-      data: { name: keyName },
+      data: { name: keyName, expires_in_days: 90 },
     });
 
     // Reload to see the key

--- a/frontend/e2e/profile.spec.ts
+++ b/frontend/e2e/profile.spec.ts
@@ -79,10 +79,7 @@ test.describe('Profile Page', () => {
     await expect(dialog.getByText(/expires:/i)).toBeVisible();
 
     // "No expiry" radio should not exist
-    await expect(dialog.getByText('No expiry')).not.toBeVisible().catch(() => {
-      // Element doesn't exist at all — expected
-    });
-    expect(await dialog.locator('text=No expiry').count()).toBe(0);
+    await expect(dialog.locator('text=No expiry')).toHaveCount(0);
 
     // Close without creating
     await dialog.getByRole('button', { name: 'Cancel' }).click();

--- a/frontend/e2e/profile.spec.ts
+++ b/frontend/e2e/profile.spec.ts
@@ -66,6 +66,66 @@ test.describe('Profile Page', () => {
     }
   });
 
+  test('API key dialog defaults to preset 90-day expiry and has no no-expiry option', async ({ page }) => {
+    await page.getByRole('button', { name: 'Generate API Key' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Generate API Key')).toBeVisible();
+
+    // "Preset duration" should be selected by default
+    await expect(dialog.getByLabelText('Preset duration')).toBeChecked();
+
+    // Expiry date preview should be visible
+    await expect(dialog.getByText(/expires:/i)).toBeVisible();
+
+    // "No expiry" radio should not exist
+    await expect(dialog.getByText('No expiry')).not.toBeVisible().catch(() => {
+      // Element doesn't exist at all — expected
+    });
+    expect(await dialog.locator('text=No expiry').count()).toBe(0);
+
+    // Close without creating
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+  });
+
+  test('created API key shows expiry date in table', async ({ page }) => {
+    const keyName = uniqueName('e2e-expiry');
+
+    await page.getByRole('button', { name: 'Generate API Key' }).click();
+    const dialog = page.getByRole('dialog');
+    await dialog.getByLabel('Key Name').fill(keyName);
+
+    // Default is 90-day preset — just submit
+    await dialog.getByRole('button', { name: 'Generate' }).click();
+
+    await expect(page.getByText('This key will not be shown again. Copy it now.')).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.getByRole('button', { name: 'Done' }).click();
+
+    // Key should appear with an expiry date (not "Never")
+    const row = page.getByRole('row').filter({ hasText: keyName });
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await expect(row.getByText('Never')).not.toBeVisible().catch(() => {});
+
+    // Cleanup
+    const token = await page.evaluate(() => localStorage.getItem('token'));
+    const meResp = await page.request.get(`${API_BASE}/api/v1/auth/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const me = await meResp.json();
+    const keysResp = await page.request.get(`${API_BASE}/api/v1/users/${me.id}/api-keys`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const keys = await keysResp.json();
+    const created = keys.find((k: { name: string }) => k.name === keyName);
+    if (created) {
+      await page.request.delete(`${API_BASE}/api/v1/users/${me.id}/api-keys/${created.id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+    }
+  });
+
   test('API key prefix is masked in table', async ({ page }) => {
     const keyName = uniqueName('e2e-masked');
 

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -40,14 +40,7 @@ import type { User, APIKey, CreateUserRequest, CreateAPIKeyRequest, CreateAPIKey
 import LoadingState from '../../../components/LoadingState';
 import { Link } from 'react-router-dom';
 
-const defaultExpiryDate = () => {
-  const d = new Date();
-  d.setDate(d.getDate() + 90);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${year}-${month}-${day}`;
-};
+const defaultKeyForm = (): CreateAPIKeyRequest => ({ name: '', expires_in_days: 90 });
 
 const getRoleChipColor = (role: string): 'error' | 'warning' | 'default' => {
   if (role === 'admin') return 'error';
@@ -85,7 +78,7 @@ const AdminUsers = () => {
 
   // Generate API key dialog
   const [generateKeyUserId, setGenerateKeyUserId] = useState<string | null>(null);
-  const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>({ name: '', expires_at: defaultExpiryDate() });
+  const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>(defaultKeyForm());
   const [generateKeyError, setGenerateKeyError] = useState<string | null>(null);
   const [generateKeyLoading, setGenerateKeyLoading] = useState(false);
 
@@ -220,7 +213,7 @@ const AdminUsers = () => {
     try {
       const result = await apiKeyService.create(targetUserId, generateKeyForm);
       setGenerateKeyUserId(null);
-      setGenerateKeyForm({ name: '', expires_at: defaultExpiryDate() });
+      setGenerateKeyForm(defaultKeyForm());
       setRawKeyData(result);
       await loadApiKeys(targetUserId);
     } catch {
@@ -373,7 +366,7 @@ const AdminUsers = () => {
                                 startIcon={<KeyIcon />}
                                 onClick={() => {
                                   setGenerateKeyUserId(u.id);
-                                  setGenerateKeyForm({ name: '', expires_at: defaultExpiryDate() });
+                                  setGenerateKeyForm(defaultKeyForm());
                                   setGenerateKeyError(null);
                                 }}
                               >
@@ -545,17 +538,18 @@ const AdminUsers = () => {
               autoFocus
             />
             <TextField
-              label="Expires At"
-              type="date"
-              value={generateKeyForm.expires_at ?? ''}
-              onChange={(e) =>
-                setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || defaultExpiryDate() }))
-              }
+              label="Expires In (days)"
+              type="number"
+              value={generateKeyForm.expires_in_days ?? 90}
+              onChange={(e) => {
+                const days = Math.max(1, parseInt(e.target.value, 10) || 1);
+                setGenerateKeyForm((prev) => ({ ...prev, expires_in_days: days, expires_at: undefined }));
+              }}
               required
               fullWidth
               size="small"
               helperText="Default: 90 days"
-              slotProps={{ inputLabel: { shrink: true } }}
+              slotProps={{ htmlInput: { min: 1 } }}
             />
           </Box>
         </DialogContent>

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -40,6 +40,12 @@ import type { User, APIKey, CreateUserRequest, CreateAPIKeyRequest, CreateAPIKey
 import LoadingState from '../../../components/LoadingState';
 import { Link } from 'react-router-dom';
 
+const defaultExpiryDate = () => {
+  const d = new Date();
+  d.setDate(d.getDate() + 90);
+  return d.toISOString().split('T')[0];
+};
+
 const getRoleChipColor = (role: string): 'error' | 'warning' | 'default' => {
   if (role === 'admin') return 'error';
   if (role === 'devops') return 'warning';
@@ -76,7 +82,7 @@ const AdminUsers = () => {
 
   // Generate API key dialog
   const [generateKeyUserId, setGenerateKeyUserId] = useState<string | null>(null);
-  const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>({ name: '' });
+  const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>({ name: '', expires_at: defaultExpiryDate() });
   const [generateKeyError, setGenerateKeyError] = useState<string | null>(null);
   const [generateKeyLoading, setGenerateKeyLoading] = useState(false);
 
@@ -211,7 +217,7 @@ const AdminUsers = () => {
     try {
       const result = await apiKeyService.create(targetUserId, generateKeyForm);
       setGenerateKeyUserId(null);
-      setGenerateKeyForm({ name: '' });
+      setGenerateKeyForm({ name: '', expires_at: defaultExpiryDate() });
       setRawKeyData(result);
       await loadApiKeys(targetUserId);
     } catch {
@@ -364,7 +370,7 @@ const AdminUsers = () => {
                                 startIcon={<KeyIcon />}
                                 onClick={() => {
                                   setGenerateKeyUserId(u.id);
-                                  setGenerateKeyForm({ name: '' });
+                                  setGenerateKeyForm({ name: '', expires_at: defaultExpiryDate() });
                                   setGenerateKeyError(null);
                                 }}
                               >
@@ -536,14 +542,16 @@ const AdminUsers = () => {
               autoFocus
             />
             <TextField
-              label="Expires At (optional)"
+              label="Expires At"
               type="date"
               value={generateKeyForm.expires_at ?? ''}
               onChange={(e) =>
-                setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || undefined }))
+                setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || defaultExpiryDate() }))
               }
+              required
               fullWidth
               size="small"
+              helperText="Default: 90 days"
               slotProps={{ inputLabel: { shrink: true } }}
             />
           </Box>

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -43,7 +43,10 @@ import { Link } from 'react-router-dom';
 const defaultExpiryDate = () => {
   const d = new Date();
   d.setDate(d.getDate() + 90);
-  return d.toISOString().split('T')[0];
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 };
 
 const getRoleChipColor = (role: string): 'error' | 'warning' | 'default' => {

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -542,7 +542,8 @@ const AdminUsers = () => {
               type="number"
               value={generateKeyForm.expires_in_days ?? 90}
               onChange={(e) => {
-                const days = Math.max(1, parseInt(e.target.value, 10) || 1);
+                const parsed = parseInt(e.target.value, 10);
+                const days = Number.isFinite(parsed) ? Math.max(1, parsed) : 90;
                 setGenerateKeyForm((prev) => ({ ...prev, expires_in_days: days, expires_at: undefined }));
               }}
               required

--- a/frontend/src/pages/Admin/Users/index.tsx
+++ b/frontend/src/pages/Admin/Users/index.tsx
@@ -542,8 +542,8 @@ const AdminUsers = () => {
               type="number"
               value={generateKeyForm.expires_in_days ?? 90}
               onChange={(e) => {
-                const parsed = parseInt(e.target.value, 10);
-                const days = Number.isFinite(parsed) ? Math.max(1, parsed) : 90;
+                const parsed = Math.floor(Number(e.target.value));
+                const days = Number.isFinite(parsed) && parsed >= 1 ? parsed : 90;
                 setGenerateKeyForm((prev) => ({ ...prev, expires_in_days: days, expires_at: undefined }));
               }}
               required

--- a/frontend/src/pages/Profile/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/Profile/__tests__/Profile.test.tsx
@@ -185,7 +185,7 @@ describe('Profile Page', () => {
     await user.click(screen.getByRole('button', { name: /^generate$/i }));
 
     await waitFor(() => {
-      expect(apiKeyService.create).toHaveBeenCalledWith('u1', { name: 'Test Key' });
+      expect(apiKeyService.create).toHaveBeenCalledWith('u1', { name: 'Test Key', expires_in_days: 90 });
     });
   });
 
@@ -487,13 +487,13 @@ describe('Profile Page', () => {
     });
   });
 
-  it('sends neither expires_at nor expires_in_days when no expiry is selected', async () => {
+  it('defaults to 90-day preset expiry when submitting without changing mode', async () => {
     (apiKeyService.list as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     (apiKeyService.create as ReturnType<typeof vi.fn>).mockResolvedValue({
-      id: 'k-none',
-      name: 'No Expiry Key',
-      prefix: 'sk_none11',
-      raw_key: 'sk_none11xyz',
+      id: 'k-default',
+      name: 'Default Key',
+      prefix: 'sk_def123',
+      raw_key: 'sk_def123xyz',
       created_at: '2026-03-18T00:00:00Z',
     });
 
@@ -509,13 +509,13 @@ describe('Profile Page', () => {
     });
 
     await user.click(screen.getByRole('button', { name: /generate api key/i }));
-    await user.type(screen.getByLabelText(/key name/i), 'No Expiry Key');
+    await user.type(screen.getByLabelText(/key name/i), 'Default Key');
 
-    // "No expiry" is default — just submit
+    // "Preset duration" is the default mode — just submit
     await user.click(screen.getByRole('button', { name: /^generate$/i }));
 
     await waitFor(() => {
-      expect(apiKeyService.create).toHaveBeenCalledWith('u1', { name: 'No Expiry Key' });
+      expect(apiKeyService.create).toHaveBeenCalledWith('u1', { name: 'Default Key', expires_in_days: 90 });
     });
   });
 

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -56,7 +56,7 @@ const EVENT_TYPE_LABELS: Record<string, string> = {
 
 const DEFAULT_EVENT_TYPES = Object.keys(EVENT_TYPE_LABELS);
 
-type ExpiryMode = 'none' | 'preset' | 'custom';
+type ExpiryMode = 'preset' | 'custom';
 
 const PRESET_DURATIONS = [
   { value: 30, label: '30 days' },
@@ -100,7 +100,7 @@ const Profile = () => {
   const [generateKeyForm, setGenerateKeyForm] = useState<CreateAPIKeyRequest>({ name: '' });
   const [generateKeyError, setGenerateKeyError] = useState<string | null>(null);
   const [generateKeyLoading, setGenerateKeyLoading] = useState(false);
-  const [expiryMode, setExpiryMode] = useState<ExpiryMode>('none');
+  const [expiryMode, setExpiryMode] = useState<ExpiryMode>('preset');
   const [presetDays, setPresetDays] = useState<number>(90);
 
   // Raw key modal
@@ -200,7 +200,7 @@ const Profile = () => {
       const result = await apiKeyService.create(currentUser.id, request);
       setGenerateKeyOpen(false);
       setGenerateKeyForm({ name: '' });
-      setExpiryMode('none');
+      setExpiryMode('preset');
       setPresetDays(90);
       setRawKeyData(result);
       await fetchApiKeys();
@@ -292,7 +292,7 @@ const Profile = () => {
           onClick={() => {
             setGenerateKeyOpen(true);
             setGenerateKeyForm({ name: '' });
-            setExpiryMode('none');
+            setExpiryMode('preset');
             setPresetDays(90);
             setGenerateKeyError(null);
           }}
@@ -453,7 +453,6 @@ const Profile = () => {
                 value={expiryMode}
                 onChange={(e) => setExpiryMode(e.target.value as ExpiryMode)}
               >
-                <FormControlLabel value="none" control={<Radio />} label="No expiry" />
                 <FormControlLabel value="preset" control={<Radio />} label="Preset duration" />
                 <FormControlLabel value="custom" control={<Radio />} label="Custom date" />
               </RadioGroup>

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -192,7 +192,12 @@ const Profile = () => {
     setGenerateKeyError(null);
     try {
       const request: CreateAPIKeyRequest = { name: generateKeyForm.name.trim() };
-      if (expiryMode === 'custom' && generateKeyForm.expires_at) {
+      if (expiryMode === 'custom') {
+        if (!generateKeyForm.expires_at) {
+          setGenerateKeyError('Please select an expiry date or switch to preset duration');
+          setGenerateKeyLoading(false);
+          return;
+        }
         request.expires_at = generateKeyForm.expires_at;
       } else {
         request.expires_in_days = presetDays;

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -192,12 +192,7 @@ const Profile = () => {
     setGenerateKeyError(null);
     try {
       const request: CreateAPIKeyRequest = { name: generateKeyForm.name.trim() };
-      if (expiryMode === 'custom') {
-        if (!generateKeyForm.expires_at) {
-          setGenerateKeyError('Please select an expiry date or switch to preset duration');
-          setGenerateKeyLoading(false);
-          return;
-        }
+      if (expiryMode === 'custom' && generateKeyForm.expires_at) {
         request.expires_at = generateKeyForm.expires_at;
       } else {
         request.expires_in_days = presetDays;
@@ -488,9 +483,15 @@ const Profile = () => {
                 label="Expires At"
                 type="date"
                 value={generateKeyForm.expires_at ?? ''}
-                onChange={(e) =>
-                  setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value || undefined }))
-                }
+                onChange={(e) => {
+                  if (e.target.value) {
+                    setGenerateKeyForm((prev) => ({ ...prev, expires_at: e.target.value }));
+                  } else {
+                    setGenerateKeyForm((prev) => ({ ...prev, expires_at: undefined }));
+                    setExpiryMode('preset');
+                    setPresetDays(90);
+                  }
+                }}
                 fullWidth
                 size="small"
                 slotProps={{ inputLabel: { shrink: true } }}

--- a/frontend/src/pages/Profile/index.tsx
+++ b/frontend/src/pages/Profile/index.tsx
@@ -192,10 +192,10 @@ const Profile = () => {
     setGenerateKeyError(null);
     try {
       const request: CreateAPIKeyRequest = { name: generateKeyForm.name.trim() };
-      if (expiryMode === 'preset') {
-        request.expires_in_days = presetDays;
-      } else if (expiryMode === 'custom' && generateKeyForm.expires_at) {
+      if (expiryMode === 'custom' && generateKeyForm.expires_at) {
         request.expires_at = generateKeyForm.expires_at;
+      } else {
+        request.expires_in_days = presetDays;
       }
       const result = await apiKeyService.create(currentUser.id, request);
       setGenerateKeyOpen(false);


### PR DESCRIPTION
## Summary
- Backend rejects API key creation without an expiration date (expires_at or expires_in_days required)
- Frontend defaults expiry to 90 days, label changed to required, clearing resets to default
- Remove auto-cap logic (dead code since expiry is now mandatory)

Closes #219

## Test plan
- [x] Backend: all API key tests pass (no-expiry cases now expect 400)
- [x] Frontend: 952/952 tests pass
- [ ] Manual: generate API key dialog shows 90-day default date
- [ ] Manual: clearing the date field resets to 90 days (cannot leave empty)
- [ ] Manual: API rejects POST without expiry field

Generated with [Claude Code](https://claude.com/claude-code)