### PR TITLE
docs: getting started guide with starter templates

### DIFF
--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -271,7 +271,7 @@ Any non-2xx response is treated as failure. Empty 200 bodies are interpreted as 
 
 For hooks that take a long time (e.g. triggering CI builds and waiting for completion), subscribers can stream progress lines before the final JSON response. The deployment log viewer shows these lines in real-time with the LIVE indicator.
 
-**Protocol:** Write ``LOG: <message>\n`` lines to the response body, flushing after each line. The final line must be the JSON `HookResponse`. Lines without the ``LOG: `` prefix are treated as the JSON response.
+**Protocol:** Write `LOG:` `<message>\n` lines to the response body, flushing after each line. The final line must be the JSON `HookResponse`. Lines without the `LOG:` prefix are treated as the JSON response.
 
 ```
 HTTP/1.1 200 OK

--- a/EXTENDING.md
+++ b/EXTENDING.md
@@ -271,7 +271,7 @@ Any non-2xx response is treated as failure. Empty 200 bodies are interpreted as 
 
 For hooks that take a long time (e.g. triggering CI builds and waiting for completion), subscribers can stream progress lines before the final JSON response. The deployment log viewer shows these lines in real-time with the LIVE indicator.
 
-**Protocol:** Write `LOG: <message>\n` lines to the response body, flushing after each line. The final line must be the JSON `HookResponse`. Lines without the `LOG: ` prefix are treated as the JSON response.
+**Protocol:** Write ``LOG: <message>\n`` lines to the response body, flushing after each line. The final line must be the JSON `HookResponse`. Lines without the ``LOG: `` prefix are treated as the JSON response.
 
 ```
 HTTP/1.1 200 OK

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ helm repo update
 helm install stack-manager k8s-stack-manager/k8s-stack-manager \
   --namespace stack-manager --create-namespace \
   --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
-  --set backend.secrets.ADMIN_PASSWORD="changeme" \
-  --set mysql.auth.rootPassword="changeme-db"
+  --set backend.secrets.ADMIN_PASSWORD="CHANGE-ME-set-a-secure-password" \
+  --set mysql.auth.rootPassword="CHANGE-ME-set-a-secure-password"
 ```
 
 See the full [Getting Started Guide](docs/getting-started.md) for next steps (configure stackctl, register a cluster, import [starter templates](examples/starter-templates/), and deploy your first stack).

--- a/README.md
+++ b/README.md
@@ -16,12 +16,10 @@ brew install omattsson/tap/stackctl
 helm repo add k8s-stack-manager https://omattsson.github.io/k8s-stack-manager
 helm repo update
 
-# Deploy to your cluster
+# Deploy to your cluster (see docs/getting-started.md for secrets setup)
 helm install stack-manager k8s-stack-manager/k8s-stack-manager \
   --namespace stack-manager --create-namespace \
-  --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
-  --set backend.secrets.ADMIN_PASSWORD="CHANGE-ME-set-a-secure-password" \
-  --set mysql.auth.rootPassword="CHANGE-ME-set-a-secure-password"
+  --values stack-manager-values.yaml
 ```
 
 See the full [Getting Started Guide](docs/getting-started.md) for next steps (configure stackctl, register a cluster, import [starter templates](examples/starter-templates/), and deploy your first stack).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,28 @@ A web application for configuring, storing, and managing multi-service Helm-base
 
 Developers create **stack definitions** (collections of Helm charts with configuration), launch **stack instances** (per-developer copies with branch and value overrides), and manage everything through an audit-logged UI with Git provider integration.
 
+## Getting Started
+
+Deploy to your cluster and create your first stack in under 10 minutes:
+
+```bash
+# Install the CLI
+brew install omattsson/tap/stackctl
+
+# Add the Helm repo
+helm repo add k8s-stack-manager https://omattsson.github.io/k8s-stack-manager
+helm repo update
+
+# Deploy to your cluster
+helm install stack-manager k8s-stack-manager/k8s-stack-manager \
+  --namespace stack-manager --create-namespace \
+  --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
+  --set backend.secrets.ADMIN_PASSWORD="changeme" \
+  --set mysql.auth.rootPassword="changeme-db"
+```
+
+See the full [Getting Started Guide](docs/getting-started.md) for next steps (configure stackctl, register a cluster, import [starter templates](examples/starter-templates/), and deploy your first stack).
+
 ## Features
 
 ### Dashboard — Stack Instance Management

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -20,3 +20,4 @@ tmp/
 .vscode/
 *.swp
 *.swo
