### PR TITLE
feat(ws): accept JWT via Sec-WebSocket-Protocol + redact ?token from logs

### DIFF
--- a/backend/internal/api/handlers/websocket.go
+++ b/backend/internal/api/handlers/websocket.go
@@ -61,6 +61,15 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 	// fallback exists so handler unit tests don't need to register
 	// the middleware to exercise the query path.
 	tokenStr, viaSubprotocol := extractSubprotocolToken(c.GetHeader("Sec-WebSocket-Protocol"))
+	// If the client explicitly chose subprotocol auth but the JWT half
+	// is missing, 401 immediately. Falling through to Authorization /
+	// query would silently switch the credential source — the caller's
+	// intent (and audit trail) is "auth via subprotocol", not whatever
+	// other header happens to be set.
+	if viaSubprotocol && tokenStr == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Authentication required"})
+		return
+	}
 	if tokenStr == "" {
 		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
 			parts := strings.SplitN(authHeader, " ", 2)
@@ -125,42 +134,64 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 // blank — so the upgrade can still 401 cleanly rather than silently
 // falling through to other auth methods).
 //
-// The header is a comma-separated list per RFC 6455 §11.3.4. We accept
-// any ordering and any number of additional subprotocols; the only
-// requirement is that both "bearer" (case-insensitive) AND a non-empty
-// second token appear. Whitespace around each entry is trimmed.
+// The header is a comma-separated list per RFC 6455 §11.3.4. The
+// credential is the subprotocol IMMEDIATELY adjacent to the bearer
+// marker — preferring the one AFTER (`bearer, <jwt>`) over the one
+// BEFORE (`<jwt>, bearer`). Non-adjacent subprotocols (e.g. a
+// `graphql-ws` declared earlier in the header) are tolerated but
+// ignored — they MUST NOT be picked as the credential, otherwise an
+// arbitrary non-JWT string ends up validated as a JWT (auth fails
+// noisily, but the parser was wrong).
 //
-// Returns ("", false) when the header is empty or does not contain a
-// bearer marker — the handler then falls back to the next auth method.
+// Returns ("", false) when the header is empty or contains no bearer
+// marker — the handler then falls back to the next auth method.
+// Returns ("", true) when the bearer marker is present but no usable
+// adjacent token exists — the handler MUST 401 rather than fall through
+// to other auth methods (the client explicitly chose subprotocol auth,
+// so silently switching credentials would be wrong).
 func extractSubprotocolToken(header string) (token string, viaSubprotocol bool) {
 	if header == "" {
 		return "", false
 	}
-	parts := strings.Split(header, ",")
-	var (
-		seenBearer bool
-		candidate  string
-	)
-	for _, raw := range parts {
-		p := strings.TrimSpace(raw)
-		if p == "" {
+	// Pre-clean: trim and drop empty entries so adjacency works on the
+	// caller-meaningful subprotocols only.
+	rawParts := strings.Split(header, ",")
+	parts := make([]string, 0, len(rawParts))
+	for _, raw := range rawParts {
+		if p := strings.TrimSpace(raw); p != "" {
+			parts = append(parts, p)
+		}
+	}
+
+	isBearer := func(s string) bool { return strings.EqualFold(s, wsSubprotocolBearer) }
+
+	// Pass 1: prefer the canonical `bearer, <jwt>` form. The first
+	// non-bearer subprotocol immediately after a bearer marker wins.
+	seenBearer := false
+	for i, p := range parts {
+		if !isBearer(p) {
 			continue
 		}
-		if strings.EqualFold(p, wsSubprotocolBearer) {
-			seenBearer = true
+		seenBearer = true
+		if i+1 < len(parts) && !isBearer(parts[i+1]) {
+			return parts[i+1], true
+		}
+	}
+	// Pass 2: tolerate the reversed `<jwt>, bearer` form. The spec puts
+	// the most-preferred subprotocol first; some clients put their
+	// credential before the marker.
+	for i, p := range parts {
+		if !isBearer(p) {
 			continue
 		}
-		// First non-bearer subprotocol is the credential candidate. We
-		// don't try to be clever about ordering — if the client puts
-		// the token first and the marker second, that's still valid.
-		if candidate == "" {
-			candidate = p
+		if i > 0 && !isBearer(parts[i-1]) {
+			return parts[i-1], true
 		}
 	}
 	if !seenBearer {
 		return "", false
 	}
-	return candidate, true
+	return "", true
 }
 
 // checkOrigin validates the request origin against the configured allowed origins.

--- a/backend/internal/api/handlers/websocket.go
+++ b/backend/internal/api/handlers/websocket.go
@@ -30,19 +30,37 @@ func NewWebSocketHandler(hub *websocket.Hub, allowedOrigins string, jwtSecret st
 	}
 }
 
+// wsSubprotocolBearer is the subprotocol marker for the
+// `Sec-WebSocket-Protocol: bearer, <jwt>` auth scheme. The client offers
+// it as the first subprotocol; the server selects it on the upgrade
+// response so browsers that require subprotocol negotiation complete
+// the handshake cleanly.
+const wsSubprotocolBearer = "bearer"
+
 // HandleWebSocket godoc
 // @Summary Open a WebSocket connection
-// @Description Upgrades the HTTP connection to a WebSocket for real-time events. Requires a valid JWT token via ?token= query parameter or Authorization: Bearer header.
+// @Description Upgrades the HTTP connection to a WebSocket for real-time events. Authenticate via one of: `Sec-WebSocket-Protocol: bearer, <jwt>` subprotocol header, `Authorization: Bearer <jwt>` header, or `?token=<jwt>` query parameter (the query token is redacted from access logs and traces by middleware before the handler runs).
 // @Tags websocket
-// @Param token query string false "JWT authentication token"
+// @Param token query string false "JWT authentication token (also accepted via Authorization header or Sec-WebSocket-Protocol subprotocol)"
 // @Success 101 "Switching Protocols"
 // @Failure 400 {object} map[string]string
 // @Failure 401 {object} map[string]string
 // @Failure 403 {object} map[string]string
 // @Router /ws [get]
 func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
-	// Extract JWT token: query param first, then Authorization header
-	tokenStr := c.Query("token")
+	// Auth precedence (most-secure first):
+	//   1. Sec-WebSocket-Protocol: bearer, <jwt>     (no URL exposure)
+	//   2. Authorization: Bearer <jwt>               (standard header)
+	//   3. ?token=<jwt> query param                  (browser fallback)
+	//
+	// For the query-param path we read first from gin.Context (set by
+	// the RedactWSToken middleware after it scrubs the URL) and only
+	// fall back to c.Query when the middleware was not wired. The
+	// production route stack always wires the middleware so the raw
+	// URL is scrubbed before any logging or tracing sees it; the
+	// fallback exists so handler unit tests don't need to register
+	// the middleware to exercise the query path.
+	tokenStr, viaSubprotocol := extractSubprotocolToken(c.GetHeader("Sec-WebSocket-Protocol"))
 	if tokenStr == "" {
 		if authHeader := c.GetHeader("Authorization"); authHeader != "" {
 			parts := strings.SplitN(authHeader, " ", 2)
@@ -50,6 +68,17 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 				tokenStr = parts[1]
 			}
 		}
+	}
+	if tokenStr == "" {
+		tokenStr = middleware.WSTokenFromContext(c)
+	}
+	if tokenStr == "" {
+		// Unreachable in production: RedactWSToken has already moved
+		// the value into the gin.Context AND scrubbed it from
+		// c.Request.URL.RawQuery, so c.Query returns "". This branch
+		// exists only for handler unit tests that mount the route
+		// without the redact middleware.
+		tokenStr = c.Query("token")
 	}
 
 	if tokenStr == "" {
@@ -68,6 +97,15 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 		WriteBufferSize: 1024,
 		CheckOrigin:     h.checkOrigin,
 	}
+	// Advertise the "bearer" subprotocol so gorilla acks it in the
+	// handshake response when the client offered it. Strict browser
+	// clients reject the upgrade if Sec-WebSocket-Protocol was set on
+	// the request but not echoed back. Setting this unconditionally is
+	// safe — gorilla only echoes a subprotocol the client actually
+	// requested.
+	if viaSubprotocol {
+		upgrader.Subprotocols = []string{wsSubprotocolBearer}
+	}
 
 	conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
@@ -79,6 +117,50 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 		slog.Error("WebSocket client creation failed", "error", err)
 		return
 	}
+}
+
+// extractSubprotocolToken parses a Sec-WebSocket-Protocol header value
+// and returns the JWT half of a `bearer, <jwt>` pair (along with a flag
+// saying that the bearer marker was present, even if the token was
+// blank — so the upgrade can still 401 cleanly rather than silently
+// falling through to other auth methods).
+//
+// The header is a comma-separated list per RFC 6455 §11.3.4. We accept
+// any ordering and any number of additional subprotocols; the only
+// requirement is that both "bearer" (case-insensitive) AND a non-empty
+// second token appear. Whitespace around each entry is trimmed.
+//
+// Returns ("", false) when the header is empty or does not contain a
+// bearer marker — the handler then falls back to the next auth method.
+func extractSubprotocolToken(header string) (token string, viaSubprotocol bool) {
+	if header == "" {
+		return "", false
+	}
+	parts := strings.Split(header, ",")
+	var (
+		seenBearer bool
+		candidate  string
+	)
+	for _, raw := range parts {
+		p := strings.TrimSpace(raw)
+		if p == "" {
+			continue
+		}
+		if strings.EqualFold(p, wsSubprotocolBearer) {
+			seenBearer = true
+			continue
+		}
+		// First non-bearer subprotocol is the credential candidate. We
+		// don't try to be clever about ordering — if the client puts
+		// the token first and the marker second, that's still valid.
+		if candidate == "" {
+			candidate = p
+		}
+	}
+	if !seenBearer {
+		return "", false
+	}
+	return candidate, true
 }
 
 // checkOrigin validates the request origin against the configured allowed origins.

--- a/backend/internal/api/handlers/websocket_test.go
+++ b/backend/internal/api/handlers/websocket_test.go
@@ -673,6 +673,17 @@ func TestExtractSubprotocolToken(t *testing.T) {
 		{"no bearer marker", "graphql-ws, jwt", "", false},
 		{"bearer with extra subprotocols", "bearer, jwt, mqtt", "jwt", true},
 		{"multiple bearer markers", "bearer, bearer", "", true},
+		// Adjacency contract: a non-auth subprotocol declared BEFORE
+		// bearer must NOT be picked as the credential — only the entry
+		// immediately adjacent to the marker counts. Locks the
+		// graphql-ws-leaks-as-jwt regression CodeRabbit flagged.
+		{"non-auth before bearer", "graphql-ws, bearer, jwt-here", "jwt-here", true},
+		// Adjacency, not first-match: non-bearer entries sandwiching
+		// the bearer pair must be ignored.
+		{"non-bearer entries before bearer pair", "graphql-ws, mqtt, bearer, jwt-here", "jwt-here", true},
+		// Reversed adjacency: <jwt>, bearer with leading non-auth
+		// protocol — only the one right before `bearer` counts.
+		{"non-auth before reversed pair", "graphql-ws, jwt-here, bearer", "jwt-here", true},
 	}
 	for _, tc := range cases {
 		tc := tc
@@ -683,6 +694,44 @@ func TestExtractSubprotocolToken(t *testing.T) {
 			assert.Equal(t, tc.wantViaSp, gotViaSp)
 		})
 	}
