### PR TITLE
docs: headless / API-only deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Default admin credentials: `admin` / `admin` (configured in docker-compose.yml).
 ### Start Locally (without Docker)
 
 ```bash
+# Start MySQL (dev-local-backend does NOT do this on its own; the
+# combined dev-local target does).
+make mysql-start
+
 # Run backend only — `make dev-local` already starts both backend AND
 # frontend in one terminal; use `dev-local-backend` if you'd rather run
 # them in separate terminals (e.g. to tail logs per service).
@@ -146,7 +150,7 @@ cd frontend && npm install && npm run dev
 k8s-stack-manager runs perfectly well without the React UI — every workflow
 the dashboard exposes is also driven by the REST API, and
 [stackctl](https://github.com/omattsson/stackctl) is the supported headless
-client. The pieces below are independent; pick whichever match your runtime.
+client. The pieces below are independent; pick whichever matches your runtime.
 
 ### Why go headless?
 
@@ -185,8 +189,11 @@ The chart's `frontend.enabled` toggle skips every frontend resource
 are unaffected.
 
 ```bash
-helm install k8s-stack-manager helm/k8s-stack-manager \
-  --namespace k8s-stack-manager --create-namespace \
+# Install from the published Helm repo (matches the "Getting Started"
+# example above). Use the local chart path `helm/k8s-stack-manager` only
+# when you have a repo checkout — typically for chart development.
+helm install stack-manager k8s-stack-manager/k8s-stack-manager \
+  --namespace stack-manager --create-namespace \
   --set backend.secrets.JWT_SECRET=my-secret-at-least-16-chars \
   --set frontend.enabled=false \
   --set ingress.host=stacks.example.com
@@ -207,10 +214,12 @@ stackctl login            # username/password
 stackctl login --sso      # opens a browser, RFC 8252 loopback flow
 ```
 
-`stackctl login --sso` uses the OIDC loopback flow — the backend opens the
-upstream IdP login page in a browser, then 302-redirects to a local server
-the CLI runs on `127.0.0.1:<random-port>` with the tokens in the query
-string. No copy/paste, no polling, no frontend involved.
+`stackctl login --sso` uses the OIDC loopback flow — the CLI calls the
+backend's `cli-auth` endpoint, opens the returned `login_url` in your
+default browser, and starts a local HTTP server on `127.0.0.1:<random-port>`.
+After you authenticate with the upstream IdP, the backend 302-redirects the
+browser to the CLI's local server with the tokens in the query string. No
+copy/paste, no polling, no frontend involved.
 
 Once authenticated, every API operation has a first-class CLI surface:
 

--- a/README.md
+++ b/README.md
@@ -132,8 +132,10 @@ Default admin credentials: `admin` / `admin` (configured in docker-compose.yml).
 ### Start Locally (without Docker)
 
 ```bash
-# Run backend
-make dev-local
+# Run backend only — `make dev-local` already starts both backend AND
+# frontend in one terminal; use `dev-local-backend` if you'd rather run
+# them in separate terminals (e.g. to tail logs per service).
+make dev-local-backend
 
 # In another terminal — run frontend
 cd frontend && npm install && npm run dev

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ helm install stack-manager k8s-stack-manager/k8s-stack-manager \
 
 See the full [Getting Started Guide](docs/getting-started.md) for next steps (configure stackctl, register a cluster, import [starter templates](examples/starter-templates/), and deploy your first stack).
 
