### PR TITLE
feat(helm): frontend.enabled toggle for headless deployments

### DIFF
--- a/helm/k8s-stack-manager/templates/NOTES.txt
+++ b/helm/k8s-stack-manager/templates/NOTES.txt
@@ -25,6 +25,7 @@ Ingress: Standard Kubernetes Ingress
 Ingress: Disabled (type: none)
 
   Access via port-forward:
+    {{- if .Values.frontend.enabled }}
     # Frontend + API (full app):
     kubectl port-forward svc/{{ include "k8s-stack-manager.frontend.serviceName" . }} 3000:{{ .Values.frontend.port }}
     kubectl port-forward svc/{{ include "k8s-stack-manager.backend.serviceName" . }} 8081:{{ .Values.backend.port }}
@@ -34,6 +35,14 @@ Ingress: Disabled (type: none)
 
   NOTE: Port-forwarding runs two separate origins. For full-app testing,
         use an ingress type or configure CORS_ALLOWED_ORIGINS accordingly.
+    {{- else }}
+    # API only (frontend.enabled=false):
+    kubectl port-forward svc/{{ include "k8s-stack-manager.backend.serviceName" . }} 8081:{{ .Values.backend.port }}
+
+    Backend API: http://localhost:8081
+
+  NOTE: Headless / API-only mode — use stackctl as the client.
+    {{- end }}
 
 {{- end }}
 
@@ -41,12 +50,16 @@ Ingress: Disabled (type: none)
 
 Watch rollout status:
   kubectl argo rollouts get rollout {{ include "k8s-stack-manager.fullname" . }}-backend --watch
+{{- if .Values.frontend.enabled }}
   kubectl argo rollouts get rollout {{ include "k8s-stack-manager.fullname" . }}-frontend --watch
+{{- end }}
 {{- else }}
 
 Watch deployment status:
   kubectl rollout status deployment/{{ include "k8s-stack-manager.fullname" . }}-backend
+{{- if .Values.frontend.enabled }}
   kubectl rollout status deployment/{{ include "k8s-stack-manager.fullname" . }}-frontend
+{{- end }}
 {{- end }}
 
 {{- if eq .Values.backend.secrets.JWT_SECRET "CHANGE-ME-generate-a-random-secret" }}

--- a/helm/k8s-stack-manager/templates/analysis-template.yaml
+++ b/helm/k8s-stack-manager/templates/analysis-template.yaml
@@ -22,10 +22,10 @@ spec:
           url: "http://{{ "{{" }}args.service-name{{ "}}" }}:{{ "{{" }}args.port{{ "}}" }}/health/ready"
           jsonPath: "{$.status}"
 {{- end }}
-{{- if and .Values.backend.rollout.analysis.enabled .Values.frontend.rollout.analysis.enabled }}
+{{- if and .Values.backend.rollout.analysis.enabled .Values.frontend.enabled .Values.frontend.rollout.analysis.enabled }}
 ---
 {{- end }}
-{{- if .Values.frontend.rollout.analysis.enabled }}
+{{- if and .Values.frontend.enabled .Values.frontend.rollout.analysis.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: AnalysisTemplate
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/configmap.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,3 +17,4 @@ data:
             try_files $uri $uri/ /index.html;
         }
     }
+{{- end }}

