### PR TITLE
feat(compose): api-only profile (no frontend container)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Copy this file to `.env` and adjust for your local setup.
+# Compose loads .env automatically; values here flow into docker-compose.yml via ${VAR}.
+
+# ---------------------------------------------------------------------------
+# Compose profiles
+# ---------------------------------------------------------------------------
+# `full` enables the frontend service. Drop it (or use a different value like
+# `api-only`) to run headless — backend + mysql only, with stackctl as the client.
+# Profile activation is additive; `otel` and `mysql-otel` profiles can be added
+# comma-separated, e.g. `COMPOSE_PROFILES=full,otel`.
+COMPOSE_PROFILES=full
+
+# ---------------------------------------------------------------------------
+# OIDC / Entra ID SSO (optional — leave blank for local-auth only)
+# ---------------------------------------------------------------------------
+# OIDC_ENABLED=true
+# OIDC_PROVIDER_URL=https://login.microsoftonline.com/<tenant>/v2.0
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_REDIRECT_URL=http://localhost:3000/api/v1/auth/oidc/callback
+# OIDC_ROLE_CLAIM=roles
+# OIDC_ADMIN_ROLES=admin
+# OIDC_AUTO_PROVISION=true
+# OIDC_LOCAL_AUTH=true

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,26 @@
-.PHONY: dev dev-otel seed dev-backend dev-frontend dev-local dev-local-backend dev-local-frontend prod prod-backend prod-frontend build clean prune test test-backend test-backend-integration test-backend-all test-frontend test-e2e integration-infra-start integration-infra-stop install docs fmt lint loadtest loadtest-start loadtest-start-backend loadtest-start-frontend loadtest-stop loadtest-stop-backend loadtest-stop-frontend loadtest-backend loadtest-backend-run loadtest-stress loadtest-stress-run loadtest-frontend loadtest-frontend-run
+.PHONY: dev dev-otel dev-api-only compose-api-only seed dev-backend dev-frontend dev-local dev-local-backend dev-local-frontend prod prod-backend prod-frontend build clean prune test test-backend test-backend-integration test-backend-all test-frontend test-e2e integration-infra-start integration-infra-stop install docs fmt lint loadtest loadtest-start loadtest-start-backend loadtest-start-frontend loadtest-stop loadtest-stop-backend loadtest-stop-frontend loadtest-backend loadtest-backend-run loadtest-stress loadtest-stress-run loadtest-frontend loadtest-frontend-run
 
 # Development mode for both services
 dev:
-	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose up --build --remove-orphans
+	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose --profile full up --build --remove-orphans
 
 # Development mode with local K8s cluster access (rancher-desktop, Docker Desktop K8s, etc.)
 dev-k8s:
-	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose -f docker-compose.yml -f docker-compose.k8s.yml up --build --remove-orphans
+	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose --profile full -f docker-compose.yml -f docker-compose.k8s.yml up --build --remove-orphans
 
 # Development mode with OpenTelemetry observability stack (Jaeger + Prometheus)
 dev-otel: ## Start full stack with OpenTelemetry (Jaeger UI: :16686, Prometheus: :9090)
-	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose --profile otel -f docker-compose.yml -f docker-compose.otel.yml up --build --remove-orphans
+	NODE_ENV=development GO_ENV=development PORT=3000 BACKEND_PORT=8081 GIN_MODE=debug docker compose --profile full --profile otel -f docker-compose.yml -f docker-compose.otel.yml up --build --remove-orphans
+
+# Headless / API-only mode (no frontend container) — pair with stackctl as the client.
+# COMPOSE_PROFILES=api-only on the recipe line so an existing .env with
+# COMPOSE_PROFILES=full cannot accidentally pull in the frontend.
+dev-api-only: ## Start backend + mysql only, no frontend (for stackctl-driven workflows)
+	COMPOSE_PROFILES=api-only GO_ENV=development BACKEND_PORT=8081 GIN_MODE=debug docker compose up --build --remove-orphans
+
+# Same as dev-api-only without the dev-mode env vars — exact API-only baseline
+compose-api-only: ## Start backend + mysql only with default env (matches Helm frontend.enabled=false)
+	COMPOSE_PROFILES=api-only docker compose up --build --remove-orphans
 
 seed: ## Seed dev environment with sample data (requires running dev stack)
 	@./scripts/seed-dev-data.sh
@@ -25,7 +35,7 @@ dev-frontend:
 
 # Production mode for both services
 prod:
-	NODE_ENV=production GO_ENV=production PORT=80 BACKEND_PORT=8080 GIN_MODE=release docker compose up --build --remove-orphans
+	NODE_ENV=production GO_ENV=production PORT=80 BACKEND_PORT=8080 GIN_MODE=release docker compose --profile full up --build --remove-orphans
 
 # Production mode for backend only
 prod-backend:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Backend (Go + Gin)
 ### Start with Docker Compose
 
 ```bash
+cp .env.example .env   # first time only — sets COMPOSE_PROFILES=full
 make dev
 ```
 
@@ -123,6 +124,31 @@ This starts all services:
 - **Swagger docs**: http://localhost:8081/swagger/index.html
 
 Default admin credentials: `admin` / `admin` (configured in docker-compose.yml).
+
+### Headless / API-only
+
+For workflows driven by [stackctl](https://github.com/omattsson/stackctl), you can
+skip the frontend container entirely:
+
+```bash
+make compose-api-only
+```
+
+`docker-compose.yml` tags the frontend service with `profiles: [full]`, so it
+only runs when that profile is active. `.env.example` sets
+`COMPOSE_PROFILES=full` by default — drop or override it to go headless:
+
+```bash
+COMPOSE_PROFILES=api-only docker compose up
+```
+
+> **Upgrading from a previous checkout?** If you have an existing `.env` from
+> before this change, add `COMPOSE_PROFILES=full` to it (or `cp .env.example
+> .env` afresh) — otherwise `docker compose up` will now start the headless
+> stack. `make dev` / `make prod` force `--profile full` and are unaffected.
+
+The matching Helm toggle is `frontend.enabled=false` (see the chart's
+`values.yaml`).
 
 ### Start Locally (without Docker)
 
@@ -139,6 +165,7 @@ cd frontend && npm install && npm run dev
 | Command | Description |
 |---|---|
 | `make dev` | Start full stack via Docker Compose |
+| `make compose-api-only` | Start backend + mysql only (headless, no frontend) |
 | `make dev-local` | Run backend + frontend locally |
 | `make test` | Run all tests (backend + frontend) |
 | `make test-backend` | Backend unit tests |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,11 @@ services:
       - backend_go_mod:/go/pkg/mod
 
   frontend:
+    # In the `full` profile so the stack can run headless (api-only) when this
+    # profile is not active. The shipped .env.example sets COMPOSE_PROFILES=full
+    # so users who copy it keep the default full-stack behavior; for headless
+    # dev use `COMPOSE_PROFILES=api-only docker compose up` or `make compose-api-only`.
+    profiles: [full]
     build:
       context: ./frontend
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- Tags the `frontend` service with `profiles: [full]` so the stack can run headless for stackctl-driven workflows.
- Ships a new `.env.example` with `COMPOSE_PROFILES=full` — `cp .env.example .env` preserves the full-stack default.
- `make dev` / `make dev-k8s` / `make dev-otel` / `make prod` now pass `--profile full` explicitly so Makefile flows are independent of the user's local `.env`.
- New `make compose-api-only` and `make dev-api-only` targets force `COMPOSE_PROFILES=api-only` on the recipe line — they stay headless even if the user's `.env` has `full` set.
- README has a new "Headless / API-only" section and an upgrade note for developers with pre-existing `.env` files.

Mirrors the Helm `frontend.enabled=false` toggle from #242 / PR #247.

Closes #243

## Test plan
- [x] `docker compose --env-file /dev/null config --services` → `backend mysql` (frontend gated).
- [x] `docker compose --env-file /dev/null --profile full config --services` → `backend frontend mysql`.
- [x] `docker compose --env-file .env.example config --services` → `backend frontend mysql`.
- [x] `COMPOSE_PROFILES=api-only docker compose config --services` → `backend mysql`.
- [x] `--profile full --profile otel` combine additively — verified all 7 services resolve for `dev-otel`.
- [x] Positional `docker compose up frontend` still starts the frontend (`--dry-run` confirms `Container app-frontend-prod Created`) — `dev-frontend` / `prod-frontend` Makefile targets unaffected.
- [x] Make recipe `COMPOSE_PROFILES=api-only` correctly overrides an inherited `COMPOSE_PROFILES=full` from the environment.

## Notes
- Existing developers with a pre-change `.env` (no `COMPOSE_PROFILES` line) will get a headless stack on raw `docker compose up`. README upgrade note explains the fix; `make dev` / `make prod` are unaffected because they pass `--profile full` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