+test-results/

--- a/backend/test-results/.last-run.json
+++ b/backend/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "failed",
-  "failedTests": []
-}

--- a/backend/test-results/.last-run.json
+++ b/backend/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,14 +25,26 @@ helm repo add k8s-stack-manager https://omattsson.github.io/k8s-stack-manager
 helm repo update
 ```
 
-Install with minimal configuration:
+Create a values file with your secrets (avoid passing secrets via `--set` — they leak through shell history):
+
+```bash
+cat > stack-manager-values.yaml <<EOF
+backend:
+  secrets:
+    JWT_SECRET: "$(openssl rand -base64 32)"
+    ADMIN_PASSWORD: "your-admin-password"
+mysql:
+  auth:
+    rootPassword: "your-db-password"
+EOF
+```
+
+Install:
 
 ```bash
 helm install stack-manager k8s-stack-manager/k8s-stack-manager \
   --namespace stack-manager --create-namespace \
-  --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
-  --set backend.secrets.ADMIN_PASSWORD="CHANGE-ME-set-a-secure-password" \
-  --set mysql.auth.rootPassword="CHANGE-ME-set-a-secure-password"
+  --values stack-manager-values.yaml
 ```
 
 Wait for all pods to be ready:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,192 @@
+# Getting Started
+
+Deploy K8s Stack Manager to your cluster and create your first stack in under 10 minutes.
+
+## Prerequisites
+
+- A running Kubernetes cluster with `kubectl` configured
+- [Helm 3.x](https://helm.sh/docs/intro/install/)
+- [stackctl](https://github.com/omattsson/stackctl) CLI
+
+## 1. Install stackctl
+
+```bash
+brew install omattsson/tap/stackctl
+```
+
+Or use the install script:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omattsson/stackctl/main/install.sh | sudo bash
+```
+
+## 2. Deploy K8s Stack Manager
+
+Add the Helm repository and install:
+
+```bash
+helm repo add k8s-stack-manager https://omattsson.github.io/k8s-stack-manager
+helm repo update
+```
+
+Install with minimal configuration:
+
+```bash
+helm install stack-manager k8s-stack-manager/k8s-stack-manager \
+  --namespace stack-manager --create-namespace \
+  --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
+  --set backend.secrets.ADMIN_PASSWORD="your-admin-password" \
+  --set mysql.auth.rootPassword="your-db-password"
+```
+
+Wait for all pods to be ready:
+
+```bash
+kubectl -n stack-manager rollout status deployment/stack-manager-backend
+kubectl -n stack-manager rollout status deployment/stack-manager-frontend
+```
+
+## 3. Access the UI
+
+Port-forward the frontend:
+
+```bash
+kubectl -n stack-manager port-forward svc/stack-manager-frontend 3000:80
+```
+
+Open http://localhost:3000 and log in with `admin` / the password you set above.
+
+## 4. Configure stackctl
+
+Start port-forwarding the backend API:
+
+```bash
+kubectl -n stack-manager port-forward svc/stack-manager-backend 8081:8081 &
+```
+
+Point stackctl at your deployment and authenticate:
+
+```bash
+stackctl config use-context my-cluster
+stackctl config set api-url http://localhost:8081
+stackctl login
+# Enter: admin / your-admin-password
+```
+
+Verify the connection:
+
+```bash
+stackctl whoami
+stackctl version
+```
+
+## 5. Grant deploy permissions
+
+The backend needs cluster-wide permissions to install Helm charts (many charts create ClusterRoles, CRDs, etc.). Grant the backend service account cluster-admin:
+
+```bash
+kubectl create clusterrolebinding stack-manager-admin \
+  --clusterrole=cluster-admin \
+  --serviceaccount=stack-manager:stack-manager-k8s-stack-manager-backend
+```
+
+> For production, scope this down to the specific resources your charts need.
+
+## 6. Register a cluster
+
+
+The backend needs a registered Kubernetes cluster to deploy stacks to. The simplest option is to register the cluster it's running on using in-cluster configuration.
+
+Go to **Admin > Clusters** in the UI and click **Add Cluster**:
+
+- **Name**: `default`
+- **API Server URL**: `https://kubernetes.default.svc`
+- **Set as Default**: checked
+
+Or register an external cluster by providing a kubeconfig.
+
+Verify with stackctl:
+
+```bash
+stackctl cluster list
+```
+
+## 7. Import starter templates
+
+The repo ships with 4 ready-to-use definition bundles. Import them with the bootstrap script:
+
+```bash
+./scripts/import-starter-templates.sh
+```
+
+Or import individually:
+
+```bash
+stackctl definition import --file examples/starter-templates/hello-world.json
+stackctl definition import --file examples/starter-templates/web-app.json
+stackctl definition import --file examples/starter-templates/api-backend.json
+stackctl definition import --file examples/starter-templates/full-stack.json
+```
+
+Check what's available:
+
+```bash
+stackctl definition list
+```
+
+### Starter templates
+
+| Name | Charts | Description |
+|------|--------|-------------|
+| Hello World | podinfo | Single chart — verify the platform works |
+| Web App | backend + frontend | Two services with deploy ordering |
+| API Backend | cache + api | API with cache tier and resource limits |
+| Full Stack | cache + api + frontend | Production-like 3-chart stack |
+
+## 8. Deploy your first stack
+
+Pick the **Web App** definition (backend + frontend — two charts with deploy ordering) and create a stack:
+
+```bash
+# List definitions and pick the Web App ID
+stackctl definition list
+
+# Create an instance from the Web App definition
+stackctl stack create --definition <web-app-id> --name my-first-stack
+
+# Deploy it — both charts deploy in order (backend first, then frontend)
+stackctl stack deploy my-first-stack
+```
+
+Monitor the deployment:
+
+```bash
+# Watch status
+stackctl stack status my-first-stack
+
+# View deployment logs — shows each chart installing in sequence
+stackctl stack logs my-first-stack
+
+# List your stacks
+stackctl stack list --mine
+```
+
+## 9. Clean up
+
+When you're done experimenting:
+
+```bash
+# Stop the stack (keeps namespace)
+stackctl stack stop my-first-stack
+
+# Or fully remove it (undeploys and deletes namespace)
+stackctl stack clean my-first-stack
+stackctl stack delete my-first-stack
+```
+
+## Next steps
+
+- [Concepts & Terminology](../WIKI.md) — templates, definitions, instances, and how they relate
+- [Architecture](../ARCHITECTURE.md) — system design, data model, and package structure
+- [Extending](../EXTENDING.md) — event hooks, custom actions, and webhook integrations
+- [stackctl CLI Reference](https://github.com/omattsson/stackctl) — full command reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,12 +42,14 @@ kubectl -n stack-manager rollout status deployment/stack-manager-k8s-stack-manag
 kubectl -n stack-manager rollout status deployment/stack-manager-k8s-stack-manager-frontend
 ```
 
+> If you enabled Argo Rollouts (`argoRollouts.enabled: true`), replace `deployment/` with `rollout/` in the commands above.
+
 ## 3. Access the UI
 
 If your cluster has Traefik installed (the chart creates IngressRoutes automatically), access the UI via the Traefik load balancer IP. Otherwise, port-forward:
 
 ```bash
-kubectl -n stack-manager port-forward svc/stack-manager-k8s-stack-manager-frontend 3000:80
+kubectl -n stack-manager port-forward svc/stack-manager-k8s-stack-manager-frontend 3000:8080
 ```
 
 Open http://localhost:3000 and log in with `admin` / the password you set above.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,11 +14,7 @@ Deploy K8s Stack Manager to your cluster and create your first stack in under 10
 brew install omattsson/tap/stackctl
 ```
 
-Or use the install script:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/omattsson/stackctl/main/install.sh | sudo bash
-```
+Or download from [releases](https://github.com/omattsson/stackctl/releases) and install manually.
 
 ## 2. Deploy K8s Stack Manager
 
@@ -35,33 +31,33 @@ Install with minimal configuration:
 helm install stack-manager k8s-stack-manager/k8s-stack-manager \
   --namespace stack-manager --create-namespace \
   --set backend.secrets.JWT_SECRET="$(openssl rand -base64 32)" \
-  --set backend.secrets.ADMIN_PASSWORD="your-admin-password" \
-  --set mysql.auth.rootPassword="your-db-password"
+  --set backend.secrets.ADMIN_PASSWORD="CHANGE-ME-set-a-secure-password" \
+  --set mysql.auth.rootPassword="CHANGE-ME-set-a-secure-password"
 ```
 
 Wait for all pods to be ready:
 
 ```bash
-kubectl -n stack-manager rollout status deployment/stack-manager-backend
-kubectl -n stack-manager rollout status deployment/stack-manager-frontend
+kubectl -n stack-manager rollout status deployment/stack-manager-k8s-stack-manager-backend
+kubectl -n stack-manager rollout status deployment/stack-manager-k8s-stack-manager-frontend
 ```
 
 ## 3. Access the UI
 
-Port-forward the frontend:
+If your cluster has Traefik installed (the chart creates IngressRoutes automatically), access the UI via the Traefik load balancer IP. Otherwise, port-forward:
 
 ```bash
-kubectl -n stack-manager port-forward svc/stack-manager-frontend 3000:80
+kubectl -n stack-manager port-forward svc/stack-manager-k8s-stack-manager-frontend 3000:80
 ```
 
 Open http://localhost:3000 and log in with `admin` / the password you set above.
 
 ## 4. Configure stackctl
 
-Start port-forwarding the backend API:
+If using port-forward for the backend API:
 
 ```bash
-kubectl -n stack-manager port-forward svc/stack-manager-backend 8081:8081 &
+kubectl -n stack-manager port-forward svc/stack-manager-k8s-stack-manager-backend 8081:8081 &
 ```
 
 Point stackctl at your deployment and authenticate:
@@ -80,20 +76,7 @@ stackctl whoami
 stackctl version
 ```
 
-## 5. Grant deploy permissions
-
-The backend needs cluster-wide permissions to install Helm charts (many charts create ClusterRoles, CRDs, etc.). Grant the backend service account cluster-admin:
-
-```bash
-kubectl create clusterrolebinding stack-manager-admin \
-  --clusterrole=cluster-admin \
-  --serviceaccount=stack-manager:stack-manager-k8s-stack-manager-backend
-```
-
-> For production, scope this down to the specific resources your charts need.
-
-## 6. Register a cluster
-
+## 5. Register a cluster
 
 The backend needs a registered Kubernetes cluster to deploy stacks to. The simplest option is to register the cluster it's running on using in-cluster configuration.
 
@@ -111,7 +94,9 @@ Verify with stackctl:
 stackctl cluster list
 ```
 
-## 7. Import starter templates
+> **Note:** The Helm chart creates a ClusterRole with permissions for namespaces, pods, deployments, and services. If your charts require additional cluster-scoped resources (ClusterRoles, CRDs, IngressClasses), you may need to extend the ClusterRole or grant broader permissions to the backend service account.
+
+## 6. Import starter templates
 
 The repo ships with 4 ready-to-use definition bundles. Import them with the bootstrap script:
 
@@ -143,7 +128,7 @@ stackctl definition list
 | API Backend | cache + api | API with cache tier and resource limits |
 | Full Stack | cache + api + frontend | Production-like 3-chart stack |
 
-## 8. Deploy your first stack
+## 7. Deploy your first stack
 
 Pick the **Web App** definition (backend + frontend — two charts with deploy ordering) and create a stack:
 
@@ -171,7 +156,7 @@ stackctl stack logs my-first-stack
 stackctl stack list --mine
 ```
 
-## 9. Clean up
+## 8. Clean up
 
 When you're done experimenting:
 
@@ -179,8 +164,10 @@ When you're done experimenting:
 # Stop the stack (keeps namespace)
 stackctl stack stop my-first-stack
 
-# Or fully remove it (undeploys and deletes namespace)
+# Remove Helm releases and delete the namespace
 stackctl stack clean my-first-stack
+
+# Delete the stack record from the platform
 stackctl stack delete my-first-stack
 ```
 

--- a/examples/starter-templates/api-backend.json
+++ b/examples/starter-templates/api-backend.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "definition": {
+    "name": "API Backend",
+    "description": "API service with cache tier — demonstrates resource limits and deploy ordering.",
+    "default_branch": "main"
+  },
+  "charts": [
+    {
+      "chart_name": "cache",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898\ncache: memory\nui:\n  message: Cache Layer",
+      "deploy_order": 1
+    },
+    {
+      "chart_name": "api",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 2\nresources:\n  requests:\n    cpu: 20m\n    memory: 32Mi\n  limits:\n    cpu: 200m\n    memory: 128Mi\nservice:\n  type: ClusterIP\n  port: 9898\ncacheServer: tcp://cache-podinfo:9898\nui:\n  message: API Service",
+      "deploy_order": 2
+    }
+  ]
+}

