### PR TITLE
test(frontend): query MUI Switch via role="switch" not "checkbox"

### DIFF
--- a/frontend/src/pages/CleanupPolicies/__tests__/CleanupPolicies.test.tsx
+++ b/frontend/src/pages/CleanupPolicies/__tests__/CleanupPolicies.test.tsx
@@ -249,11 +249,13 @@ describe('CleanupPolicies Page', () => {
       expect(screen.getByText('Idle Cleanup')).toBeInTheDocument();
     });
 
-    // Find the enabled toggle for Idle Cleanup (first switch)
-    const switches = screen.getAllByRole('checkbox');
-    const idleSwitch = switches.find((_s, i) => i === 0);
+    // MUI Switch's input exposes role="switch" (overrides the implicit
+    // checkbox role of <input type="checkbox">). Wait for the row's
+    // switch to render before clicking.
+    const switches = await screen.findAllByRole('switch');
+    const idleSwitch = switches[0];
     expect(idleSwitch).toBeDefined();
-    await user.click(idleSwitch!);
+    await user.click(idleSwitch);
 
     await waitFor(() => {
       expect(cleanupPolicyService.update).toHaveBeenCalledWith('p1', expect.objectContaining({

--- a/frontend/src/pages/Profile/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/Profile/__tests__/Profile.test.tsx
@@ -394,8 +394,10 @@ describe('Profile Page', () => {
       expect(screen.getByText('Notification Preferences')).toBeInTheDocument();
     });
 
-    // Toggle the first preference
-    const toggles = screen.getAllByRole('checkbox');
+    // MUI Switch's input exposes role="switch" (overrides the implicit
+    // checkbox role of <input type="checkbox">). Wait for the prefs
+    // table to render before clicking.
+    const toggles = await screen.findAllByRole('switch');
     expect(toggles.length).toBeGreaterThanOrEqual(1);
     await user.click(toggles[0]);
 


### PR DESCRIPTION
## Summary
Two toggle tests have been silently failing on `main` (and on both open
dependabot PRs #259, #260) for the same reason:

- `CleanupPolicies > toggles policy enabled state`
- `Profile > toggles notification preference and saves`

Both used `getAllByRole('checkbox')` to locate the row's MUI `<Switch>`.
MUI Switch's input sets **`role="switch"` explicitly**, which per the
ARIA spec overrides the implicit `checkbox` role of `<input type="checkbox">`.
So the query returned zero matches and the assertion `toBeGreaterThanOrEqual(1)` blew up.

Switched both queries to `findAllByRole('switch')`. `find*` also gives
us proper retry semantics so the row has time to render after the
async data fetch resolves.

## Why this surfaced now
The MUI bump in #253 changed Switch to set the explicit ARIA role.
Dependabot's dev-dep bumps (#259, #260) don't *cause* the failure —
they just keep tripping over it on PR validation.

## Test plan
- [x] Reproduced locally on `main` HEAD — both tests fail
- [x] Reproduced on #259 branch — same two failures
- [x] Applied fix, ran `npm test` — `957/957` pass
- [x] Verified with both old and new lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test interactions for notification preferences and cleanup policy toggles to improve test synchronization and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omattsson/k8s-stack-manager/pull/263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->