--- a/helm/k8s-stack-manager/templates/frontend/deployment.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.argoRollouts.enabled }}
+{{- if and .Values.frontend.enabled (not .Values.argoRollouts.enabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/hpa.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.frontend.autoscaling.enabled }}
+{{- if and .Values.frontend.enabled .Values.frontend.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/pdb.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/pdb.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.frontend.pdb.enabled }}
+{{- if and .Values.frontend.enabled .Values.frontend.pdb.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/rollout.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/rollout.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.argoRollouts.enabled }}
+{{- if and .Values.frontend.enabled .Values.argoRollouts.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Rollout
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/service-canary.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/service-canary.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.argoRollouts.enabled }}
+{{- if and .Values.frontend.enabled .Values.argoRollouts.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/helm/k8s-stack-manager/templates/frontend/service.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.frontend.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       targetPort: http
   selector:
     {{- include "k8s-stack-manager.frontend.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/k8s-stack-manager/templates/frontend/serviceaccount.yaml
+++ b/helm/k8s-stack-manager/templates/frontend/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.frontend.serviceAccount.create }}
+{{- if and .Values.frontend.enabled .Values.frontend.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/k8s-stack-manager/templates/ingress.yaml
+++ b/helm/k8s-stack-manager/templates/ingress.yaml
@@ -51,6 +51,7 @@ spec:
                 name: {{ include "k8s-stack-manager.backend.serviceName" . }}
                 port:
                   number: {{ .Values.backend.port }}
+          {{- if .Values.frontend.enabled }}
           - path: /
             pathType: Prefix
             backend:
@@ -58,4 +59,5 @@ spec:
                 name: {{ include "k8s-stack-manager.frontend.serviceName" . }}
                 port:
                   number: {{ .Values.frontend.port }}
+          {{- end }}
 {{- end }}

--- a/helm/k8s-stack-manager/templates/traefik/ingressroute.yaml
+++ b/helm/k8s-stack-manager/templates/traefik/ingressroute.yaml
@@ -60,6 +60,7 @@ spec:
           kind: Service
           port: {{ .Values.backend.port }}
           {{- end }}
+    {{- if .Values.frontend.enabled }}
     # Everything else → frontend
     - match: {{ if .Values.ingress.host }}Host(`{{ .Values.ingress.host }}`) && {{ end }}PathPrefix(`/`)
       kind: Rule
@@ -75,6 +76,7 @@ spec:
       middlewares:
         - name: {{ include "k8s-stack-manager.fullname" . }}-secure-headers
       {{- end }}
+    {{- end }}
   {{- if .Values.ingress.traefik.tls.secretName }}
   tls:
     secretName: {{ .Values.ingress.traefik.tls.secretName }}

--- a/helm/k8s-stack-manager/templates/traefik/traefik-service.yaml
+++ b/helm/k8s-stack-manager/templates/traefik/traefik-service.yaml
@@ -15,6 +15,7 @@ spec:
       - name: {{ include "k8s-stack-manager.backend.canaryService" . }}
         port: {{ .Values.backend.port }}
         weight: 0
+{{- if .Values.frontend.enabled }}
 ---
 # TraefikService for frontend: Argo Rollouts manages the weights during canary rollouts.
 apiVersion: traefik.io/v1alpha1
@@ -32,4 +33,5 @@ spec:
       - name: {{ include "k8s-stack-manager.frontend.canaryService" . }}
         port: {{ .Values.frontend.port }}
         weight: 0
+{{- end }}
 {{- end }}

--- a/helm/k8s-stack-manager/values.yaml
+++ b/helm/k8s-stack-manager/values.yaml
@@ -133,6 +133,11 @@ backend:
 # Frontend
 # ---------------------------------------------------------------------------
 frontend:
+  # Set to false for headless / API-only deployments — skips all frontend resources
+  # (Deployment/Rollout, Service, ConfigMap, HPA, PDB, ServiceAccount) and the
+  # ingress rule routing `/` to the frontend. The backend (/api, /ws, /health,
+  # /swagger) is unaffected.
+  enabled: true
   image:
     repository: k8s-stack-manager/frontend
     tag: ""  # Empty = uses Chart.AppVersion


### PR DESCRIPTION
## Summary
- Adds a `frontend.enabled` value (default `true`) to the Helm chart so the chart can render API-only / headless deployments.
- When `false`, all frontend resources are skipped: Deployment/Rollout, Service, canary Service, ConfigMap, HPA, PDB, ServiceAccount, AnalysisTemplate, plus the `/` rule on the standard `Ingress` and the Traefik `IngressRoute` (and the frontend `TraefikService`).
- Backend routes (`/api`, `/ws`, `/health`, `/swagger`) and the backend `TraefikService` are unaffected.
- `NOTES.txt` switches to an API-only port-forward block and drops the `frontend` rollout-status line when the toggle is off.
- Default unchanged — existing installs are not affected.

Closes #242

## Test plan
- [x] `helm lint helm/k8s-stack-manager` — clean (defaults).
- [x] `helm lint helm/k8s-stack-manager --set frontend.enabled=false` — clean.
- [x] `helm template testrel helm/k8s-stack-manager --set frontend.enabled=false` — 0 occurrences of `frontend` in rendered output.
- [x] Same with `--set argoRollouts.enabled=true` and `--set frontend.rollout.analysis.enabled=true` — frontend `AnalysisTemplate` also dropped (only backend `AnalysisTemplate` rendered).
- [x] `--set ingress.type=ingress --set frontend.enabled=false` — standard `Ingress` keeps `/api`, `/ws`, `/health`, `/swagger` rules; `/` dropped.
- [x] `--set ingress.type=traefik --set frontend.enabled=false` — `IngressRoute` keeps the same four routes; `PathPrefix(/)` rule dropped; no dangling `---` document marker on the `TraefikService`.
- [x] `helm install --dry-run --set ingress.type=none --set frontend.enabled=false` — `NOTES.txt` renders the API-only port-forward block.
- [x] Baseline (no flag) — `frontend` resources still render and rollout-status output unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