--- a/examples/starter-templates/full-stack.json
+++ b/examples/starter-templates/full-stack.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "1.0",
+  "definition": {
+    "name": "Full Stack",
+    "description": "Cache + API + frontend — a production-like 3-chart stack with deploy ordering.",
+    "default_branch": "main"
+  },
+  "charts": [
+    {
+      "chart_name": "cache",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898\ncache: memory\nui:\n  message: Cache Layer",
+      "deploy_order": 1
+    },
+    {
+      "chart_name": "api",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 2\nresources:\n  requests:\n    cpu: 20m\n    memory: 32Mi\n  limits:\n    cpu: 200m\n    memory: 128Mi\nservice:\n  type: ClusterIP\n  port: 9898\ncacheServer: tcp://cache-podinfo:9898\nui:\n  message: API Service",
+      "deploy_order": 2
+    },
+    {
+      "chart_name": "frontend",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898\nbackendURL: http://api-podinfo:9898\nui:\n  message: Frontend",
+      "deploy_order": 3
+    }
+  ]
+}

--- a/examples/starter-templates/hello-world.json
+++ b/examples/starter-templates/hello-world.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": "1.0",
+  "definition": {
+    "name": "Hello World",
+    "description": "Single podinfo service — the simplest stack to verify the platform works.",
+    "default_branch": "main"
+  },
+  "charts": [
+    {
+      "chart_name": "podinfo",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898",
+      "deploy_order": 1
+    }
+  ]
+}

