### PR TITLE
feat(oidc): RFC 8252 loopback flow for CLI auth

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -297,6 +297,570 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/admin/notification-channels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all notification channels with subscription counts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List all notification channels",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handlers.notificationChannelWithCount"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a new notification channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Create a notification channel",
+                "parameters": [
+                    {
+                        "description": "Channel",
+                        "name": "channel",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/event-types": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all known event types that channels can subscribe to",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List all event types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a notification channel by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Get a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates an existing notification channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Update a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Channel updates",
+                        "name": "channel",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.updateChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes a notification channel and its subscriptions",
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Delete a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/delivery-logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns paginated delivery logs for a notification channel",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List delivery logs for a channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (default 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns event type subscriptions for a channel",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Get channel subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces all event type subscriptions for a channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Update channel subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Event types",
+                        "name": "subscriptions",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.updateSubscriptionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a test payload to the channel's webhook URL",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Test a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/orphaned-namespaces": {
             "get": {
                 "security": [
@@ -972,7 +1536,10 @@ const docTemplate = `{
         },
         "/api/v1/auth/oidc/cli-auth": {
             "post": {
-                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes.",
+                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes. Optionally accepts a loopback ` + "`" + `redirect_uri` + "`" + ` (http scheme, any loopback IP such as 127.0.0.1 or [::1], or hostname \"localhost\", with an explicit port) for the RFC 8252 native-app flow — the callback then 302-redirects the browser directly to that URL with tokens in the query string, no polling needed.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -980,12 +1547,31 @@ const docTemplate = `{
                     "auth"
                 ],
                 "summary": "Start CLI SSO authentication flow",
+                "parameters": [
+                    {
+                        "description": "Optional loopback redirect_uri",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CLIAuthRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "session_id, login_url, expires_in",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid redirect_uri",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "404": {
@@ -2975,8 +3561,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer",
-                                "format": "int64"
+                                "type": "integer"
                             }
                         }
                     },
@@ -7772,6 +8357,14 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.CLIAuthRequest": {
+            "type": "object",
+            "properties": {
+                "redirect_uri": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.CLITokenRequest": {
             "type": "object",
             "required": [
@@ -8571,6 +9164,27 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.createChannelRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "webhook_url"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.extendTTLRequest": {
             "type": "object",
             "properties": {
@@ -8585,6 +9199,32 @@ const docTemplate = `{
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {}
+                }
+            }
+        },
+        "handlers.notificationChannelWithCount": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "subscription_count": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
                 }
             }
         },
@@ -8666,6 +9306,23 @@ const docTemplate = `{
                 }
             }
         },
+        "handlers.updateChannelRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.updatePreferenceRequest": {
             "type": "object",
             "properties": {
@@ -8677,6 +9334,17 @@ const docTemplate = `{
                 },
                 "event_type": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.updateSubscriptionsRequest": {
+            "type": "object",
+            "properties": {
+                "event_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -9456,6 +10124,29 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.NotificationChannel": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "webhook_url": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -295,6 +295,570 @@
                 }
             }
         },
+        "/api/v1/admin/notification-channels": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all notification channels with subscription counts",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List all notification channels",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/handlers.notificationChannelWithCount"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Creates a new notification channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Create a notification channel",
+                "parameters": [
+                    {
+                        "description": "Channel",
+                        "name": "channel",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.createChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/event-types": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns all known event types that channels can subscribe to",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List all event types",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns a notification channel by ID",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Get a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Updates an existing notification channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Update a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Channel updates",
+                        "name": "channel",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.updateChannelRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.NotificationChannel"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Deletes a notification channel and its subscriptions",
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Delete a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/delivery-logs": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns paginated delivery logs for a notification channel",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "List delivery logs for a channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page size (default 20)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset (default 0)",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/subscriptions": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns event type subscriptions for a channel",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Get channel subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replaces all event type subscriptions for a channel",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Update channel subscriptions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Event types",
+                        "name": "subscriptions",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handlers.updateSubscriptionsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/admin/notification-channels/{id}/test": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Sends a test payload to the channel's webhook URL",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "notification-channels"
+                ],
+                "summary": "Test a notification channel",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Channel ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/admin/orphaned-namespaces": {
             "get": {
                 "security": [
@@ -970,7 +1534,10 @@
         },
         "/api/v1/auth/oidc/cli-auth": {
             "post": {
-                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes.",
+                "description": "Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes. Optionally accepts a loopback `redirect_uri` (http scheme, any loopback IP such as 127.0.0.1 or [::1], or hostname \"localhost\", with an explicit port) for the RFC 8252 native-app flow — the callback then 302-redirects the browser directly to that URL with tokens in the query string, no polling needed.",
+                "consumes": [
+                    "application/json"
+                ],
                 "produces": [
                     "application/json"
                 ],
@@ -978,12 +1545,31 @@
                     "auth"
                 ],
                 "summary": "Start CLI SSO authentication flow",
+                "parameters": [
+                    {
+                        "description": "Optional loopback redirect_uri",
+                        "name": "request",
+                        "in": "body",
+                        "schema": {
+                            "$ref": "#/definitions/handlers.CLIAuthRequest"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "session_id, login_url, expires_in",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "invalid redirect_uri",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
                         }
                     },
                     "404": {
@@ -2973,8 +3559,7 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": {
-                                "type": "integer",
-                                "format": "int64"
+                                "type": "integer"
                             }
                         }
                     },
@@ -7770,6 +8355,14 @@
                 }
             }
         },
+        "handlers.CLIAuthRequest": {
+            "type": "object",
+            "properties": {
+                "redirect_uri": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.CLITokenRequest": {
             "type": "object",
             "required": [
@@ -8569,6 +9162,27 @@
                 }
             }
         },
+        "handlers.createChannelRequest": {
+            "type": "object",
+            "required": [
+                "name",
+                "webhook_url"
+            ],
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.extendTTLRequest": {
             "type": "object",
             "properties": {
@@ -8583,6 +9197,32 @@
                 "parameters": {
                     "type": "object",
                     "additionalProperties": {}
+                }
+            }
+        },
+        "handlers.notificationChannelWithCount": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "subscription_count": {
+                    "type": "integer"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
                 }
             }
         },
@@ -8664,6 +9304,23 @@
                 }
             }
         },
+        "handlers.updateChannelRequest": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "secret": {
+                    "type": "string"
+                },
+                "webhook_url": {
+                    "type": "string"
+                }
+            }
+        },
         "handlers.updatePreferenceRequest": {
             "type": "object",
             "properties": {
@@ -8675,6 +9332,17 @@
                 },
                 "event_type": {
                     "type": "string"
+                }
+            }
+        },
+        "handlers.updateSubscriptionsRequest": {
+            "type": "object",
+            "properties": {
+                "event_types": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 }
             }
         },
@@ -9454,6 +10122,29 @@
                     "type": "string"
                 },
                 "user_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.NotificationChannel": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "updated_at": {
+                    "type": "string"
+                },
+                "webhook_url": {
                     "type": "string"
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -83,6 +83,11 @@ definitions:
       template_name:
         type: string
     type: object
+  handlers.CLIAuthRequest:
+    properties:
+      redirect_uri:
+        type: string
+    type: object
   handlers.CLITokenRequest:
     properties:
       session_id:
@@ -605,6 +610,20 @@ definitions:
       entity_type:
         type: string
     type: object
+  handlers.createChannelRequest:
+    properties:
+      enabled:
+        type: boolean
+      name:
+        type: string
+      secret:
+        type: string
+      webhook_url:
+        type: string
+    required:
+    - name
+    - webhook_url
+    type: object
   handlers.extendTTLRequest:
     properties:
       ttl_minutes:
@@ -615,6 +634,23 @@ definitions:
       parameters:
         additionalProperties: {}
         type: object
+    type: object
+  handlers.notificationChannelWithCount:
+    properties:
+      created_at:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: string
+      name:
+        type: string
+      subscription_count:
+        type: integer
+      updated_at:
+        type: string
+      webhook_url:
+        type: string
     type: object
   handlers.quickDeployRequest:
     properties:
@@ -669,6 +705,17 @@ definitions:
         example: 10Gi
         type: string
     type: object
+  handlers.updateChannelRequest:
+    properties:
+      enabled:
+        type: boolean
+      name:
+        type: string
+      secret:
+        type: string
+      webhook_url:
+        type: string
+    type: object
   handlers.updatePreferenceRequest:
     properties:
       channel:
@@ -677,6 +724,13 @@ definitions:
         type: boolean
       event_type:
         type: string
+    type: object
+  handlers.updateSubscriptionsRequest:
+    properties:
+      event_types:
+        items:
+          type: string
+        type: array
     type: object
   handlers.versionDetailResponse:
     properties:
@@ -1199,6 +1253,21 @@ definitions:
       user_id:
         type: string
     type: object
+  models.NotificationChannel:
+    properties:
+      created_at:
+        type: string
+      enabled:
+        type: boolean
+      id:
+        type: string
+      name:
+        type: string
+      updated_at:
+        type: string
+      webhook_url:
+        type: string
+    type: object
   models.NotificationPreference:
     properties:
       channel:
@@ -1696,6 +1765,368 @@ paths:
       summary: Run a cleanup policy manually
       tags:
       - cleanup-policies
+  /api/v1/admin/notification-channels:
+    get:
+      description: Returns all notification channels with subscription counts
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/handlers.notificationChannelWithCount'
+            type: array
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List all notification channels
+      tags:
+      - notification-channels
+    post:
+      consumes:
+      - application/json
+      description: Creates a new notification channel
+      parameters:
+      - description: Channel
+        in: body
+        name: channel
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.createChannelRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.NotificationChannel'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Create a notification channel
+      tags:
+      - notification-channels
+  /api/v1/admin/notification-channels/{id}:
+    delete:
+      description: Deletes a notification channel and its subscriptions
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Delete a notification channel
+      tags:
+      - notification-channels
+    get:
+      description: Returns a notification channel by ID
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.NotificationChannel'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get a notification channel
+      tags:
+      - notification-channels
+    put:
+      consumes:
+      - application/json
+      description: Updates an existing notification channel
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Channel updates
+        in: body
+        name: channel
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.updateChannelRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.NotificationChannel'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "409":
+          description: Conflict
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update a notification channel
+      tags:
+      - notification-channels
+  /api/v1/admin/notification-channels/{id}/delivery-logs:
+    get:
+      description: Returns paginated delivery logs for a notification channel
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Page size (default 20)
+        in: query
+        name: limit
+        type: integer
+      - description: Offset (default 0)
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List delivery logs for a channel
+      tags:
+      - notification-channels
+  /api/v1/admin/notification-channels/{id}/subscriptions:
+    get:
+      description: Returns event type subscriptions for a channel
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Get channel subscriptions
+      tags:
+      - notification-channels
+    put:
+      consumes:
+      - application/json
+      description: Replaces all event type subscriptions for a channel
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Event types
+        in: body
+        name: subscriptions
+        required: true
+        schema:
+          $ref: '#/definitions/handlers.updateSubscriptionsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Update channel subscriptions
+      tags:
+      - notification-channels
+  /api/v1/admin/notification-channels/{id}/test:
+    post:
+      description: Sends a test payload to the channel's webhook URL
+      parameters:
+      - description: Channel ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Test a notification channel
+      tags:
+      - notification-channels
+  /api/v1/admin/notification-channels/event-types:
+    get:
+      description: Returns all known event types that channels can subscribe to
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+      security:
+      - BearerAuth: []
+      summary: List all event types
+      tags:
+      - notification-channels
   /api/v1/admin/orphaned-namespaces:
     get:
       description: Lists all Kubernetes namespaces matching the stack-* pattern that
@@ -2149,9 +2580,21 @@ paths:
       - auth
   /api/v1/auth/oidc/cli-auth:
     post:
+      consumes:
+      - application/json
       description: Generates a session ID and OIDC authorization URL for CLI-based
         SSO login. The CLI opens the returned login_url in a browser and polls cli-token
-        until authentication completes.
+        until authentication completes. Optionally accepts a loopback `redirect_uri`
+        (http scheme, any loopback IP such as 127.0.0.1 or [::1], or hostname "localhost",
+        with an explicit port) for the RFC 8252 native-app flow — the callback then
+        302-redirects the browser directly to that URL with tokens in the query string,
+        no polling needed.
+      parameters:
+      - description: Optional loopback redirect_uri
+        in: body
+        name: request
+        schema:
+          $ref: '#/definitions/handlers.CLIAuthRequest'
       produces:
       - application/json
       responses:
@@ -2159,6 +2602,12 @@ paths:
           description: session_id, login_url, expires_in
           schema:
             additionalProperties: true
+            type: object
+        "400":
+          description: invalid redirect_uri
+          schema:
+            additionalProperties:
+              type: string
             type: object
         "404":
           description: Not Found
@@ -3509,7 +3958,6 @@ paths:
           description: OK
           schema:
             additionalProperties:
-              format: int64
               type: integer
             type: object
         "401":

--- a/backend/internal/api/handlers/oidc.go
+++ b/backend/internal/api/handlers/oidc.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -40,10 +41,12 @@ type CLITokenRequest struct {
 }
 
 // CLIAuthRequest is the optional body for starting CLI SSO authentication.
-// When RedirectURI is a loopback URL (http://127.0.0.1:<port> or
-// http://localhost:<port>), the callback handler 302-redirects the browser
-// directly to it with tokens in the query string (RFC 8252 loopback flow)
-// instead of the HTML success page. Polling cli-token still works either way.
+// When RedirectURI is a loopback URL — any IP for which net.IP.IsLoopback()
+// is true (e.g. 127.0.0.1, [::1]) or the literal hostname "localhost", with
+// http scheme and an explicit port in 1..65535 — the callback handler
+// 302-redirects the browser directly to it with tokens in the query string
+// (RFC 8252 loopback flow) instead of the HTML success page. Polling
+// cli-token still works either way.
 type CLIAuthRequest struct {
 	RedirectURI string `json:"redirect_uri,omitempty"`
 }
@@ -336,7 +339,7 @@ func (h *OIDCHandler) Callback(c *gin.Context) {
 
 // CLIAuth godoc
 // @Summary      Start CLI SSO authentication flow
-// @Description  Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes. Optionally accepts a loopback `redirect_uri` (http://127.0.0.1:<port>) for the RFC 8252 native-app flow — the callback then 302-redirects the browser directly to that URL with tokens in the query string, no polling needed.
+// @Description  Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes. Optionally accepts a loopback `redirect_uri` (http scheme, any loopback IP such as 127.0.0.1 or [::1], or hostname "localhost", with an explicit port) for the RFC 8252 native-app flow — the callback then 302-redirects the browser directly to that URL with tokens in the query string, no polling needed.
 // @Tags         auth
 // @Accept       json
 // @Produce      json
@@ -352,16 +355,19 @@ func (h *OIDCHandler) CLIAuth(c *gin.Context) {
 		return
 	}
 
-	// Optional body — empty body is supported for backward compatibility.
+	// Optional body — accept empty / chunked / unknown-length bodies for
+	// backward compatibility. Body==nil (from raw http.NewRequest with nil
+	// body) is skipped; io.EOF (empty http.NoBody) is tolerated; any other
+	// JSON error is a real malformed request.
 	var req CLIAuthRequest
-	if c.Request.ContentLength > 0 {
-		if err := c.ShouldBindJSON(&req); err != nil {
+	if c.Request.Body != nil {
+		if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
 			return
 		}
 	}
 	if req.RedirectURI != "" && !isLoopbackRedirect(req.RedirectURI) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "redirect_uri must be a loopback URL (http://127.0.0.1:<port> or http://localhost:<port>)"})
+		c.JSON(http.StatusBadRequest, gin.H{"error": "redirect_uri must be a loopback http URL (e.g. http://127.0.0.1:<port>, http://[::1]:<port>, or http://localhost:<port>) with port 1..65535"})
 		return
 	}
 

--- a/backend/internal/api/handlers/oidc.go
+++ b/backend/internal/api/handlers/oidc.go
@@ -4,8 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -35,6 +37,52 @@ func redactSessionID(id string) string {
 // CLITokenRequest is the request body for polling CLI auth status.
 type CLITokenRequest struct {
 	SessionID string `json:"session_id" binding:"required"`
+}
+
+// CLIAuthRequest is the optional body for starting CLI SSO authentication.
+// When RedirectURI is a loopback URL (http://127.0.0.1:<port> or
+// http://localhost:<port>), the callback handler 302-redirects the browser
+// directly to it with tokens in the query string (RFC 8252 loopback flow)
+// instead of the HTML success page. Polling cli-token still works either way.
+type CLIAuthRequest struct {
+	RedirectURI string `json:"redirect_uri,omitempty"`
+}
+
+// isLoopbackRedirect reports whether s is a syntactically valid loopback HTTP
+// URL: http://127.0.0.1:<port>, http://[::1]:<port>, or http://localhost:<port>,
+// optional path and query. Port must be 1..65535. Only http (not https) — RFC
+// 8252 §7.3 recommends http for native-app loopback. Userinfo and fragment are
+// rejected to close two smuggling vectors.
+func isLoopbackRedirect(s string) bool {
+	u, err := url.Parse(s)
+	if err != nil {
+		return false
+	}
+	if u.Scheme != "http" {
+		return false
+	}
+	if u.User != nil || u.Fragment != "" {
+		return false
+	}
+	host := u.Hostname()
+	if host == "" {
+		return false
+	}
+	if host != "localhost" {
+		ip := net.ParseIP(host)
+		if ip == nil || !ip.IsLoopback() {
+			return false
+		}
+	}
+	portStr := u.Port()
+	if portStr == "" {
+		return false
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil || port < 1 || port > 65535 {
+		return false
+	}
+	return true
 }
 
 var cliAuthSuccessPage = []byte(`<!DOCTYPE html>
@@ -248,6 +296,29 @@ func (h *OIDCHandler) Callback(c *gin.Context) {
 			}
 			return
 		}
+
+		// RFC 8252 loopback flow: redirect to the CLI's local server with tokens
+		// as query params. The CLI's listener reads them and closes the browser
+		// tab. Polling cli-token still works as a fallback for the same session
+		// (UpdateCLIAuth above runs before this branch on purpose).
+		if stateData.LoopbackURL != "" {
+			// Merge into any existing query the CLI supplied (e.g. cli_state).
+			// LoopbackURL was validated by isLoopbackRedirect at issuance time.
+			loopURL, perr := url.Parse(stateData.LoopbackURL)
+			if perr != nil {
+				slog.Error("Stored loopback URL failed to parse", "error", perr)
+				c.Data(http.StatusInternalServerError, "text/html; charset=utf-8", []byte(`<html><body><h1>Error</h1><p>Something went wrong. Please try again.</p></body></html>`))
+				return
+			}
+			q := loopURL.Query()
+			q.Set("access_token", cliToken)
+			q.Set("token_type", "Bearer")
+			q.Set("expires_in", strconv.Itoa(int(h.authCfg.JWTExpiration.Seconds())))
+			loopURL.RawQuery = q.Encode()
+			c.Redirect(http.StatusFound, loopURL.String())
+			return
+		}
+
 		c.Data(http.StatusOK, "text/html; charset=utf-8", cliAuthSuccessPage)
 		return
 	}
@@ -265,16 +336,32 @@ func (h *OIDCHandler) Callback(c *gin.Context) {
 
 // CLIAuth godoc
 // @Summary      Start CLI SSO authentication flow
-// @Description  Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes.
+// @Description  Generates a session ID and OIDC authorization URL for CLI-based SSO login. The CLI opens the returned login_url in a browser and polls cli-token until authentication completes. Optionally accepts a loopback `redirect_uri` (http://127.0.0.1:<port>) for the RFC 8252 native-app flow — the callback then 302-redirects the browser directly to that URL with tokens in the query string, no polling needed.
 // @Tags         auth
+// @Accept       json
 // @Produce      json
+// @Param        request body CLIAuthRequest false "Optional loopback redirect_uri"
 // @Success      200 {object} map[string]interface{} "session_id, login_url, expires_in"
+// @Failure      400 {object} map[string]string "invalid redirect_uri"
 // @Failure      404 {object} map[string]string
 // @Failure      500 {object} map[string]string
 // @Router       /api/v1/auth/oidc/cli-auth [post]
 func (h *OIDCHandler) CLIAuth(c *gin.Context) {
 	if !h.cfg.Enabled {
 		c.JSON(http.StatusNotFound, gin.H{"error": "OIDC is not enabled"})
+		return
+	}
+
+	// Optional body — empty body is supported for backward compatibility.
+	var req CLIAuthRequest
+	if c.Request.ContentLength > 0 {
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+			return
+		}
+	}
+	if req.RedirectURI != "" && !isLoopbackRedirect(req.RedirectURI) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "redirect_uri must be a loopback URL (http://127.0.0.1:<port> or http://localhost:<port>)"})
 		return
 	}
 
@@ -302,6 +389,7 @@ func (h *OIDCHandler) CLIAuth(c *gin.Context) {
 	if err := h.sessionStore.SaveOIDCState(c.Request.Context(), state, sessionstore.OIDCStateData{
 		CodeVerifier: verifier,
 		RedirectURL:  "cli:" + sessionID,
+		LoopbackURL:  req.RedirectURI,
 	}, cliTTL); err != nil {
 		slog.Error("Failed to save OIDC state for CLI auth", "error", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": msgInternalServerError})

--- a/backend/internal/api/handlers/oidc_test.go
+++ b/backend/internal/api/handlers/oidc_test.go
@@ -1199,6 +1199,39 @@ func TestOIDCCLIAuth_NoBodyStillWorks(t *testing.T) {
 	require.Equal(t, http.StatusOK, w.Code, "empty body must remain backward-compatible")
 }
 
+// Chunked / unknown-length bodies have ContentLength == -1. The earlier
+// implementation gated body parsing on `ContentLength > 0` which silently
+// dropped these requests; this test guards against the regression.
+func TestOIDCCLIAuth_AcceptsChunkedBody(t *testing.T) {
+	t.Parallel()
+
+	h, store, _ := newOIDCHandlerSetup(t, false)
+	r := setupOIDCRouter(h.CLIAuth, http.MethodPost, "/api/v1/auth/oidc/cli-auth")
+
+	body := `{"redirect_uri":"http://127.0.0.1:54321"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/auth/oidc/cli-auth", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	// Force chunked-transfer semantics — Go's http server reports ContentLength=-1 here.
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	loginURL, _ := resp["login_url"].(string)
+	parsed, err := url.Parse(loginURL)
+	require.NoError(t, err)
+	state := parsed.Query().Get("state")
+	stateData, err := store.ConsumeOIDCState(context.Background(), state)
+	require.NoError(t, err)
+	require.NotNil(t, stateData)
+	assert.Equal(t, "http://127.0.0.1:54321", stateData.LoopbackURL, "chunked body must be parsed, not skipped")
+}
+
 func TestOIDCCallback_LoopbackRedirect(t *testing.T) {
 	t.Parallel()
 

--- a/backend/internal/api/handlers/oidc_test.go
+++ b/backend/internal/api/handlers/oidc_test.go
@@ -1095,3 +1095,188 @@ func TestIsNotFoundError(t *testing.T) {
 		})
 	}
 }
+
+// ---- Loopback redirect (RFC 8252 CLI flow) ----
+
+func TestIsLoopbackRedirect(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{name: "127.0.0.1 with port", in: "http://127.0.0.1:54321", want: true},
+		{name: "127.0.0.1 with port and path", in: "http://127.0.0.1:54321/callback", want: true},
+		{name: "localhost with port", in: "http://localhost:54321", want: true},
+		{name: "ipv6 loopback [::1] with port", in: "http://[::1]:54321", want: true},
+		{name: "loopback with caller query", in: "http://127.0.0.1:54321/?cli_state=xyz", want: true},
+		{name: "missing port", in: "http://127.0.0.1", want: false},
+		{name: "https rejected", in: "https://127.0.0.1:54321", want: false},
+		{name: "non-loopback host", in: "http://example.com:54321", want: false},
+		{name: "192.168 not loopback", in: "http://192.168.1.1:54321", want: false},
+		{name: "userinfo rejected", in: "http://user:pass@127.0.0.1:54321", want: false},
+		{name: "fragment rejected", in: "http://127.0.0.1:54321/#x", want: false},
+		{name: "non-numeric port rejected", in: "http://127.0.0.1:abc", want: false},
+		{name: "port 0 rejected", in: "http://127.0.0.1:0", want: false},
+		{name: "port above 65535 rejected", in: "http://127.0.0.1:99999", want: false},
+		{name: "empty string", in: "", want: false},
+		{name: "garbage", in: "not a url", want: false},
+		{name: "javascript scheme", in: "javascript:alert(1)", want: false},
+		{name: "ipv4 non-loopback in IsLoopback range still rejected", in: "http://10.0.0.1:54321", want: false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isLoopbackRedirect(tt.in))
+		})
+	}
+}
+
+func TestOIDCCLIAuth_AcceptsLoopbackRedirect(t *testing.T) {
+	t.Parallel()
+
+	h, store, _ := newOIDCHandlerSetup(t, false)
+	r := setupOIDCRouter(h.CLIAuth, http.MethodPost, "/api/v1/auth/oidc/cli-auth")
+
+	w := httptest.NewRecorder()
+	body := `{"redirect_uri":"http://127.0.0.1:54321"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/auth/oidc/cli-auth", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]any
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.NotEmpty(t, resp["session_id"])
+
+	// Extract state from login_url and verify the loopback URL was persisted.
+	loginURL, _ := resp["login_url"].(string)
+	parsed, err := url.Parse(loginURL)
+	require.NoError(t, err)
+	state := parsed.Query().Get("state")
+	require.NotEmpty(t, state)
+
+	stateData, err := store.ConsumeOIDCState(context.Background(), state)
+	require.NoError(t, err)
+	require.NotNil(t, stateData)
+	assert.Equal(t, "http://127.0.0.1:54321", stateData.LoopbackURL)
+}
+
+func TestOIDCCLIAuth_RejectsNonLoopbackRedirect(t *testing.T) {
+	t.Parallel()
+
+	h, _, _ := newOIDCHandlerSetup(t, false)
+	r := setupOIDCRouter(h.CLIAuth, http.MethodPost, "/api/v1/auth/oidc/cli-auth")
+
+	w := httptest.NewRecorder()
+	body := `{"redirect_uri":"https://evil.example.com/steal"}`
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/auth/oidc/cli-auth", strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+	assert.Contains(t, resp["error"], "loopback")
+}
+
+func TestOIDCCLIAuth_NoBodyStillWorks(t *testing.T) {
+	t.Parallel()
+
+	h, _, _ := newOIDCHandlerSetup(t, false)
+	r := setupOIDCRouter(h.CLIAuth, http.MethodPost, "/api/v1/auth/oidc/cli-auth")
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/auth/oidc/cli-auth", nil)
+	require.NoError(t, err)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "empty body must remain backward-compatible")
+}
+
+func TestOIDCCallback_LoopbackRedirect(t *testing.T) {
+	t.Parallel()
+
+	h, stateStore, _ := newOIDCHandlerSetup(t, false)
+
+	sessionID := "cli-session-loopback"
+	loopback := "http://127.0.0.1:54321"
+
+	require.NoError(t, stateStore.SaveOIDCState(context.Background(), "valid-state-loop", sessionstore.OIDCStateData{
+		CodeVerifier: "test-verifier",
+		RedirectURL:  "cli:" + sessionID,
+		LoopbackURL:  loopback,
+	}, 5*time.Minute))
+	require.NoError(t, stateStore.SaveCLIAuth(context.Background(), sessionID, sessionstore.CLIAuthData{
+		Status: "pending",
+	}, 10*time.Minute))
+
+	r := setupOIDCRouter(h.Callback, http.MethodGet, "/api/v1/auth/oidc/callback")
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback?code=test-code&state=valid-state-loop", nil)
+	require.NoError(t, err)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code, "loopback flow must 302")
+	location := w.Header().Get("Location")
+	require.NotEmpty(t, location)
+
+	parsed, err := url.Parse(location)
+	require.NoError(t, err)
+	assert.Equal(t, "http", parsed.Scheme)
+	assert.Equal(t, "127.0.0.1:54321", parsed.Host)
+	q := parsed.Query()
+	assert.NotEmpty(t, q.Get("access_token"), "access_token must be in query")
+	assert.Equal(t, "Bearer", q.Get("token_type"))
+	assert.NotEmpty(t, q.Get("expires_in"))
+
+	// Polling fallback should still see the completed session.
+	data, err := stateStore.GetCLIAuth(context.Background(), sessionID)
+	require.NoError(t, err)
+	require.NotNil(t, data)
+	assert.Equal(t, "completed", data.Status)
+	assert.NotEmpty(t, data.Token)
+}
+
+func TestOIDCCallback_LoopbackRedirect_PreservesCallerQuery(t *testing.T) {
+	t.Parallel()
+
+	h, stateStore, _ := newOIDCHandlerSetup(t, false)
+
+	sessionID := "cli-session-loopback-q"
+	loopback := "http://127.0.0.1:54321/cb?cli_state=xyz"
+
+	require.NoError(t, stateStore.SaveOIDCState(context.Background(), "valid-state-loopq", sessionstore.OIDCStateData{
+		CodeVerifier: "test-verifier",
+		RedirectURL:  "cli:" + sessionID,
+		LoopbackURL:  loopback,
+	}, 5*time.Minute))
+	require.NoError(t, stateStore.SaveCLIAuth(context.Background(), sessionID, sessionstore.CLIAuthData{
+		Status: "pending",
+	}, 10*time.Minute))
+
+	r := setupOIDCRouter(h.Callback, http.MethodGet, "/api/v1/auth/oidc/callback")
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest(http.MethodGet, "/api/v1/auth/oidc/callback?code=test-code&state=valid-state-loopq", nil)
+	require.NoError(t, err)
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	parsed, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, "/cb", parsed.Path)
+
+	q := parsed.Query()
+	assert.Equal(t, "xyz", q.Get("cli_state"), "caller-supplied query param must be preserved")
+	assert.NotEmpty(t, q.Get("access_token"))
+	assert.Equal(t, "Bearer", q.Get("token_type"))
+	assert.NotEmpty(t, q.Get("expires_in"))
+	// Each key must appear exactly once — no `?` smuggling.
+	assert.Len(t, q["cli_state"], 1)
+	assert.Len(t, q["access_token"], 1)
+}

--- a/backend/internal/sessionstore/sessionstore.go
+++ b/backend/internal/sessionstore/sessionstore.go
@@ -11,6 +11,12 @@ var ErrSessionNotFound = errors.New("session not found or expired")
 type OIDCStateData struct {
 	CodeVerifier string `json:"code_verifier"`
 	RedirectURL  string `json:"redirect_url"`
+	// LoopbackURL, when set, is a validated `http://127.0.0.1:<port>` /
+	// `http://localhost:<port>` URL supplied by a CLI client running a local
+	// HTTP listener (RFC 8252 native-app loopback flow). When set on a CLI
+	// session, the callback handler 302-redirects the browser to this URL
+	// with tokens as query params instead of the usual HTML success page.
+	LoopbackURL string `json:"loopback_url,omitempty"`
 }
 
 type CLIAuthData struct {

--- a/backend/internal/sessionstore/sessionstore.go
+++ b/backend/internal/sessionstore/sessionstore.go
@@ -11,11 +11,15 @@ var ErrSessionNotFound = errors.New("session not found or expired")
 type OIDCStateData struct {
 	CodeVerifier string `json:"code_verifier"`
 	RedirectURL  string `json:"redirect_url"`
-	// LoopbackURL, when set, is a validated `http://127.0.0.1:<port>` /
-	// `http://localhost:<port>` URL supplied by a CLI client running a local
-	// HTTP listener (RFC 8252 native-app loopback flow). When set on a CLI
-	// session, the callback handler 302-redirects the browser to this URL
-	// with tokens as query params instead of the usual HTML success page.
+	// LoopbackURL, when set, is a validated loopback http URL supplied by a
+	// CLI client running a local HTTP listener (RFC 8252 native-app loopback
+	// flow). Accepted forms: any IP for which net.IP.IsLoopback() is true
+	// (e.g. http://127.0.0.1:<port>, http://[::1]:<port>) or the literal
+	// hostname http://localhost:<port>, with port in 1..65535. See
+	// handlers.isLoopbackRedirect for the authoritative validator. When set
+	// on a CLI session, the callback handler 302-redirects the browser to
+	// this URL with tokens as query params instead of the usual HTML
+	// success page.
 	LoopbackURL string `json:"loopback_url,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
Adds the [RFC 8252](https://www.rfc-editor.org/rfc/rfc8252) native-app loopback flow to the OIDC CLI auth path.

`POST /api/v1/auth/oidc/cli-auth` now accepts an optional body:
```json
{ "redirect_uri": "http://127.0.0.1:54321" }
```

When the value is a validated loopback URL, `/api/v1/auth/oidc/callback` 302-redirects the browser directly to that URL with tokens as query parameters:
```
http://127.0.0.1:54321/?access_token=…&token_type=Bearer&expires_in=…
```

The CLI's local listener parses the query, closes the browser tab, and the polling fallback (`/oidc/cli-token`) remains available for the same session.

Closes #244

## Validation rules for `redirect_uri`
- Scheme **must** be `http` (per RFC 8252 §7.3).
- Host **must** be a loopback IP (`127.0.0.1`, `[::1]`, etc.) or the literal `localhost`.
- Port **must** be present and in 1..65535 (rejects port 0 and >65535).
- Userinfo and fragment are rejected.
- Caller-supplied query (e.g., `?cli_state=xyz`) is preserved via `url.Values` merge.

Invalid values return `400 redirect_uri must be a loopback URL …`.

## Backward compatibility
- `LoopbackURL` is added to `OIDCStateData` with `omitempty`; the MySQL store serializes the whole struct to JSON so existing rows deserialize cleanly.
- `CLIAuth` accepts an empty request body unchanged — existing stackctl polling callers are not affected.
- `Callback` only diverges from the existing HTML-success-page behavior when `LoopbackURL != ""`. All other flows (web SSO, polling) are byte-for-byte identical.

## Test plan
- [x] `TestIsLoopbackRedirect` — 18 table-driven cases covering: valid IPv4/IPv6/localhost with port and path, valid loopback with caller-supplied query, missing/non-numeric/zero/out-of-range port, https/non-http schemes, non-loopback hosts (10.0.0.1, 192.168.x, example.com), userinfo, fragment, `javascript:`, empty/garbage.
- [x] `TestOIDCCLIAuth_AcceptsLoopbackRedirect` — sends a loopback redirect_uri, verifies `LoopbackURL` is persisted on the OIDC state.
- [x] `TestOIDCCLIAuth_RejectsNonLoopbackRedirect` — `https://evil.example.com/...` returns 400 with a clear error.
- [x] `TestOIDCCLIAuth_NoBodyStillWorks` — backward-compat: empty body returns 200.
- [x] `TestOIDCCallback_LoopbackRedirect` — callback issues 302 to the loopback URL with `access_token`/`token_type`/`expires_in`; polling fallback also sees the completed session.
- [x] `TestOIDCCallback_LoopbackRedirect_PreservesCallerQuery` — `cli_state=xyz` in the original loopback URL survives the merge with the token params (no `?` smuggling).
- [x] `go test ./internal/...` — all 24 backend packages pass.
- [x] `go vet ./...` — clean.

## Security notes
- The redirect Location header contains an access token; per RFC 8252 §8.5 this is the standard native-app trade-off and is acceptable for short-lived loopback delivery. No backend logger emits the Location header or the token (audited `slog`/`fmt.Print*` call sites).
- State is single-use (consumed at the top of `Callback`); a duplicate browser-retry of the 302 lands on `/login?error=invalid_state` rather than re-delivering the token.
- No refresh token is included in the loopback response — refresh-token cookies don't survive cross-origin to a loopback listener, and the CLI flow already issues a long-lived JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