+}
+
+// TestHandleWebSocket_SubprotocolBearer_MissingTokenIgnoresOtherAuth
+// locks the documented fall-through prevention: when the client
+// explicitly chose subprotocol auth (offered `bearer` in
+// Sec-WebSocket-Protocol) but the JWT half is missing, the handler
+// MUST 401 immediately even when a perfectly valid Authorization
+// header is set on the same request. Silently switching credential
+// sources behind the user's back would be a security regression —
+// the audit trail must reflect the auth method the caller actually
+// asked for.
+func TestHandleWebSocket_SubprotocolBearer_MissingTokenIgnoresOtherAuth(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	handler := NewWebSocketHandler(hub, "*", wsTestJWTSecret)
+	router := gin.New()
+	router.GET("/ws", handler.HandleWebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	dialer := *gorilla.DefaultDialer
+	// Client offers `bearer` but no JWT half. Without the guard, the
+	// handler would happily accept the Authorization header below.
+	dialer.Subprotocols = []string{"bearer"}
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+generateTestToken(t))
+
+	_, resp, err := dialer.Dial(wsURL, header)
+	require.Error(t, err, "subprotocol-with-no-token MUST 401 even when Authorization is valid")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
 // TestHandleWebSocket_SubprotocolBearer_DoesNotLeakInQuery is a

--- a/backend/internal/api/handlers/websocket_test.go
+++ b/backend/internal/api/handlers/websocket_test.go
@@ -562,3 +562,160 @@ func TestHandleWebSocket_ClientDisconnect(t *testing.T) {
 	// Hub should eventually unregister the client
 	waitForHubClients(t, hub, 0)
 }
+
+// ---------- Sec-WebSocket-Protocol bearer auth (#245) ----------
+
+// TestHandleWebSocket_SubprotocolBearer_Valid covers the documented
+// `Sec-WebSocket-Protocol: bearer, <jwt>` auth path: the upgrade
+// succeeds, the server acknowledges "bearer" in the response, and the
+// hub registers the client.
+func TestHandleWebSocket_SubprotocolBearer_Valid(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	handler := NewWebSocketHandler(hub, "*", wsTestJWTSecret)
+	router := gin.New()
+	router.GET("/ws", handler.HandleWebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	token := generateTestToken(t)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	dialer := *gorilla.DefaultDialer
+	dialer.Subprotocols = []string{"bearer", token}
+	conn, resp, err := dialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
+	assert.Equal(t, "bearer", conn.Subprotocol(),
+		"server must echo bearer as the selected subprotocol — strict browser "+
+			"clients reject the upgrade otherwise")
+	waitForHubClients(t, hub, 1)
+}
+
+// TestHandleWebSocket_SubprotocolBearer_InvalidToken locks the rejection
+// path: a malformed/expired JWT in the subprotocol position fails with
+// 401 and never reaches the hub.
+func TestHandleWebSocket_SubprotocolBearer_InvalidToken(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	handler := NewWebSocketHandler(hub, "*", wsTestJWTSecret)
+	router := gin.New()
+	router.GET("/ws", handler.HandleWebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	dialer := *gorilla.DefaultDialer
+	dialer.Subprotocols = []string{"bearer", "not-a-real-jwt"}
+	_, resp, err := dialer.Dial(wsURL, nil)
+	require.Error(t, err, "invalid token must fail the upgrade")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+// TestHandleWebSocket_SubprotocolBearer_MissingToken covers the case
+// where the client sends just `bearer` with no second subprotocol —
+// extractSubprotocolToken correctly flags this as "bearer was offered
+// but token missing" so the handler 401s instead of silently falling
+// through to other auth methods (which would also fail, but with a
+// less informative reason).
+func TestHandleWebSocket_SubprotocolBearer_MissingToken(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	handler := NewWebSocketHandler(hub, "*", wsTestJWTSecret)
+	router := gin.New()
+	router.GET("/ws", handler.HandleWebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+
+	dialer := *gorilla.DefaultDialer
+	dialer.Subprotocols = []string{"bearer"}
+	_, resp, err := dialer.Dial(wsURL, nil)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestExtractSubprotocolToken(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name      string
+		header    string
+		wantTok   string
+		wantViaSp bool
+	}{
+		{"empty header", "", "", false},
+		{"only bearer marker", "bearer", "", true},
+		{"bearer + token", "bearer, jwt-here", "jwt-here", true},
+		{"bearer + token without space", "bearer,jwt-here", "jwt-here", true},
+		{"token + bearer (reversed order)", "jwt-here, bearer", "jwt-here", true},
+		{"case-insensitive marker", "BEARER, jwt", "jwt", true},
+		{"no bearer marker", "graphql-ws, jwt", "", false},
+		{"bearer with extra subprotocols", "bearer, jwt, mqtt", "jwt", true},
+		{"multiple bearer markers", "bearer, bearer", "", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotTok, gotViaSp := extractSubprotocolToken(tc.header)
+			assert.Equal(t, tc.wantTok, gotTok)
+			assert.Equal(t, tc.wantViaSp, gotViaSp)
+		})
+	}
+}
+
+// TestHandleWebSocket_SubprotocolBearer_DoesNotLeakInQuery is a
+// belt-and-braces check: subprotocol auth never touches the URL, so
+// the query string remains empty regardless of redact middleware
+// state.
+func TestHandleWebSocket_SubprotocolBearer_DoesNotLeakInQuery(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	var capturedURL string
+	hub := websocket.NewHub()
+	go hub.Run()
+	defer hub.Shutdown()
+
+	handler := NewWebSocketHandler(hub, "*", wsTestJWTSecret)
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		capturedURL = c.Request.URL.String()
+		c.Next()
+	})
+	router.GET("/ws", handler.HandleWebSocket)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	token := generateTestToken(t)
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/ws"
+	dialer := *gorilla.DefaultDialer
+	dialer.Subprotocols = []string{"bearer", token}
+	conn, _, err := dialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	assert.NotContains(t, capturedURL, token, "subprotocol auth must never expose the token in the URL")
+	assert.NotContains(t, capturedURL, "token=", "subprotocol auth must never set a token query param")
+}

--- a/backend/internal/api/middleware/ws_redact.go
+++ b/backend/internal/api/middleware/ws_redact.go
@@ -42,13 +42,19 @@ func RedactWSToken() gin.HandlerFunc {
 			return
 		}
 		q := c.Request.URL.Query()
-		token := q.Get("token")
-		if token == "" {
+		// Check key presence (not value!) so `/ws?token=` is scrubbed
+		// just like `/ws?token=<jwt>` is. Leaving `token=` in the URL
+		// would still leak the param name in access logs and confuse
+		// log-scanning tools looking for "this request had token=…".
+		if _, hasToken := q["token"]; !hasToken {
 			c.Next()
 			return
 		}
-		// Stash for the handler.
-		c.Set(wsContextKey, token)
+		// Stash for the handler only when a non-empty value was sent —
+		// `?token=` (empty) is treated as "no credential" by the handler.
+		if token := q.Get("token"); token != "" {
+			c.Set(wsContextKey, token)
+		}
 		// Scrub from the request URL so downstream middleware (otelgin
 		// `http.target`, any access logger that reads RawQuery /
 		// RequestURI) does not capture the token. RequestURI is what

--- a/backend/internal/api/middleware/ws_redact.go
+++ b/backend/internal/api/middleware/ws_redact.go
@@ -1,0 +1,78 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// wsContextKey is the gin.Context key used to pass the WebSocket
+// authentication token from the redaction middleware to the handler.
+// Exported via Get* helpers below rather than as a string constant so
+// the contract stays in one place.
+const wsContextKey = "ws.token"
+
+// RedactWSToken strips the `token` query parameter from `/ws` requests
+// before any logging or tracing middleware can capture it.
+//
+// The WebSocket /ws endpoint accepts a JWT via a `?token=<jwt>` query
+// parameter (for browsers that can't send Authorization headers on
+// upgrade). Several downstream middlewares — most notably otelgin,
+// which sets the `http.target` span attribute to the raw RequestURI —
+// would otherwise persist that token in traces, access logs, and
+// observability backends. This middleware moves the value into the
+// gin.Context under `ws.token` and rewrites the URL so the rest of
+// the stack only ever sees `/ws` with no query string.
+//
+// The middleware MUST be registered before any middleware that reads
+// `c.Request.URL.RawQuery` or `c.Request.RequestURI` (otelgin,
+// HTTPMetrics, custom access-log middlewares). It is a no-op for
+// every path other than `/ws`.
+//
+// The handler retrieves the token via WSTokenFromContext below.
+func RedactWSToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Match `/ws` exactly OR any descendant (`/ws/v2`, `/ws/foo`).
+		// `/wsfoo` and `/wso` are NOT matched — the second segment must
+		// be either absent or path-separated. Keeps redaction in scope
+		// even if a future route adds versioned WS endpoints.
+		path := c.Request.URL.Path
+		if path != "/ws" && !strings.HasPrefix(path, "/ws/") {
+			c.Next()
+			return
+		}
+		q := c.Request.URL.Query()
+		token := q.Get("token")
+		if token == "" {
+			c.Next()
+			return
+		}
+		// Stash for the handler.
+		c.Set(wsContextKey, token)
+		// Scrub from the request URL so downstream middleware (otelgin
+		// `http.target`, any access logger that reads RawQuery /
+		// RequestURI) does not capture the token. RequestURI is what
+		// `RequestURI` field of *http.Request reports — we update it
+		// too, even though otelgin reads URL.Path + URL.RawQuery, to
+		// keep the request struct internally consistent.
+		q.Del("token")
+		c.Request.URL.RawQuery = q.Encode()
+		if c.Request.RequestURI != "" {
+			c.Request.RequestURI = c.Request.URL.RequestURI()
+		}
+		c.Next()
+	}
+}
+
+// WSTokenFromContext returns the JWT extracted by RedactWSToken, if
+// any. The empty string means no token was found in the request — the
+// handler should fall back to Authorization header / Sec-WebSocket-
+// Protocol checking before failing the upgrade.
+func WSTokenFromContext(c *gin.Context) string {
+	if v, ok := c.Get(wsContextKey); ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}

--- a/backend/internal/api/middleware/ws_redact_test.go
+++ b/backend/internal/api/middleware/ws_redact_test.go
@@ -101,6 +101,41 @@ func TestRedactWSToken_NoTokenIsNoOp(t *testing.T) {
 	assert.Empty(t, stashed, "no token in URL → empty stash")
 }
 
+// TestRedactWSToken_EmptyTokenValueStillScrubbed locks the contract
+// "the key `token` is stripped regardless of its value". A request like
+// `/ws?token=` would leak the `token=` literal in RawQuery if the
+// middleware early-returned on `q.Get("token") == ""` — a real failure
+// mode if a browser's token-injection script half-fires.
+func TestRedactWSToken_EmptyTokenValueStillScrubbed(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	var (
+		seenRawQuery string
+		stashed      string
+	)
+	router := gin.New()
+	router.Use(RedactWSToken())
+	router.Use(func(c *gin.Context) {
+		seenRawQuery = c.Request.URL.RawQuery
+		c.Next()
+	})
+	router.GET("/ws", func(c *gin.Context) {
+		stashed = WSTokenFromContext(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws?token=&keep=this", nil)
+	req.RequestURI = req.URL.RequestURI()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NotContains(t, seenRawQuery, "token", "empty `?token=` key must still be stripped from RawQuery")
+	assert.Contains(t, seenRawQuery, "keep=this", "non-sensitive query params must survive")
+	assert.Empty(t, stashed, "empty value must not be stashed — the handler treats this as 'no credential'")
+}
+
 func TestRedactWSToken_MatchesDescendantPathsButNotLookalikes(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)

--- a/backend/internal/api/middleware/ws_redact_test.go
+++ b/backend/internal/api/middleware/ws_redact_test.go
@@ -1,0 +1,171 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactWSToken_StripsTokenAndStashesInContext(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	var (
+		seenRawQuery   string
+		seenRequestURI string
+		stashedToken   string
+	)
+	router := gin.New()
+	router.Use(RedactWSToken())
+	// Downstream middleware sees the URL AFTER redaction — this is the
+	// observation point that simulates otelgin / Logger / metrics
+	// reading the URL for their attribute / log payload.
+	router.Use(func(c *gin.Context) {
+		seenRawQuery = c.Request.URL.RawQuery
+		seenRequestURI = c.Request.RequestURI
+		c.Next()
+	})
+	router.GET("/ws", func(c *gin.Context) {
+		stashedToken = WSTokenFromContext(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws?token=secret-jwt&keep=this", nil)
+	req.RequestURI = req.URL.RequestURI()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "secret-jwt", stashedToken, "handler must see the token via WSTokenFromContext")
+	assert.NotContains(t, seenRawQuery, "token=", "downstream middleware must NOT see the token query param")
+	assert.NotContains(t, seenRawQuery, "secret-jwt", "downstream middleware must NOT see the raw token value")
+	assert.Contains(t, seenRawQuery, "keep=this", "non-sensitive query params must survive")
+	assert.NotContains(t, seenRequestURI, "secret-jwt", "RequestURI must also be scrubbed for middleware that reads it instead of RawQuery")
+}
+
+func TestRedactWSToken_PassthroughForOtherPaths(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	var seenRawQuery string
+	router := gin.New()
+	router.Use(RedactWSToken())
+	router.Use(func(c *gin.Context) {
+		seenRawQuery = c.Request.URL.RawQuery
+		c.Next()
+	})
+	router.GET("/api/v1/audit-logs", func(c *gin.Context) {
+		// Audit logs uses a `cursor` param that is not sensitive; ensure
+		// the middleware never touches non-/ws traffic.
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit-logs?token=should-pass-through&cursor=xyz", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, seenRawQuery, "token=should-pass-through",
+		"middleware must not strip token from paths other than /ws — query semantics are path-specific")
+	assert.Contains(t, seenRawQuery, "cursor=xyz")
+}
+
+func TestRedactWSToken_NoTokenIsNoOp(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	var (
+		seenRawQuery string
+		stashed      string
+	)
+	router := gin.New()
+	router.Use(RedactWSToken())
+	router.Use(func(c *gin.Context) {
+		seenRawQuery = c.Request.URL.RawQuery
+		c.Next()
+	})
+	router.GET("/ws", func(c *gin.Context) {
+		stashed = WSTokenFromContext(c)
+		c.Status(http.StatusOK)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/ws?keep=this", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, "keep=this", seenRawQuery)
+	assert.Empty(t, stashed, "no token in URL → empty stash")
+}
+
+func TestRedactWSToken_MatchesDescendantPathsButNotLookalikes(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	// Locks the path-matching contract documented in RedactWSToken:
+	// exact `/ws` and `/ws/<anything>` get scrubbed; `/wso`, `/wsdebug`,
+	// `/ws-debug` do NOT (the second segment must be path-separated).
+	cases := []struct {
+		path       string
+		wantScrub  bool
+	}{
+		{path: "/ws", wantScrub: true},
+		{path: "/ws/v2", wantScrub: true},
+		{path: "/ws/foo/bar", wantScrub: true},
+		{path: "/wsfoo", wantScrub: false},
+		{path: "/wso", wantScrub: false},
+		{path: "/ws-debug", wantScrub: false},
+		{path: "/api/v1/audit-logs", wantScrub: false},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			var seenRawQuery string
+			router := gin.New()
+			router.Use(RedactWSToken())
+			router.Use(func(c *gin.Context) {
+				seenRawQuery = c.Request.URL.RawQuery
+				c.Next()
+			})
+			router.GET(tc.path, func(c *gin.Context) { c.Status(http.StatusOK) })
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tc.path+"?token=jwt", nil)
+			router.ServeHTTP(w, req)
+
+			if tc.wantScrub {
+				assert.NotContains(t, seenRawQuery, "token=", "expected %s to be scrubbed", tc.path)
+			} else {
+				assert.Contains(t, seenRawQuery, "token=jwt", "expected %s to pass through", tc.path)
+			}
+		})
+	}
+}
+
+func TestWSTokenFromContext_EmptyWithoutMiddleware(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	c.Request = httptest.NewRequest(http.MethodGet, "/ws?token=foo", nil)
+
+	// No middleware ran → context key was never set → empty.
+	assert.Empty(t, WSTokenFromContext(c))
+}
+
+func TestWSTokenFromContext_HandlesWrongType(t *testing.T) {
+	t.Parallel()
+	gin.SetMode(gin.TestMode)
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	// Defensive: if someone (a future test, a misbehaving middleware)
+	// stashes a non-string under the key, the helper must NOT panic.
+	c.Set(wsContextKey, 12345)
+	require.NotPanics(t, func() {
+		assert.Empty(t, WSTokenFromContext(c))
+	})
+}

--- a/backend/internal/api/routes/routes.go
+++ b/backend/internal/api/routes/routes.go
@@ -123,6 +123,11 @@ func SetupRoutes(router *gin.Engine, deps Deps) *RateLimiters {
 
 	// Add middleware
 	router.Use(middleware.RequestID())
+	// RedactWSToken MUST run before HTTPMetrics / otelgin / Logger so it
+	// can strip the ?token=<jwt> query param from /ws requests before
+	// those middlewares persist the raw URL in span attributes, metrics
+	// labels, or access logs.
+	router.Use(middleware.RedactWSToken())
 	// Only attach HTTP metrics middleware when a metric exporter is enabled,
 	// to avoid per-request timing/attribute overhead in the no-op case.
 	if cfg.Otel.Enabled || cfg.Otel.MetricsEnabled {


### PR DESCRIPTION
## Summary

- New `Sec-WebSocket-Protocol: bearer, <jwt>` auth path on `/ws`. The handler advertises `"bearer"` as a supported subprotocol only when the client offered it, so gorilla acks it in the upgrade response and strict browser clients complete the handshake cleanly.
- New `RedactWSToken()` middleware. For paths matching `/ws` or `/ws/<descendant>`, it moves the `?token=<jwt>` query param into `gin.Context` (`ws.token`) and rewrites `URL.RawQuery` + `Request.RequestURI` so the token is gone before any downstream middleware reads the URL. Wired immediately after `RequestID` and BEFORE `HTTPMetrics` / `otelgin` / `Logger` in `routes.go`.
- Handler auth precedence (most-secure first): subprotocol → `Authorization: Bearer` → `WSTokenFromContext` (set by middleware) → `c.Query("token")` (unreachable in production; preserved so handler unit tests can mount `/ws` without the middleware).
- Subprotocol parsing is RFC 6455 §11.3.4 compliant: tolerates any ordering, case-insensitive `bearer` marker, multiple subprotocols, blank token half (returns `viaSubprotocol=true, token=""` so the handler 401s cleanly rather than silently falling through to other auth methods).

## Acceptance criteria

- [x] Both auth methods (query param, subprotocol) produce the same authenticated session as `Authorization: Bearer …` — locked by `TestHandleWebSocket_ValidTokenQueryParam`, `TestHandleWebSocket_SubprotocolBearer_Valid`, and `TestHandleWebSocket_ValidTokenBearerHeader`.
- [x] Existing header-based auth still works — all 9 pre-existing WS handler tests pass unchanged.
- [x] Token is redacted from access logs (query-param risk) — `TestRedactWSToken_StripsTokenAndStashesInContext` asserts `URL.RawQuery` and `RequestURI` are both scrubbed before the next middleware sees them. `otelgin` reads `http.target` from the request URL, so this kills the trace-attribute leak.

## Test plan

- [x] `go test ./... -count=1` green across all 25 backend packages
- [x] `go vet ./...` clean
- [x] New tests: 5 in `ws_redact_test.go` (strip+stash, passthrough, no-op, missing-middleware safety, wrong-type defensive, path-matching table) + 5 in `websocket_test.go` (subprotocol valid + bearer ack, invalid token → 401, missing token → 401, no-query-leak check, 9-case `extractSubprotocolToken` table)

Closes #245
Tracks omattsson/stackctl#59

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket connections accept bearer tokens via the standard WebSocket subprotocol header as an authentication option.

* **Bug Fixes / Behavior**
  * Handshakes that advertise bearer subprotocol without an adjacent token are rejected to avoid ambiguous auth fallbacks.
  * Query-token values for WebSocket endpoints are scrubbed so they no longer appear in logs, traces, or metrics.

* **Documentation**
  * API docs updated to describe supported WebSocket auth sources and token-redaction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/k8s-stack-manager/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->