--- a/examples/starter-templates/web-app.json
+++ b/examples/starter-templates/web-app.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0",
+  "definition": {
+    "name": "Web App",
+    "description": "Frontend + backend podinfo services — demonstrates multi-chart deploy ordering.",
+    "default_branch": "main"
+  },
+  "charts": [
+    {
+      "chart_name": "backend",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898\nui:\n  message: Backend API",
+      "deploy_order": 1
+    },
+    {
+      "chart_name": "frontend",
+      "repository_url": "https://stefanprodan.github.io/podinfo",
+      "source_repo_url": "https://github.com/stefanprodan/podinfo",
+      "chart_path": "podinfo",
+      "chart_version": "6.11.2",
+      "default_values": "replicaCount: 1\nresources:\n  requests:\n    cpu: 10m\n    memory: 16Mi\n  limits:\n    cpu: 100m\n    memory: 64Mi\nservice:\n  type: ClusterIP\n  port: 9898\nbackendURL: http://backend-podinfo:9898\nui:\n  message: Frontend",
+      "deploy_order": 2
+    }
+  ]
+}

--- a/scripts/import-starter-templates.sh
+++ b/scripts/import-starter-templates.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -o pipefail
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMPLATES_DIR="$(cd "${SCRIPT_DIR}/../examples/starter-templates" && pwd)"
@@ -10,6 +10,20 @@ if ! command -v stackctl &>/dev/null; then
   exit 1
 fi
 