+> Don't need the UI? Skip straight to the [Headless / API-only
+> deployment](#headless--api-only-deployment) section — stackctl drives every
+> workflow.
+
 ## Features
 
 ### Dashboard — Stack Instance Management
@@ -125,31 +129,6 @@ This starts all services:
 
 Default admin credentials: `admin` / `admin` (configured in docker-compose.yml).
 
-### Headless / API-only
-
-For workflows driven by [stackctl](https://github.com/omattsson/stackctl), you can
-skip the frontend container entirely:
-
-```bash
-make compose-api-only
-```
-
-`docker-compose.yml` tags the frontend service with `profiles: [full]`, so it
-only runs when that profile is active. `.env.example` sets
-`COMPOSE_PROFILES=full` by default — drop or override it to go headless:
-
-```bash
-COMPOSE_PROFILES=api-only docker compose up
-```
-
-> **Upgrading from a previous checkout?** If you have an existing `.env` from
-> before this change, add `COMPOSE_PROFILES=full` to it (or `cp .env.example
-> .env` afresh) — otherwise `docker compose up` will now start the headless
-> stack. `make dev` / `make prod` force `--profile full` and are unaffected.
-
-The matching Helm toggle is `frontend.enabled=false` (see the chart's
-`values.yaml`).
-
 ### Start Locally (without Docker)
 
 ```bash
@@ -159,6 +138,89 @@ make dev-local
 # In another terminal — run frontend
 cd frontend && npm install && npm run dev
 ```
+
+## Headless / API-only deployment
+
+k8s-stack-manager runs perfectly well without the React UI — every workflow
+the dashboard exposes is also driven by the REST API, and
+[stackctl](https://github.com/omattsson/stackctl) is the supported headless
+client. The pieces below are independent; pick whichever match your runtime.
+
+### Why go headless?
+
+- CI/CD pipelines that drive deploys/stops/rollbacks with `stackctl`
+- Air-gapped environments where shipping a SPA isn't worth the surface area
+- Reduced resource footprint (one less Deployment, no nginx)
+- Faster cold starts in ephemeral preview environments
+
+The frontend never authenticates against the backend differently from the
+CLI, so dropping it costs you nothing operationally.
+
+### Docker Compose
+
+```bash
+# One-shot — Makefile target sets the profile for you
+make compose-api-only
+
+# Or explicitly via env var (works with any compose subcommand)
+COMPOSE_PROFILES=api-only docker compose up
+```
+
+`docker-compose.yml` tags the frontend service with `profiles: [full]`, so it
+only runs when that profile is active. `.env.example` sets
+`COMPOSE_PROFILES=full` by default; drop or override it to go headless.
+
+> **Upgrading from a previous checkout?** If you have an existing `.env` from
+> before this change, add `COMPOSE_PROFILES=full` to it (or `cp .env.example
+> .env` afresh) — otherwise `docker compose up` will now start the headless
+> stack. `make dev` / `make prod` force `--profile full` and are unaffected.
+
+### Helm chart
+
+The chart's `frontend.enabled` toggle skips every frontend resource
+(Deployment/Rollout, Service, ConfigMap, HPA, PDB, ServiceAccount) and the
+`/` ingress rule. The backend routes (`/api`, `/ws`, `/health`, `/swagger`)
+are unaffected.
+
+```bash
+helm install k8s-stack-manager helm/k8s-stack-manager \
+  --namespace k8s-stack-manager --create-namespace \
+  --set backend.secrets.JWT_SECRET=my-secret-at-least-16-chars \
+  --set frontend.enabled=false \
+  --set ingress.host=stacks.example.com
+```
+
+### stackctl CLI
+
+Once the API is reachable, install stackctl and point it at the cluster:
+
+```bash
+# Install
+brew install omattsson/tap/stackctl
+
+# Point at the backend (admin credentials from your install)
+stackctl config set api-url https://stacks.example.com
+stackctl login            # username/password
+# …or, if your install has OIDC configured:
+stackctl login --sso      # opens a browser, RFC 8252 loopback flow
+```
+
+`stackctl login --sso` uses the OIDC loopback flow — the backend opens the
+upstream IdP login page in a browser, then 302-redirects to a local server
+the CLI runs on `127.0.0.1:<random-port>` with the tokens in the query
+string. No copy/paste, no polling, no frontend involved.
+
+Once authenticated, every API operation has a first-class CLI surface:
+
+```bash
+stackctl template list
+stackctl stack deploy my-app
+stackctl stack watch --id <instance-id>    # real-time WS events
+stackctl audit log export --format csv --output-file audit.csv
+```
+
+See the [stackctl README](https://github.com/omattsson/stackctl) for the
+full command surface.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

- Promotes the existing "Headless / API-only" subsection from H3 under "Quick Start" to a dedicated H2 section so it appears in GitHub's auto-generated README TOC.
- Expands it into a one-stop deployment guide that ties together every headless piece that landed in K1/K2/K3:
  - Docker Compose `api-only` profile (#243 / `make compose-api-only`)
  - Helm `frontend.enabled=false` toggle (#242) with a copy-pasteable `helm install --set frontend.enabled=false` example
  - OIDC loopback flow (#244 / #249) with a `stackctl login --sso` example and a one-liner on the RFC 8252 redirect chain
  - stackctl install + auth bootstrap + a four-line tour of common operations
- Adds a forward pointer from "Getting Started" so readers who already know they want headless can jump straight there.

## Acceptance criteria

- [x] Section linked from the top-level TOC — H2 sections show up in GitHub's auto-generated README sidebar.
- [x] Examples are copy-pasteable — all snippets are runnable as-is (compose, helm, stackctl).

Closes #246
Tracks omattsson/stackctl#59

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Don't need the UI?" callout in Getting Started linking to headless/API-only instructions.
  * Added a local development workflow for running backend and frontend separately (no Docker required).
  * Expanded headless/API-only guide with updated deployment and upgrade notes for compose and Helm-based installs, including disabling frontend and configuring ingress.
  * Added examples for CLI authentication (password and SSO), stack management, and exporting audit logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/k8s-stack-manager/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->