+if ! command -v python3 &>/dev/null; then
+  echo "Error: python3 is required for JSON parsing."
+  exit 1
+fi
+
+shopt -s nullglob
+json_files=("${TEMPLATES_DIR}"/*.json)
+shopt -u nullglob
+
+if [ ${#json_files[@]} -eq 0 ]; then
+  echo "No template bundles found in ${TEMPLATES_DIR}"
+  exit 1
+fi
+
 echo "Importing starter templates..."
 echo
 
@@ -17,16 +31,20 @@ imported=0
 skipped=0
 failed=0
 
-for file in "${TEMPLATES_DIR}"/*.json; do
+for file in "${json_files[@]}"; do
   name=$(python3 -c "import json,sys; print(json.load(sys.stdin)['definition']['name'])" < "${file}" 2>/dev/null || basename "${file}" .json)
 
-  if export N="${name}" && stackctl definition list -o json 2>/dev/null | N="${name}" python3 -c "import json,sys,os; defs=json.load(sys.stdin).get('data',[]); sys.exit(0 if any(d['name']==os.environ['N'] for d in defs) else 1)" 2>/dev/null; then
+  if N="${name}" stackctl definition list -o json 2>/dev/null | N="${name}" python3 -c "
+import json,sys,os
+defs = json.load(sys.stdin).get('data', [])
+sys.exit(0 if any(d['name'] == os.environ['N'] for d in defs) else 1)
+" 2>/dev/null; then
     echo "  Skip: ${name} (already exists)"
     skipped=$((skipped + 1))
     continue
   fi
 
-  if stackctl definition import --file "${file}" -q >/dev/null; then
+  if stackctl definition import --file "${file}" -q >/dev/null 2>&1; then
     echo "  OK:   ${name}"
     imported=$((imported + 1))
   else

--- a/scripts/import-starter-templates.sh
+++ b/scripts/import-starter-templates.sh
@@ -49,7 +49,7 @@ sys.exit(0 if any(d['name'] == os.environ['N'] for d in defs) else 1)
     imported=$((imported + 1))
   } || {
     echo "  FAIL: ${name}"
-    echo "        ${output}" | head -3
+    while IFS= read -r line; do echo "        ${line}"; done <<< "${output:0:300}"
     failed=$((failed + 1))
   }
 done

--- a/scripts/import-starter-templates.sh
+++ b/scripts/import-starter-templates.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="$(cd "${SCRIPT_DIR}/../examples/starter-templates" && pwd)"
+
+if ! command -v stackctl &>/dev/null; then
+  echo "Error: stackctl is not installed."
+  echo "Install it with: brew install omattsson/tap/stackctl"
+  exit 1
+fi
+
+echo "Importing starter templates..."
+echo
+
+imported=0
+skipped=0
+failed=0
+
+for file in "${TEMPLATES_DIR}"/*.json; do
+  name=$(python3 -c "import json,sys; print(json.load(sys.stdin)['definition']['name'])" < "${file}" 2>/dev/null || basename "${file}" .json)
+
+  if export N="${name}" && stackctl definition list -o json 2>/dev/null | N="${name}" python3 -c "import json,sys,os; defs=json.load(sys.stdin).get('data',[]); sys.exit(0 if any(d['name']==os.environ['N'] for d in defs) else 1)" 2>/dev/null; then
+    echo "  Skip: ${name} (already exists)"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  if stackctl definition import --file "${file}" -q >/dev/null; then
+    echo "  OK:   ${name}"
+    imported=$((imported + 1))
+  else
+    echo "  FAIL: ${name}"
+    failed=$((failed + 1))
+  fi
+done
+
+echo
+echo "Done. Imported: ${imported}, Skipped: ${skipped}, Failed: ${failed}"
+
+if [ "${failed}" -gt 0 ]; then
+  exit 1
+fi
+
+echo
+echo "Next steps:"
+echo "  stackctl definition list"
+echo "  stackctl stack create --definition <id> --name my-stack"
+echo "  stackctl stack deploy my-stack"

--- a/scripts/import-starter-templates.sh
+++ b/scripts/import-starter-templates.sh
@@ -44,13 +44,14 @@ sys.exit(0 if any(d['name'] == os.environ['N'] for d in defs) else 1)
     continue
   fi
 
-  if stackctl definition import --file "${file}" -q >/dev/null 2>&1; then
+  output=$(stackctl definition import --file "${file}" -q 2>&1) && {
     echo "  OK:   ${name}"
     imported=$((imported + 1))
-  else
+  } || {
     echo "  FAIL: ${name}"
+    echo "        ${output}" | head -3
     failed=$((failed + 1))
-  fi
+  }
 done
 
 echo


### PR DESCRIPTION
## Summary
- Add step-by-step getting started guide (docs/getting-started.md) — deploy via Helm, configure stackctl, import templates, deploy first stack
- Add 4 starter template bundles using podinfo (namespace-scoped, no cluster resources needed):
  - Hello World (1 chart), Web App (2 charts), API Backend (2 charts), Full Stack (3 charts)
- Add idempotent bootstrap script (scripts/import-starter-templates.sh) using stackctl
- Update README with Getting Started section

## Tested end-to-end on Rancher Desktop
- Helm install -> all pods running in ~30s
- stackctl login + cluster registration
- All 4 templates imported successfully
- Web App (2-chart) deployed: backend first, frontend second, both pods running

## Test plan
- [x] Full guide followed from clean state on rancher-desktop
- [x] Bootstrap script: imports 4/4, idempotent on re-run (skips all)
- [x] Multi-chart deployment: sequential ordering verified in logs
- [x] All pods healthy after deploy

Generated with [Claude Code](https://claude.com/claude-code)